### PR TITLE
FFI use `MModule::cname`

### DIFF
--- a/src/compiler/compiler_ffi.nit
+++ b/src/compiler/compiler_ffi.nit
@@ -43,7 +43,7 @@ redef class MModule
 
 		ensure_compile_nitni_base(v)
 
-		nitni_ccu.header_c_types.add("#include \"{name}._ffi.h\"\n")
+		nitni_ccu.header_c_types.add("#include \"{c_name}._ffi.h\"\n")
 		nitni_ccu.header_c_types.add """
 extern void nitni_global_ref_incr(void*);
 extern void nitni_global_ref_decr(void*);
@@ -255,11 +255,11 @@ end
 redef class CCompilationUnit
 	fun write_as_nitni(mmodule: MModule, compdir: String)
 	do
-		var base_name = "{mmodule.name}._nitni"
+		var base_name = "{mmodule.c_name}._nitni"
 
 		var h_file = "{base_name}.h"
 		write_header_to_file( mmodule, "{compdir}/{h_file}", new Array[String],
-			"{mmodule.cname.to_s.to_upper}_NITG_NITNI_H")
+			"{mmodule.c_name.to_s.to_upper}_NITG_NITNI_H")
 
 		var c_file = "{base_name}.c"
 		write_body_to_file( mmodule, "{compdir}/{c_file}", ["\"{h_file}\""] )

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -124,7 +124,7 @@ class CPPLanguage
 
 		# write .cpp and .hpp file
 		cpp_file.header_custom.add("extern \"C\" \{\n")
-		cpp_file.header_custom.add("#include \"{mmodule.name}._ffi.h\"\n")
+		cpp_file.header_custom.add("#include \"{mmodule.c_name}._ffi.h\"\n")
 		cpp_file.header_custom.add("\}\n")
 
 		var file = cpp_file.write_to_files(mmodule, compdir)
@@ -158,10 +158,10 @@ class CPPCompilationUnit
 
 	fun write_to_files(mmodule: MModule, compdir: String): ExternCppFile
 	do
-		var base_name = "{mmodule.name}._ffi"
+		var base_name = "{mmodule.c_name}._ffi"
 
 		var h_file = "{base_name}.hpp"
-		var guard = "{mmodule.cname.to_s.to_upper}_NIT_HPP"
+		var guard = "{mmodule.c_name.to_s.to_upper}_NIT_HPP"
 
 		write_header_to_file(mmodule, "{compdir}/{h_file}", new Array[String], guard)
 

--- a/src/ffi/ffi.nit
+++ b/src/ffi/ffi.nit
@@ -57,7 +57,7 @@ redef class MModule
 
 		# include dependancies FFI
 		for mod in header_dependencies do
-			if mod.uses_ffi then ffi_ccu.header_custom.add("#include \"{mod.name}._ffi.h\"\n")
+			if mod.uses_ffi then ffi_ccu.header_custom.add("#include \"{mod.c_name}._ffi.h\"\n")
 		end
 
 		ffi_ccu.write_as_impl(self, compdir)
@@ -95,7 +95,7 @@ redef class AModule
 			language.compile_module_block(block, ffi_ccu, mmodule)
 		end
 
-		ffi_ccu.header_c_base.add( "#include \"{mmodule.name}._nitni.h\"\n" )
+		ffi_ccu.header_c_base.add( "#include \"{mmodule.c_name}._nitni.h\"\n" )
 
 		ffi_ccu.body_decl.add("#ifdef ANDROID\n")
 		ffi_ccu.body_decl.add("	#include <android/log.h>\n")

--- a/src/ffi/ffi_base.nit
+++ b/src/ffi/ffi_base.nit
@@ -152,10 +152,10 @@ end
 redef class CCompilationUnit
 	fun write_as_impl(mmodule: MModule, compdir: String)
 	do
-		var base_name = "{mmodule.name}._ffi"
+		var base_name = "{mmodule.c_name}._ffi"
 
 		var h_file = "{base_name}.h"
-		var guard = "{mmodule.cname.to_s.to_upper}_NIT_H"
+		var guard = "{mmodule.c_name.to_upper}_NIT_H"
 		write_header_to_file(mmodule, "{compdir}/{h_file}", new Array[String], guard)
 
 		var c_file = "{base_name}.c"

--- a/src/ffi/objc.nit
+++ b/src/ffi/objc.nit
@@ -79,7 +79,7 @@ class ObjCLanguage
 
 		# write .m and _m.h file
 		mmodule.objc_file.header_c_types.add """
-	#include "{{{mmodule.cname}}}._ffi.h"
+	#include "{{{mmodule.c_name}}}._ffi.h"
 """
 
 		var file = objc_file.write_to_files(mmodule, compdir)
@@ -114,10 +114,10 @@ private class ObjCCompilationUnit
 	# Write this compilation unit to Objective-C source files
 	fun write_to_files(mmodule: MModule, compdir: String): ExternObjCFile
 	do
-		var base_name = "{mmodule.cname}._ffi"
+		var base_name = "{mmodule.c_name}._ffi"
 
 		var h_file = "{base_name}_m.h"
-		var guard = "{mmodule.cname.to_s.to_upper}_NIT_OBJC_H"
+		var guard = "{mmodule.c_name.to_upper}_NIT_OBJC_H"
 		write_header_to_file(mmodule, compdir/h_file, new Array[String], guard)
 
 		var c_file = "{base_name}.m"

--- a/src/nitni/nitni_base.nit
+++ b/src/nitni/nitni_base.nit
@@ -22,7 +22,6 @@ module nitni_base
 
 import parser
 import modelbuilder # builder only for externcalls
-private import compiler::abstract_compiler
 
 redef class MMethod
 	# Short name of this method in C (without the class name)
@@ -50,12 +49,6 @@ redef class MMethod
 		if nit_name.chars.last == '=' then return "{nit_name.substring(0, nit_name.length-1)}__assign"
 		return nit_name
 	end
-end
-
-redef class MModule
-	# Mangled name of this module in C
-	fun cname: String do return c_name # FIXME this is a hack to keep the internal FFI
-	# API independent of the compilers while still using the `MModule::c_name` service.
 end
 
 redef class MMethodDef


### PR DESCRIPTION
This prevents conflicts between two modules using the FFI and with the same short name. It follows the same change for all generated files.