### PR TITLE
More on Sockets and FinalizableOnce

### DIFF
--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -66,7 +66,11 @@ class TCPStream
 			closed = true
 			return
 		end
-		socket.setsockopt(new NativeSocketOptLevels.socket, new NativeSocketOptNames.reuseaddr, 1)
+		if not socket.setsockopt(new NativeSocketOptLevels.socket, new NativeSocketOptNames.reuseaddr, 1) then
+			end_reached = true
+			closed = true
+			return
+		end
 		var hostname = socket.gethostbyname(host)
 		addrin = new NativeSocketAddrIn.with_hostent(hostname, port)
 
@@ -174,8 +178,10 @@ class TCPStream
 	# Send the data present in the socket buffer
 	fun flush
 	do
-		socket.setsockopt(new NativeSocketOptLevels.tcp, new NativeSocketOptNames.tcp_nodelay, 1)
-		socket.setsockopt(new NativeSocketOptLevels.tcp, new NativeSocketOptNames.tcp_nodelay, 0)
+		if not socket.setsockopt(new NativeSocketOptLevels.tcp, new NativeSocketOptNames.tcp_nodelay, 1) or
+		   not socket.setsockopt(new NativeSocketOptLevels.tcp, new NativeSocketOptNames.tcp_nodelay, 0) then
+			closed = true
+		end
 	end
 end
 
@@ -193,7 +199,10 @@ class TCPServer
 		socket = new NativeSocket.socket(new NativeSocketAddressFamilies.af_inet,
 			new NativeSocketTypes.sock_stream, new NativeSocketProtocolFamilies.pf_null)
 		assert not socket.address_is_null
-		socket.setsockopt(new NativeSocketOptLevels.socket, new NativeSocketOptNames.reuseaddr, 1)
+		if not socket.setsockopt(new NativeSocketOptLevels.socket, new NativeSocketOptNames.reuseaddr, 1) then
+			closed = true
+			return
+		end
 		addrin = new NativeSocketAddrIn.with(port, new NativeSocketAddressFamilies.af_inet)
 		address = addrin.address
 

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -145,12 +145,14 @@ extern class NativeSocket `{ int* `}
 	`}
 
 	# Sets an option for the socket
-	fun setsockopt(level: NativeSocketOptLevels, option_name: NativeSocketOptNames, option_value: Int) `{
+	#
+	# Returns `true` on success.
+	fun setsockopt(level: NativeSocketOptLevels, option_name: NativeSocketOptNames, option_value: Int): Bool `{
 		int err = setsockopt(*recv, level, option_name, &option_value, sizeof(int));
 		if(err != 0){
-			perror("Error on setsockopts: ");
-			exit(1);
+			return 0;
 		}
+		return 1;
 	`}
 
 	fun bind(addrIn: NativeSocketAddrIn): Int `{ return bind(*recv, (struct sockaddr*)addrIn, sizeof(*addrIn)); `}

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -37,6 +37,7 @@ in "C" `{
 
 # Wrapper for the data structure PollFD used for polling on a socket
 class PollFD
+	super FinalizableOnce
 
 	# The PollFD object
 	private var poll_struct: NativeSocketPollFD
@@ -76,6 +77,10 @@ class PollFD
 		return response & mask;
 	`}
 
+	redef fun finalize_once
+	do
+		poll_struct.free
+	end
 end
 
 # Data structure used by the poll function

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -79,24 +79,23 @@ class PollFD
 end
 
 # Data structure used by the poll function
-private extern class NativeSocketPollFD `{ struct pollfd `}
+private extern class NativeSocketPollFD `{ struct pollfd * `}
 
-	# File descriptor id
-	private fun fd: Int `{ return recv.fd; `}
+	# File descriptor
+	fun fd: Int `{ return recv->fd; `}
 
 	# List of events to be watched
-	private fun events: Int `{ return recv.events; `}
+	fun events: Int `{ return recv->events; `}
 
 	# List of events received by the last poll function
-	private fun revents: Int `{  return recv.revents; `}
+	fun revents: Int `{  return recv->revents; `}
 
 	new (pid: Int, events: NativeSocketPollValues) `{
-		struct pollfd poll;
-		poll.fd = pid;
-		poll.events = events;
+		struct pollfd *poll = malloc(sizeof(struct pollfd));
+		poll->fd = pid;
+		poll->events = events;
 		return poll;
 	`}
-
 end
 
 extern class NativeSocket `{ int* `}
@@ -177,7 +176,7 @@ extern class NativeSocket `{ int* `}
 	# The array's members are pollfd structures within which fd specifies an open file descriptor and events and revents are bitmasks constructed by
 	# OR'ing a combination of the pollfd flags.
 	private fun native_poll(filedesc: NativeSocketPollFD, timeout: Int): Int `{
-		int poll_return = poll(&filedesc, 1, timeout);
+		int poll_return = poll(filedesc, 1, timeout);
 		return poll_return;
 	`}
 

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -368,9 +368,6 @@ extern class NativeSocketAddressFamilies `{ int `}
 	# Novell Internet Protocol
 	new af_ipx `{ return AF_IPX; `}
 
-	# Integrated Services Digital Network
-	new af_isdn `{ return AF_ISDN; `}
-
 	# IPv6
 	new af_inet6 `{ return AF_INET6; `}
 
@@ -387,7 +384,6 @@ extern class NativeSocketProtocolFamilies `{ int `}
 	new pf_decnet `{ return PF_DECnet; `}
 	new pf_route `{ return PF_ROUTE; `}
 	new pf_ipx `{ return PF_IPX; `}
-	new pf_isdn `{ return PF_ISDN; `}
 	new pf_key `{ return PF_KEY; `}
 	new pf_inet6 `{ return PF_INET6; `}
 	new pf_max `{ return PF_MAX; `}

--- a/lib/standard/gc.nit
+++ b/lib/standard/gc.nit
@@ -36,3 +36,29 @@ class Finalizable
 	# to use attributes of this instances.
 	fun finalize do end
 end
+
+# An object to be finalized only once
+#
+# This is an utility sub-class to `Finalizable` which ensures that `finalized_once`
+# is called only once per instance. User classes implementing `FinalizableOnce`
+# shoud specialize `finalize_once` and _not_ `finalize`. When manipulating the user
+# class, only `finalize` should be called as it protects `finalize_once`.
+class FinalizableOnce
+	super Finalizable
+
+	# Has `self` been finalized? (either by the GC or an explicit call to `finalize`)
+	var finalized = false
+
+	redef fun finalize
+	do
+		if finalized then return
+
+		finalize_once
+		finalized = true
+	end
+
+	# Real finalization method of `FinalizableOnce`, will be called only once
+	#
+	# See: `Finalizable::finalize` for restrictions on finalizer methods.
+	protected fun finalize_once do end
+end


### PR DESCRIPTION
Additionnal notes:
* `FinalizableOnce` will probably be the most common `Finalizable`, but it wouldn't cover all cases.
* Remove some unused features from `socket` to make it compatible with Android.
* Fix an illegal extern class by making it a pointer.
* Do not `exit 1` on socket error.