### PR TITLE
No abort() on bad execvp

### DIFF
--- a/lib/standard/exec_nit.c
+++ b/lib/standard/exec_nit.c
@@ -82,7 +82,7 @@ se_exec_data_t* exec_Process_Process_basic_exec_execute_4(void *s, char *prog, c
 
 		/* calls */
 		execvp(prog, arg);
-		abort();
+		_exit(127);
 	}
 	else if (id > 0)
        	{ /* father */

--- a/tests/sav/error_annot_c_compiler_alt5.res
+++ b/tests/sav/error_annot_c_compiler_alt5.res
@@ -1,2 +1,1 @@
-Caught signal : Aborted
 alt/error_annot_c_compiler_alt5.nit:21,57--79: Annotation error: Something went wrong executing the argument of annotation "c_compiler_option", make sure the command is valid.

--- a/tests/sav/test_exec.res
+++ b/tests/sav/test_exec.res
@@ -1,3 +1,14 @@
 A hello world!
+0
+
+B hello world!0
+
 C hello world!
-B hello world!D hello world!
+0
+
+D hello world!0
+
+E
+1
+
+127

--- a/tests/test_exec.nit
+++ b/tests/test_exec.nit
@@ -18,19 +18,43 @@ import exec
 
 var hw = new Process("echo", "A", "hello", "world!")
 hw.wait
+print hw.status
+
+print ""
 
 var ip = new IProcess("echo", "B hello world!")
 ip.read_line.output
 ip.wait
+print ip.status
+
+print ""
 
 var op = new OProcess.from_a("cat", null)
 op.write("C hello world!\n")
 op.close
 op.wait
+print op.status
+
+print ""
 
 var iop = new IOProcess.from_a("cat", null)
 iop.write("D hello world!\n")
 iop.read_line.output
 iop.close
 iop.wait
+print iop.status
 
+print ""
+
+var e1 = new Process("sh", "-c", "echo E; exit 1")
+e1.wait
+print e1.status
+
+print ""
+
+var ioperr = new IOProcess.from_a("bad command", null)
+ioperr.write("D hello world!\n")
+ioperr.read_line.output
+ioperr.close
+ioperr.wait
+print ioperr.status


### PR DESCRIPTION
When a bad command is passed to Process, the child-process will `C-abort()`, displaying frightening messages on the screen and causing confusion to the user.
Instead, just `_exit(127)` to terminate the child silently and let the parent do its things.

TODO better error management to not lose the error of the failed `execvp` system call.