### PR TITLE
Reject arrays of null

### DIFF
--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -1243,7 +1243,7 @@ redef class AArrayExpr
 		if mtype == null then
 			mtype = v.merge_types(self, mtypes)
 		end
-		if mtype == null then
+		if mtype == null or mtype isa MNullType then
 			v.error(self, "Type Error: ambiguous array type {mtypes.join(" ")}")
 			return
 		end

--- a/tests/base_array.nit
+++ b/tests/base_array.nit
@@ -25,3 +25,4 @@ for i in a do
 end
 
 #alt1# var b = [10, true]
+#alt2# var c = [null, null]

--- a/tests/sav/base_array_alt2.res
+++ b/tests/sav/base_array_alt2.res
@@ -1,0 +1,1 @@
+alt/base_array_alt2.nit:28,9--20: Type Error: ambiguous array type null null


### PR DESCRIPTION
The type `Array[null]` not exprimable directly, and this is a good thing because it is and useless type and is brokes the compilers (except --erasure for obvious reasons). However, it was still possible to create such a buggy type with literal arrays. eg `[null, null]`.