### PR TITLE
Runtime function

### DIFF
--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1778,34 +1778,55 @@ class SeparateCompilerVisitor
 end
 
 redef class MMethodDef
-	fun separate_runtime_function: AbstractRuntimeFunction
+	# The C function associated to a mmethoddef
+	fun separate_runtime_function: SeparateRuntimeFunction
 	do
 		var res = self.separate_runtime_function_cache
 		if res == null then
-			res = new SeparateRuntimeFunction(self)
+			var recv = mclassdef.bound_mtype
+			var msignature = msignature.resolve_for(recv, recv, mclassdef.mmodule, true)
+			res = new SeparateRuntimeFunction(self, recv, msignature, c_name)
 			self.separate_runtime_function_cache = res
 		end
 		return res
 	end
 	private var separate_runtime_function_cache: nullable SeparateRuntimeFunction
 
-	fun virtual_runtime_function: AbstractRuntimeFunction
+	# The C function associated to a mmethoddef, that can be stored into a VFT of a class
+	# The first parameter (the reciever) is always typed by val* in order to accept an object value
+	# The C-signature is always compatible with the intro
+	fun virtual_runtime_function: SeparateRuntimeFunction
 	do
 		var res = self.virtual_runtime_function_cache
 		if res == null then
-			res = new VirtualRuntimeFunction(self)
+			# Because the function is virtual, the signature must match the one of the original class
+			var intromclassdef = mproperty.intro.mclassdef
+			var recv = intromclassdef.bound_mtype
+			var msignature = mproperty.intro.msignature.resolve_for(recv, recv, intromclassdef.mmodule, true)
+			res = new SeparateRuntimeFunction(self, recv, msignature, "VIRTUAL_{c_name}")
 			self.virtual_runtime_function_cache = res
+			res.is_thunk = true
 		end
 		return res
 	end
-	private var virtual_runtime_function_cache: nullable VirtualRuntimeFunction
+	private var virtual_runtime_function_cache: nullable SeparateRuntimeFunction
 end
 
 # The C function associated to a methoddef separately compiled
 class SeparateRuntimeFunction
 	super AbstractRuntimeFunction
 
-	redef fun build_c_name: String do return "{mmethoddef.c_name}"
+	# The call-side static receiver
+	var called_recv: MType
+
+	# The call-side static signature
+	var called_signature: MSignature
+
+	# The name on the compiled method
+	redef var build_c_name: String
+
+	# Statically call the original body instead
+	var is_thunk = false
 
 	redef fun to_s do return self.mmethoddef.to_s
 
@@ -1815,12 +1836,12 @@ class SeparateRuntimeFunction
 
 		var recv = self.mmethoddef.mclassdef.bound_mtype
 		var v = compiler.new_visitor
-		var selfvar = new RuntimeVariable("self", recv, recv)
+		var selfvar = new RuntimeVariable("self", called_recv, recv)
 		var arguments = new Array[RuntimeVariable]
 		var frame = new StaticFrame(v, mmethoddef, recv, arguments)
 		v.frame = frame
 
-		var msignature = mmethoddef.msignature.resolve_for(mmethoddef.mclassdef.bound_mtype, mmethoddef.mclassdef.bound_mtype, mmethoddef.mclassdef.mmodule, true)
+		var msignature = called_signature
 
 		var sig = new FlatBuffer
 		var comment = new FlatBuffer
@@ -1858,84 +1879,14 @@ class SeparateRuntimeFunction
 		end
 		frame.returnlabel = v.get_name("RET_LABEL")
 
-		if recv != arguments.first.mtype then
-			#print "{self} {recv} {arguments.first}"
-		end
-		mmethoddef.compile_inside_to_c(v, arguments)
-
-		v.add("{frame.returnlabel.as(not null)}:;")
-		if ret != null then
-			v.add("return {frame.returnvar.as(not null)};")
-		end
-		v.add("\}")
-		if not self.c_name.has_substring("VIRTUAL", 0) then compiler.names[self.c_name] = "{mmethoddef.mclassdef.mmodule.name}::{mmethoddef.mclassdef.mclass.name}::{mmethoddef.mproperty.name} ({mmethoddef.location.file.filename}:{mmethoddef.location.line_start})"
-	end
-end
-
-# The C function associated to a methoddef on a primitive type, stored into a VFT of a class
-# The first parameter (the reciever) is always typed by val* in order to accept an object value
-class VirtualRuntimeFunction
-	super AbstractRuntimeFunction
-
-	redef fun build_c_name: String do return "VIRTUAL_{mmethoddef.c_name}"
-
-	redef fun to_s do return self.mmethoddef.to_s
-
-	redef fun compile_to_c(compiler)
-	do
-		var mmethoddef = self.mmethoddef
-
-		var recv = self.mmethoddef.mclassdef.bound_mtype
-		var v = compiler.new_visitor
-		var selfvar = new RuntimeVariable("self", v.object_type, recv)
-		var arguments = new Array[RuntimeVariable]
-		var frame = new StaticFrame(v, mmethoddef, recv, arguments)
-		v.frame = frame
-
-		var sig = new FlatBuffer
-		var comment = new FlatBuffer
-
-		# Because the function is virtual, the signature must match the one of the original class
-		var intromclassdef = self.mmethoddef.mproperty.intro.mclassdef
-		var msignature = mmethoddef.mproperty.intro.msignature.resolve_for(intromclassdef.bound_mtype, intromclassdef.bound_mtype, intromclassdef.mmodule, true)
-		var ret = msignature.return_mtype
-		if ret != null then
-			sig.append("{ret.ctype} ")
-		else
-			sig.append("void ")
-		end
-		sig.append(self.c_name)
-		sig.append("({selfvar.mtype.ctype} {selfvar}")
-		comment.append("({selfvar}: {selfvar.mtype}")
-		arguments.add(selfvar)
-		for i in [0..msignature.arity[ do
-			var mtype = msignature.mparameters[i].mtype
-			if i == msignature.vararg_rank then
-				mtype = v.get_class("Array").get_mtype([mtype])
+		if is_thunk then
+			var subret = v.call(mmethoddef, recv, arguments)
+			if ret != null then
+				assert subret != null
+				v.assign(frame.returnvar.as(not null), subret)
 			end
-			comment.append(", {mtype}")
-			sig.append(", {mtype.ctype} p{i}")
-			var argvar = new RuntimeVariable("p{i}", mtype, mtype)
-			arguments.add(argvar)
-		end
-		sig.append(")")
-		comment.append(")")
-		if ret != null then
-			comment.append(": {ret}")
-		end
-		compiler.provide_declaration(self.c_name, "{sig};")
-
-		v.add_decl("/* method {self} for {comment} */")
-		v.add_decl("{sig} \{")
-		if ret != null then
-			frame.returnvar = v.new_var(ret)
-		end
-		frame.returnlabel = v.get_name("RET_LABEL")
-
-		var subret = v.call(mmethoddef, recv, arguments)
-		if ret != null then
-			assert subret != null
-			v.assign(frame.returnvar.as(not null), subret)
+		else
+			mmethoddef.compile_inside_to_c(v, arguments)
 		end
 
 		v.add("{frame.returnlabel.as(not null)}:;")
@@ -1943,11 +1894,8 @@ class VirtualRuntimeFunction
 			v.add("return {frame.returnvar.as(not null)};")
 		end
 		v.add("\}")
-		if not self.c_name.has_substring("VIRTUAL", 0) then compiler.names[self.c_name] = "{mmethoddef.mclassdef.mmodule.name}::{mmethoddef.mclassdef.mclass.name}::{mmethoddef.mproperty.name} ({mmethoddef.location.file.filename}--{mmethoddef.location.line_start})"
+		compiler.names[self.c_name] = "{mmethoddef.full_name} ({mmethoddef.location.file.filename}:{mmethoddef.location.line_start})"
 	end
-
-	# TODO ?
-	redef fun call(v, arguments) do abort
 end
 
 redef class MEntity

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -235,13 +235,9 @@ class SeparateErasureCompiler
 						v.add_decl("NULL, /* DEAD {mclass.intro_mmodule}:{mclass}:{mpropdef} */")
 						continue
 					end
-					if true or mpropdef.mclassdef.bound_mtype.ctype != "val*" then
-						v.require_declaration("VIRTUAL_{mpropdef.c_name}")
-						v.add_decl("(nitmethod_t)VIRTUAL_{mpropdef.c_name}, /* pointer to {mclass.intro_mmodule}:{mclass}:{mpropdef} */")
-					else
-						v.require_declaration("{mpropdef.c_name}")
-						v.add_decl("(nitmethod_t){mpropdef.c_name}, /* pointer to {mclass.intro_mmodule}:{mclass}:{mpropdef} */")
-					end
+					var rf = mpropdef.virtual_runtime_function
+					v.require_declaration(rf.c_name)
+					v.add_decl("(nitmethod_t){rf.c_name}, /* pointer to {mpropdef.full_name} */")
 				end
 			end
 			v.add_decl("\}")


### PR DESCRIPTION
Refactor SeparateRuntimeFunction and related services in the separate compiler.

This simplify the compiler and improve the efficiency of the generated code a little.

Before: 0m7.588s
After: 0m7.364s (-3%)

This refactorisation is required for some next PR that will improve polymorphic calls