### PR TITLE
Use linker symbols to encode colors

### DIFF
--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -329,6 +329,18 @@ Usually you do not need them since they make the generated code slower.
 `--colo-dead-methods`
 :   Force colorization of dead methods.
 
+`--colors-are-symbols`
+:   Store colors as symbols instead of static data.
+
+    By default, the various identifiers used to implement OO-mechanisms are stored as genuine constant static variables.
+
+    This option uses linker symbols to encode these identifiers.
+    This makes the compiled program faster since less indirections are required to get the values.
+    It also produces executables that are a little bit smaller since static memory does not have to store the colors.
+
+    Warning: the usage of linker symbols is not portable on all toolchains (eg. Mac OS X).
+    Also, this option does nothing on some platforms (like android).
+
 `--no-gcc-directive`
 :   Disable advanced gcc directives for optimization.
 

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -371,6 +371,18 @@ class MakefileToolchain
 			dep_rules.add(o)
 		end
 
+		# Generate linker script, if any
+		if not compiler.linker_script.is_empty then
+			var linker_script_path = "{compile_dir}/linker_script"
+			ofiles.add "linker_script"
+			var f = new OFStream.open(linker_script_path)
+			for l in compiler.linker_script do
+				f.write l
+				f.write "\n"
+			end
+			f.close
+		end
+
 		var java_files = new Array[ExternFile]
 
 		var pkgconfigs = new Array[String]
@@ -510,6 +522,10 @@ abstract class AbstractCompiler
 
 	# Where global declaration are stored (the main .h)
 	var header: CodeWriter is writable, noinit
+
+	# Additionnal linker script for `ld`.
+	# Mainly used to do specific link-time symbol resolution
+	var linker_script = new Array[String]
 
 	# Provide a declaration that can be requested (before or latter) by a visitor
 	fun provide_declaration(key: String, s: String)

--- a/src/compiler/android_platform.nit
+++ b/src/compiler/android_platform.nit
@@ -36,6 +36,8 @@ class AndroidPlatform
 
 	redef fun supports_libunwind do return false
 
+	redef fun supports_linker_script do return false
+
 	redef fun toolchain(toolcontext) do return new AndroidToolchain(toolcontext)
 end
 

--- a/src/compiler/emscripten_platform.nit
+++ b/src/compiler/emscripten_platform.nit
@@ -33,6 +33,7 @@ class EmscriptenPlatform
 
 	redef fun supports_libunwind do return false
 	redef fun supports_libgc do return false
+	redef fun supports_linker_script do return false
 	redef fun toolchain(toolcontext) do return new EnscriptenToolchain(toolcontext)
 end
 

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -252,27 +252,15 @@ class SeparateCompiler
 
 	fun compile_color_const(v: SeparateCompilerVisitor, m: Object, color: Int) do
 		if color_consts_done.has(m) then return
-		if m isa MProperty then
+		if m isa MEntity then
 			if modelbuilder.toolcontext.opt_inline_coloring_numbers.value then
 				self.provide_declaration(m.const_color, "#define {m.const_color} {color}")
 			else
 				self.provide_declaration(m.const_color, "extern const int {m.const_color};")
 				v.add("const int {m.const_color} = {color};")
 			end
-		else if m isa MPropDef then
-			if modelbuilder.toolcontext.opt_inline_coloring_numbers.value then
-				self.provide_declaration(m.const_color, "#define {m.const_color} {color}")
-			else
-				self.provide_declaration(m.const_color, "extern const int {m.const_color};")
-				v.add("const int {m.const_color} = {color};")
-			end
-		else if m isa MType then
-			if modelbuilder.toolcontext.opt_inline_coloring_numbers.value then
-				self.provide_declaration(m.const_color, "#define {m.const_color} {color}")
-			else
-				self.provide_declaration(m.const_color, "extern const int {m.const_color};")
-				v.add("const int {m.const_color} = {color};")
-			end
+		else
+			abort
 		end
 		color_consts_done.add(m)
 	end
@@ -1953,20 +1941,18 @@ class VirtualRuntimeFunction
 	redef fun call(v, arguments) do abort
 end
 
-redef class MType
-	fun const_color: String do return "COLOR_{c_name}"
+redef class MEntity
+	var const_color: String is lazy do return "COLOR_{c_name}"
 end
 
 interface PropertyLayoutElement end
 
 redef class MProperty
 	super PropertyLayoutElement
-	fun const_color: String do return "COLOR_{c_name}"
 end
 
 redef class MPropDef
 	super PropertyLayoutElement
-	fun const_color: String do return "COLOR_{c_name}"
 end
 
 redef class AMethPropdef

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -258,7 +258,7 @@ class SeparateCompiler
 		if m isa MEntity then
 			if modelbuilder.toolcontext.opt_inline_coloring_numbers.value then
 				self.provide_declaration(m.const_color, "#define {m.const_color} {color}")
-			else if not modelbuilder.toolcontext.opt_colors_are_symbols.value then
+			else if not modelbuilder.toolcontext.opt_colors_are_symbols.value or not v.compiler.target_platform.supports_linker_script then
 				self.provide_declaration(m.const_color, "extern const int {m.const_color};")
 				v.add("const int {m.const_color} = {color};")
 			else

--- a/src/platform.nit
+++ b/src/platform.nit
@@ -112,4 +112,7 @@ class Platform
 
 	# Does this platform declare its own main function? If so, we won't generate one in Nit.
 	fun no_main: Bool do return false
+
+	# Does the platform accepts linker scripts?
+	fun supports_linker_script: Bool do return true
 end

--- a/src/platform.nit
+++ b/src/platform.nit
@@ -103,7 +103,7 @@ end
 # Sub-classes of `Platform` represent the target platform of a compilation
 #
 # Services will be added to this class in other modules.
-abstract class Platform
+class Platform
 	# Does the platform provide and support the library `unwind`?
 	fun supports_libunwind: Bool do return true
 


### PR DESCRIPTION
Genuine constant static variables are used to store the colors used in OO mechanisms.
This makes the compiler program slower since additional indirections are required to get the values.
It also produces a little bit larger executables since static memory has to store the colors.

This PR introduce a trick user in the original PRM that uses linker symbols to encode the colors.
It is not completely portable so it must be activated with the option `--colors-are-symbols`

For numbers (with the traditional nitc/nitc/nitc)
before: 0m7.544s
after: 0m7.228s (so -4%)