### PR TITLE
Namespace for

### DIFF
--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -112,6 +112,22 @@ class MModule
 		end
 	end
 
+	# The namespace used for entities according to their visibility `v`.
+	#
+	# Public entities use only the project as a namespace.
+	# Private entities use the `full_name` (i.e. "project::module")
+	#
+	# This method is used by entities to implement their `full_name`.
+	fun namespace_for(v: MVisibility): String do
+		if v <= private_visibility then return full_name
+		var mgroup = self.mgroup
+		if mgroup == null then
+			return full_name
+		else
+			return mgroup.mproject.full_name
+		end
+	end
+
 	# Return the name of the global C identifier associated to `self`.
 	# This name is used to prefix files and other C identifiers associated with `self`.
 	redef var c_name: String is lazy do
@@ -125,6 +141,19 @@ class MModule
 		return res
 	end
 
+	# C identifier version of `namespace_for`.
+	# See `c_name`
+	#
+	# This method is used by entities to implement their `c_name`.
+	fun c_namespace_for(v: MVisibility): String do
+		if v <= private_visibility then return c_name
+		var mgroup = self.mgroup
+		if mgroup == null then
+			return c_name
+		else
+			return mgroup.mproject.c_name
+		end
+	end
 
 	# Create a new empty module and register it to a model
 	init

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -76,6 +76,14 @@ class MModule
 	# The group of module in the project if any
 	var mgroup: nullable MGroup
 
+	# The project of the module if any
+	# Safe alias for `mgroup.mproject`
+	fun mproject: nullable MProject
+	do
+		var g = mgroup
+		if g == null then return null else return g.mproject
+	end
+
 	# The short name of the module
 	redef var name: String
 

--- a/src/model/mproject.nit
+++ b/src/model/mproject.nit
@@ -27,6 +27,10 @@ class MProject
 	# The name of the project
 	redef var name: String
 
+	redef fun full_name do return name
+
+	redef var c_name = name.to_cmangle is lazy
+
 	# The model of the project
 	redef var model: Model
 

--- a/tests/sav/nitunit_args4.res
+++ b/tests/sav/nitunit_args4.res
@@ -5,17 +5,17 @@ Entities: 4; Documented ones: 3; With nitunits: 3; Failures: 0
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_nitunit2"><testcase classname="nitunit.test_nitunit2.standard::kernel::Object" name="test_nitunit2::Object::foo1"><system-err></system-err><system-out>if true then
+<testsuites><testsuite package="test_nitunit2"><testcase classname="nitunit.test_nitunit2.standard::Object" name="test_nitunit2::Object::foo1"><system-err></system-err><system-out>if true then
 
    assert true
 
 end
-</system-out></testcase><testcase classname="nitunit.test_nitunit2.standard::kernel::Object" name="test_nitunit2::Object::bar2"><system-err></system-err><system-out>if true then
+</system-out></testcase><testcase classname="nitunit.test_nitunit2.standard::Object" name="test_nitunit2::Object::bar2"><system-err></system-err><system-out>if true then
 
     assert true
 
 end
-</system-out></testcase><testcase classname="nitunit.test_nitunit2.standard::kernel::Object" name="test_nitunit2::Object::foo3"><system-err></system-err><system-out>var a = 1
+</system-out></testcase><testcase classname="nitunit.test_nitunit2.standard::Object" name="test_nitunit2::Object::foo3"><system-err></system-err><system-out>var a = 1
 assert a == 1
 assert a == 1
 </system-out></testcase></testsuite><testsuite></testsuite></testsuites>

--- a/tests/sav/nitunit_args5.res
+++ b/tests/sav/nitunit_args5.res
@@ -5,7 +5,7 @@ Entities: 6; Documented ones: 5; With nitunits: 3; Failures: 0
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_doc2"><testcase classname="nitunit.test_doc2.standard::kernel::Object" name="test_doc2::Object::foo1"><system-err></system-err><system-out>assert true # tested
-</system-out></testcase><testcase classname="nitunit.test_doc2.standard::kernel::Object" name="test_doc2::Object::foo2"><system-err></system-err><system-out>assert true # tested
-</system-out></testcase><testcase classname="nitunit.test_doc2.standard::kernel::Object" name="test_doc2::Object::foo3"><system-err></system-err><system-out>assert true # tested
+<testsuites><testsuite package="test_doc2"><testcase classname="nitunit.test_doc2.standard::Object" name="test_doc2::Object::foo1"><system-err></system-err><system-out>assert true # tested
+</system-out></testcase><testcase classname="nitunit.test_doc2.standard::Object" name="test_doc2::Object::foo2"><system-err></system-err><system-out>assert true # tested
+</system-out></testcase><testcase classname="nitunit.test_doc2.standard::Object" name="test_doc2::Object::foo3"><system-err></system-err><system-out>assert true # tested
 </system-out></testcase></testsuite><testsuite></testsuite></testsuites>


### PR DESCRIPTION
Better implementation for `full_name` and `c_name` that make them shorter and use the project as the namespace of public entities.

Examples of fullnames of entities used in messages

* A public class `A` defined in the module `m` of the project `p` was `p::m::A`, now it is `p::A`.
* A public method `x` defined in a class `A` in the module `m` of the project `p` was `p::m::A::x`, now it is `p::A::x`

Exeaple of fullnames for entities that are used internally:

* The refinement of `A` in a module `p::n` was `p::n#p::m::A`, now it is `p::n#A`
* The redefinition of `x` in a class `B` in `p::n` was `p::n#p::m::B#p::m::A::x`, now it is `p::n#B#A::x`

The `c_name` get some comparable simplifications, so C identifiers will be simpler and will less overflow in unwind or in valgrind.

Note: please ignore the first commits that come from #1069 