### PR TITLE
Support for Java arrays, Java libs on Android and Google Cardboard head tracking

### DIFF
--- a/lib/android/cardboard.nit
+++ b/lib/android/cardboard.nit
@@ -1,0 +1,70 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	 http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Services from the Google Cardboard SDK for virtual reality on Android
+#
+# Projects using this module should keep the `cardboard.jar` archive in the
+# `libs` folder at the root of the project.
+#
+# External resources:
+# * Download `cardboard.jar` from
+# https://raw.githubusercontent.com/googlesamples/cardboard-java/master/CardboardSample/libs/cardboard.jar
+# * Read about Cardboard at
+# https://developers.google.com/cardboard/
+# * Find the Cardboard SDK documentation at
+# https://developers.google.com/cardboard/android/latest/reference/com/google/vrtoolkit/cardboard/package-summary
+module cardboard
+
+import java::collections
+import native_app_glue
+
+in "Java" `{
+	import com.google.vrtoolkit.cardboard.CardboardActivity;
+	import com.google.vrtoolkit.cardboard.sensors.HeadTracker;
+`}
+
+# Provides head tracking information from the device IMU
+#
+# The corresponding Java class is no longer documented, but it is still useful.
+extern class NativeHeadTracker in "Java" `{ com.google.vrtoolkit.cardboard.sensors.HeadTracker `}
+	super JavaObject
+
+	# Instantiate a new `NativeHeadTracker` for the given `context`
+	new (context: NativeContext) in "Java" `{
+		return HeadTracker.createFromContext(context);
+	`}
+
+	# Start tracking head movement
+	fun start_tracking in "Java" `{ recv.startTracking(); `}
+
+	# Stop tracking head movement
+	fun stop_tracking in "Java" `{ recv.stopTracking(); `}
+
+	# Apply correction to the gyroscope values
+	fun gyro_bias=(matrix: JavaFloatArray) in "Java" `{
+		recv.setGyroBias(matrix);
+	`}
+
+	# Enable finer analysis using the neck as center of movement
+	fun neck_model_enabled=(value: Bool) in "Java" `{
+		recv.setNeckModelEnabled(value);
+	`}
+
+	# Fill `matrix` with the last rotation matrix calculated from head movements
+	#
+	# Require: matrix.length >= offset + 16
+	fun last_head_view(matrix: JavaFloatArray, offset: Int) in "Java" `{
+		recv.getLastHeadView(matrix, (int)offset);
+	`}
+end

--- a/lib/java/collections.nit
+++ b/lib/java/collections.nit
@@ -1,0 +1,130 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Basic Java collections
+#
+# ~~~
+# var coll = new JavaArray(2)
+#
+# assert coll[0].is_java_null
+# coll[0] = "zero".to_java_string
+# coll[1] = "one".to_java_string
+#
+# assert coll.length == 2
+# assert coll.first.to_s == "zero"
+# assert coll[1].to_s == "one"
+# assert [for e in coll do e.to_s] == ["zero", "one"]
+# ~~~
+module collections
+
+import java
+
+# Java primitive array
+#
+# These have fixed size so they offer the same services as `SequenceRead` and
+# `[]=`, but would not support `Sequence::add`.
+extern class AbstractJavaArray[E: Object]
+	super SequenceRead[E]
+	super JavaObject
+
+	# Set the `value` at `key`
+	fun []=(key: Int, value: E) is abstract
+
+	redef fun iterator do return new JavaArrayIterator[E](self)
+
+	redef fun reverse_iterator do return new JavaArrayReverseIterator[E](self)
+end
+
+# Java primitive array `float[]`
+#
+# Note that Nit `Float` is the size of a double, so storing them in a
+# `JavaFloatArray` may lead to a loss of precision.
+extern class JavaFloatArray in "Java" `{ float[] `}
+	super AbstractJavaArray[Float]
+
+	# Get a new array of the given `size`
+	new(size: Int) in "Java" `{ return new float[(int)size]; `}
+
+	redef fun [](i) in "Java" `{ return (double)recv[(int)i]; `}
+
+	redef fun []=(i, e) in "Java" `{ recv[(int)i] = (float)e; `}
+
+	redef fun length in "Java" `{ return recv.length; `}
+end
+
+# Java primitive array `double[]`
+extern class JavaDoubleArray in "Java" `{ double[] `}
+	super AbstractJavaArray[Float]
+
+	# Get a new array of the given `size`
+	new(size: Int) in "Java" `{ return new double[(int)size]; `}
+
+	redef fun [](i) in "Java" `{ return recv[(int)i]; `}
+
+	redef fun []=(i, e) in "Java" `{ recv[(int)i] = (float)e; `}
+
+	redef fun length in "Java" `{ return recv.length; `}
+end
+
+# Java primitive array `Object[]`
+extern class JavaArray in "Java" `{ java.lang.Object[] `}
+	super AbstractJavaArray[JavaObject]
+
+	# Get a new array of the given `size`
+	new(size: Int) in "Java" `{ return new Object[(int)size]; `}
+
+	redef fun [](i) in "Java" `{ return recv[(int)i]; `}
+
+	redef fun []=(i, e) in "Java" `{ recv[(int)i] = e; `}
+
+	redef fun length in "Java" `{ return recv.length; `}
+end
+
+# TODO other primitive arrays:
+# * Java primitive array `byte[]`
+# * Java primitive array `short[]`
+# * Java primitive array `int[]`
+# * Java primitive array `long[]`
+# * Java primitive array `boolean[]`
+# * Java primitive array `char[]`
+
+# An `Iterator` on Java primitive arrays
+private class JavaArrayIterator[E: Object]
+	super IndexedIterator[E]
+
+	var array: AbstractJavaArray[E]
+
+	redef fun item do return array[index]
+
+	redef fun is_ok do return index < array.length
+
+	redef fun next do index += 1
+
+	redef var index = 0
+end
+
+# A reverse `Iterator` on Java primitive arrays
+private class JavaArrayReverseIterator[E: Object]
+	super IndexedIterator[E]
+
+	var array: AbstractJavaArray[E]
+
+	redef fun item do return array[index]
+
+	redef fun is_ok do return index >= 0
+
+	redef fun next do index -= 1
+
+	redef var index = array.length - 1
+end

--- a/src/compiler/android_platform.nit
+++ b/src/compiler/android_platform.nit
@@ -234,21 +234,22 @@ $(call import-module,android/native_app_glue)
 			end
 		end
 
-		### copy resources  (for android)
-		# This will be accessed from `android_project_root`
-		var res_dir
+		### Copy resources and libs where expected by the SDK
+		var project_root
 		if compiler.mainmodule.location.file != null then
 			# it is a real file, use "{file}/../res"
-			res_dir = "{compiler.mainmodule.location.file.filename.dirname}/../res"
+			project_root = "{compiler.mainmodule.location.file.filename.dirname}/.."
 		else
 			# probably used -m, use "."
-			res_dir = "res"
+			project_root = "."
 		end
+
+		# Android resources folder
+		var res_dir = project_root / "res"
 		if res_dir.file_exists then
 			# copy the res folder to .nit_compile
 			res_dir = res_dir.realpath
-			var target_res_dir = "{android_project_root}"
-			toolcontext.exec_and_check(["cp", "-R", res_dir, target_res_dir], "Android project error")
+			toolcontext.exec_and_check(["cp", "-R", res_dir, android_project_root], "Android project error")
 		end
 
 		if not res_dir.file_exists or not "{res_dir}/values/strings.xml".file_exists then
@@ -257,6 +258,12 @@ $(call import-module,android/native_app_glue)
 <resources>
     <string name="app_name">{{{app_name}}}</string>
 </resources>""".write_to_file "{dir}/res/values/strings.xml"
+		end
+
+		# Android libs folder
+		var libs_dir = project_root / "libs"
+		if libs_dir.file_exists then
+			toolcontext.exec_and_check(["cp", "-r", libs_dir, android_project_root], "Android project error")
 		end
 	end
 

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -518,6 +518,35 @@ redef class MClassType
 				else break
 			end
 
+			# Change `float[]` to `[float`
+			if jni_type.has('[') then
+				var depth = jni_type.chars.count('[')
+				var java_type = jni_type.replace("[]", "")
+				var short
+
+				if java_type == "boolean" then
+					short = "Z"
+				else if java_type == "byte" then
+					short = "B"
+				else if java_type == "char" then
+					short = "C"
+				else if java_type == "short" then
+					short = "S"
+				else if java_type == "int" then
+					short = "I"
+				else if java_type == "long" then
+					short = "J"
+				else if java_type == "float" then
+					short = "F"
+				else if java_type == "double" then
+					short = "D"
+				else
+					short = "L{java_type};"
+				end
+
+				return "["*depth + short
+			end
+
 			return "L{jni_type};"
 		end
 		if mclass.name == "Bool" then return "Z"
@@ -530,6 +559,7 @@ redef class MClassType
 	redef fun jni_signature_alt
 	do
 		var ftype = mclass.ftype
+
 		if ftype isa ForeignJavaType then return "Object"
 		if mclass.name == "Bool" then return "Boolean"
 		if mclass.name == "Char" then return "Char"


### PR DESCRIPTION
Use the same approach to copy the "libs" dir to the Android project than the "res" dir.

Extern Java types for primitive arrays is a bit tricky to convert to JNI format. For example, `Object[]` in Java is represented by `[Ljava.lang.Object;` in JNI format, and `int[]` is `[I`.

Add some primitive Java arrays, will add more as needed. Will also need to update jwrapper to use those.

The last commit hints at my next demo. It is mostly generated with jwrapper.