### PR TITLE
Tools works with groups

### DIFF
--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -41,7 +41,7 @@ var arguments = toolcontext.option_context.rest
 # build model
 var model = new Model
 var mbuilder = new ModelBuilder(model, toolcontext)
-var mmodules = mbuilder.parse(arguments)
+var mmodules = mbuilder.parse_full(arguments)
 
 if mmodules.is_empty then return
 mbuilder.run_phases

--- a/src/nitlight.nit
+++ b/src/nitlight.nit
@@ -41,7 +41,7 @@ var modelbuilder = new ModelBuilder(model, toolcontext)
 
 var args = toolcontext.option_context.rest
 
-var mmodules = modelbuilder.parse(args)
+var mmodules = modelbuilder.parse_full(args)
 modelbuilder.run_phases
 
 if opt_full.value then mmodules = model.mmodules

--- a/src/nitmetrics.nit
+++ b/src/nitmetrics.nit
@@ -36,7 +36,7 @@ var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
 # Here we load an process all modules passed on the command line
-var mmodules = modelbuilder.parse(arguments)
+var mmodules = modelbuilder.parse_full(arguments)
 modelbuilder.run_phases
 
 print "*** METRICS ***"

--- a/src/nitpick.nit
+++ b/src/nitpick.nit
@@ -46,7 +46,7 @@ var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
 # Here we load an process all modules passed on the command line
-var mmodules = modelbuilder.parse(arguments)
+var mmodules = modelbuilder.parse_full(arguments)
 toolcontext.mmodules_to_check.add_all mmodules
 
 modelbuilder.run_phases

--- a/src/nitserial.nit
+++ b/src/nitserial.nit
@@ -127,7 +127,7 @@ end
 var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
-var mmodules = modelbuilder.parse(arguments)
+var mmodules = modelbuilder.parse_full(arguments)
 modelbuilder.run_phases
 
 # Create a distinct support module per targetted modules

--- a/src/nituml.nit
+++ b/src/nituml.nit
@@ -51,7 +51,7 @@ var arguments = toolcontext.option_context.rest
 # build model
 var model = new Model
 var mbuilder = new ModelBuilder(model, toolcontext)
-var mmodules = mbuilder.parse(arguments)
+var mmodules = mbuilder.parse_full(arguments)
 
 if mmodules.is_empty then return
 mbuilder.run_phases

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -53,7 +53,7 @@ end
 var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
-var mmodules = modelbuilder.parse(args)
+var mmodules = modelbuilder.parse_full(args)
 modelbuilder.run_phases
 
 if toolcontext.opt_gen_unit.value then


### PR DESCRIPTION
Make Nit tools more POLA when projects (or groups) are given on the command line.

eg. people using `nitunit ../lib/mylib` may expect that all the unit tests of the lib are executed, not just those from the default module `../lib/mylib/mylib.nit` (that often is basically an empty bottom module)

So this PR introduces `parse_full` in the loader that loads and returns all the modules of given groups, then adapt most tools to use `parse_full`.

No more crazy shell pipelines with `nitls` or `find` to use nitunit, nitpick and other on all the modules of your libs or programs.