### PR TITLE
Rename annotations for the C/C++ compilers and linker to `cflags` and `ldflags`

### DIFF
--- a/contrib/pep8analysis/src/pep8analysis_web.nit
+++ b/contrib/pep8analysis/src/pep8analysis_web.nit
@@ -20,8 +20,8 @@
 # analysis results. The result graph will be sent to the JavaScript function
 # `show_graph` with the source of the graph in Graphviz's dot.
 module pep8analysis_web is
-	cpp_compiler_option("--std=c++11 --bind")
-	c_linker_option("--bind")
+	cppflags "--std=c++11 --bind"
+	ldflags "--bind"
 end
 
 import emscripten

--- a/lib/cocoa/app_kit.nit
+++ b/lib/cocoa/app_kit.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # The Application Kit provides services to create GUI
-module app_kit is c_linker_option "-framework AppKit"
+module app_kit is ldflags "-framework AppKit"
 
 import foundation
 

--- a/lib/cocoa/cocoa.nit
+++ b/lib/cocoa/cocoa.nit
@@ -20,7 +20,7 @@
 #
 # This wrapper of the Cocoa API regroups the Foundation Kit and the
 # Application Kit.
-module cocoa is c_linker_option "-framework Cocoa"
+module cocoa is ldflags "-framework Cocoa"
 
 import foundation
 import app_kit

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # The Foundation Kit provides basic Objective-C classes and structures
-module foundation is c_linker_option "-framework Foundation"
+module foundation is ldflags "-framework Foundation"
 
 in "ObjC Header" `{
 	#import <Foundation/Foundation.h>

--- a/lib/cpp.nit
+++ b/lib/cpp.nit
@@ -16,7 +16,7 @@
 
 # Offers features to interface with C++ code and libraries
 module cpp is
-	new_annotation cpp_compiler_option
+	new_annotation cppflags
 end
 
 # A pointer to a C++ std::string instance

--- a/lib/java/java.nit
+++ b/lib/java/java.nit
@@ -27,8 +27,8 @@
 # most of JNI functions. You can use it to further customize the behavior
 # of your code.
 module java is
-	c_compiler_option "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
-	c_linker_option("-L $(JNI_LIB_PATH) -ljvm")
+	cflags "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
+	ldflags "-L $(JNI_LIB_PATH) -ljvm"
 	new_annotation extra_java_files
 end
 

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -19,8 +19,8 @@
 #
 # See: http://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/jniTOC.html
 module jvm is
-	c_compiler_option "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
-	c_linker_option "-L $(JNI_LIB_PATH) -ljvm"
+	cflags "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
+	ldflags "-L $(JNI_LIB_PATH) -ljvm"
 end
 
 in "C Header" `{

--- a/lib/mpi.nit
+++ b/lib/mpi.nit
@@ -26,8 +26,8 @@
 # Since this module is a thin wrapper around OpenMPI, in case of missing
 # documentation, you can refer to https://www.open-mpi.org/doc/v1.8/.
 module mpi is
-	c_compiler_option(exec("mpicc", "-showme:compile"))
-	c_linker_option(exec("mpicc", "-showme:link"))
+	cflags exec("mpicc", "-showme:compile")
+	ldflags exec("mpicc", "-showme:link")
 end
 
 import c

--- a/lib/pthreads/extra.nit
+++ b/lib/pthreads/extra.nit
@@ -16,8 +16,8 @@
 
 # Offers some POSIX threads services that are not available on all platforms
 module extra is
-	c_compiler_option("-pthread")
-	c_linker_option("-pthread")
+	cflags "-pthread"
+	ldflags "-pthread"
 end
 
 intrude import pthreads

--- a/lib/pthreads/pthreads.nit
+++ b/lib/pthreads/pthreads.nit
@@ -16,8 +16,8 @@
 
 # Main POSIX threads support and intro the classes `Thread`, `Mutex` and `Barrier`
 module pthreads is
-	c_compiler_option("-pthread")
-	c_linker_option("-pthread")
+	cflags "-pthread"
+	ldflags "-pthread"
 	pkgconfig "bdw-gc"
 end
 

--- a/lib/realtime.nit
+++ b/lib/realtime.nit
@@ -11,7 +11,7 @@
 # another product.
 
 # Provides the Clock utility class to keep time of real time flow
-module realtime is c_linker_option("-lrt")
+module realtime is ldflags "-lrt"
 
 in "C header" `{
 #ifdef _POSIX_C_SOURCE

--- a/lib/sdl.nit
+++ b/lib/sdl.nit
@@ -16,8 +16,8 @@
 
 # SDL display support (used in Linux for windows and inputes only)
 module sdl is
-	c_compiler_option(exec("sdl-config", "--cflags"))
-	c_linker_option(exec("sdl-config", "--libs"), "-lSDL_image -lSDL_ttf")
+	cflags exec("sdl-config", "--cflags")
+	ldflags(exec("sdl-config", "--libs"), "-lSDL_image -lSDL_ttf")
 end
 
 import mnit_display

--- a/lib/sdl2/image.nit
+++ b/lib/sdl2/image.nit
@@ -20,7 +20,7 @@
 # alone: JPG, PNG, TIF, GIT, ICO and much more.
 module image is
 	pkgconfig "sdl2"
-	c_linker_option "-lSDL2_image"
+	ldflags "-lSDL2_image"
 end
 
 import sdl2

--- a/src/compiler/compiler_ffi.nit
+++ b/src/compiler/compiler_ffi.nit
@@ -52,7 +52,7 @@ extern void nitni_global_ref_decr(void*);
 		nitni_ccu.write_as_nitni(self, v.compiler.modelbuilder.compile_dir)
 
 		for file in nitni_ccu.files do
-			var f = new ExternCFile(file, c_compiler_options)
+			var f = new ExternCFile(file, cflags)
 			f.pkgconfigs.add_all pkgconfigs
 			v.compiler.extern_bodies.add(f)
 		end
@@ -76,7 +76,7 @@ extern void nitni_global_ref_decr(void*);
 
 	redef fun collect_linker_libs
 	do
-		var s = c_linker_options
+		var s = ldflags
 		if s.is_empty then return null
 		var res = new ArraySet[String]
 		res.add s

--- a/src/ffi/c.nit
+++ b/src/ffi/c.nit
@@ -72,8 +72,8 @@ redef class Location
 end
 
 redef class MModule
-	var c_compiler_options = "" is writable
-	var c_linker_options = "" is writable
+	var cflags = "" is writable
+	var ldflags = "" is writable
 
 	# Additional libraries needed for the compilation
 	# Will be used with pkg-config

--- a/src/ffi/c_compiler_options.nit
+++ b/src/ffi/c_compiler_options.nit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Offers the annotations `c_compiler_option` and `c_linker_option` to specify
+# Offers the annotations `cflags` and `ldflags` to specify
 # options for the C compiler directly or indirectly. Differs from the `pkgconfig`
 # annotation by the separation of the options between the compiler and linker.
 module c_compiler_options
@@ -24,15 +24,15 @@ import cpp
 private import annotation
 
 redef class ToolContext
-	var c_compiler_options_phase: Phase = new CCompilerOptionsPhase(self, null)
+	var cflags_phase: Phase = new CCompilerOptionsPhase(self, null)
 end
 
 private class CCompilerOptionsPhase
 	super Phase
 
-	fun compiler_annotation_name: String do return "c_compiler_option"
-	fun linker_annotation_name: String do return "c_linker_option"
-	fun cpp_compiler_annotation_name: String do return "cpp_compiler_option"
+	fun compiler_annotation_name: String do return "cflags"
+	fun linker_annotation_name: String do return "ldflags"
+	fun cpp_compiler_annotation_name: String do return "cppflags"
 
 	redef fun process_annotated_node(nmoduledecl, nat)
 	do
@@ -145,17 +145,17 @@ private class CCompilerOptionsPhase
 
 	fun process_c_compiler_annotation(mmodule: MModule, opt: String)
 	do
-		mmodule.c_compiler_options = "{mmodule.c_compiler_options} {opt}"
+		mmodule.cflags = "{mmodule.cflags} {opt}"
 	end
 
 	fun process_c_linker_annotation(mmodule: MModule, opt: String)
 	do
-		mmodule.c_linker_options = "{mmodule.c_linker_options} {opt}"
+		mmodule.ldflags = "{mmodule.ldflags} {opt}"
 	end
 
 	fun process_cpp_compiler_annotation(mmodule: MModule, opt: String)
 	do
-		mmodule.cpp_compiler_options = "{mmodule.cpp_compiler_options} {opt}"
+		mmodule.cppflags = "{mmodule.cppflags} {opt}"
 	end
 end
 

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -27,7 +27,7 @@ end
 redef class MModule
 	private var cpp_file: nullable CPPCompilationUnit = null
 
-	var cpp_compiler_options = "" is writable
+	var cppflags = "" is writable
 end
 
 class CPPLanguage
@@ -133,7 +133,7 @@ class CPPLanguage
 		mmodule.ffi_files.add(file)
 
 		# add linked option to support C++
-		mmodule.c_linker_options = "{mmodule.c_linker_options} -lstdc++"
+		mmodule.ldflags = "{mmodule.ldflags} -lstdc++"
 	end
 
 	redef fun compile_callback(callback, mmodule, mainmodule, ecc)
@@ -180,7 +180,7 @@ class ExternCppFile
 	var mmodule: MModule
 
 	redef fun makefile_rule_name do return "{filename.basename("")}.o"
-	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cpp_compiler_options} -c {filename.basename("")} -o {filename.basename("")}.o"
+	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cppflags} -c {filename.basename("")} -o {filename.basename("")}.o"
 	redef fun compiles_to_o_file do return true
 end
 

--- a/src/ffi/ffi.nit
+++ b/src/ffi/ffi.nit
@@ -62,7 +62,7 @@ redef class MModule
 
 		ffi_ccu.write_as_impl(self, compdir)
 		for filename in ffi_ccu.files do
-			var f = new ExternCFile(filename, c_compiler_options)
+			var f = new ExternCFile(filename, cflags)
 			f.pkgconfigs.add_all pkgconfigs
 			ffi_files.add(f)
 		end

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -242,8 +242,8 @@ redef class MModule
 	# Tell the C compiler where to find jni.h and how to link with libjvm
 	private fun insert_compiler_options
 	do
-		c_compiler_options = "{c_compiler_options} -I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
-		c_linker_options = "{c_linker_options} -L $(JNI_LIB_PATH) -ljvm"
+		cflags = "{cflags} -I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
+		ldflags = "{ldflags} -L $(JNI_LIB_PATH) -ljvm"
 	end
 
 	# Name of the generated Java class where to store all implementation methods of this module

--- a/src/ffi/objc.nit
+++ b/src/ffi/objc.nit
@@ -154,7 +154,7 @@ private class ObjCCompilationUnit
 
 		files.add compdir/c_file
 
-		mmodule.c_linker_options = "{mmodule.c_linker_options} -lobjc"
+		mmodule.ldflags = "{mmodule.ldflags} -lobjc"
 
 		return new ExternObjCFile(compdir/c_file, mmodule)
 	end

--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -92,8 +92,8 @@ extern
 no_warning
 
 pkgconfig
-c_compiler_option
-c_linker_option
+cflags
+ldflags
 
 platform
 """

--- a/tests/error_annot_c_compiler.nit
+++ b/tests/error_annot_c_compiler.nit
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#alt1#	module error_annot_c_compiler_alt1 is c_compiler_option
-#alt2#	module error_annot_c_compiler_alt2 is c_compiler_option(foo("llvm-config"))
-#alt3#	module error_annot_c_compiler_alt3 is c_compiler_option(foo("llvm-config", "2nd arg"))
-#alt4#	module error_annot_c_compiler_alt4 is c_linker_option
-#alt5#	module error_annot_c_compiler_alt5 is c_compiler_option(exec("invalid-program"))
-#alt6#	module error_annot_c_compiler_alt6 is c_compiler_option(exec)
+#alt1#	module error_annot_c_compiler_alt1 is cflags
+#alt2#	module error_annot_c_compiler_alt2 is cflags(foo("llvm-config"))
+#alt3#	module error_annot_c_compiler_alt3 is cflags(foo("llvm-config", "2nd arg"))
+#alt4#	module error_annot_c_compiler_alt4 is ldflags
+#alt5#	module error_annot_c_compiler_alt5 is cflags(exec("invalid-program"))
+#alt6#	module error_annot_c_compiler_alt6 is cflags(exec)
 
 fun foo `{ printf("nothing...\n"); `}
 

--- a/tests/sav/error_annot_c_compiler_alt1.res
+++ b/tests/sav/error_annot_c_compiler_alt1.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt1.nit:17,39--55: Syntax error: "c_compiler_option" expects at least one argument.
+alt/error_annot_c_compiler_alt1.nit:17,39--44: Syntax error: "cflags" expects at least one argument.

--- a/tests/sav/error_annot_c_compiler_alt2.res
+++ b/tests/sav/error_annot_c_compiler_alt2.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt2.nit:18,39--75: Syntax error: "c_compiler_option" accepts only calls to `exec` with the command as arguments.
+alt/error_annot_c_compiler_alt2.nit:18,39--64: Syntax error: "cflags" accepts only calls to `exec` with the command as arguments.

--- a/tests/sav/error_annot_c_compiler_alt3.res
+++ b/tests/sav/error_annot_c_compiler_alt3.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt3.nit:19,39--86: Syntax error: "c_compiler_option" accepts only calls to `exec` with the command as arguments.
+alt/error_annot_c_compiler_alt3.nit:19,39--75: Syntax error: "cflags" accepts only calls to `exec` with the command as arguments.

--- a/tests/sav/error_annot_c_compiler_alt4.res
+++ b/tests/sav/error_annot_c_compiler_alt4.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt4.nit:20,39--53: Syntax error: "c_linker_option" expects at least one argument.
+alt/error_annot_c_compiler_alt4.nit:20,39--45: Syntax error: "ldflags" expects at least one argument.

--- a/tests/sav/error_annot_c_compiler_alt5.res
+++ b/tests/sav/error_annot_c_compiler_alt5.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt5.nit:21,57--79: Annotation error: Something went wrong executing the argument of annotation "c_compiler_option", make sure the command is valid.
+alt/error_annot_c_compiler_alt5.nit:21,46--68: Annotation error: Something went wrong executing the argument of annotation "cflags", make sure the command is valid.

--- a/tests/sav/error_annot_c_compiler_alt6.res
+++ b/tests/sav/error_annot_c_compiler_alt6.res
@@ -1,1 +1,1 @@
-alt/error_annot_c_compiler_alt6.nit:22,39--61: Syntax error: "c_compiler_option" accepts only calls to `exec` with the command as arguments.
+alt/error_annot_c_compiler_alt6.nit:22,39--50: Syntax error: "cflags" accepts only calls to `exec` with the command as arguments.

--- a/tests/test_annot_c_compiler.nit
+++ b/tests/test_annot_c_compiler.nit
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 module test_annot_c_compiler is
-	c_compiler_option("-I /usr/include")
-	c_compiler_option(exec("pkg-config", "--cflags", "sdl"))
-	c_linker_option("-lm")
-	c_linker_option("-lm", "-L /usr/bin")
+	cflags "-I /usr/include"
+	cflags exec("pkg-config", "--cflags", "sdl")
+	ldflags "-lm"
+	ldflags("-lm", "-L /usr/bin")
 end
 
 fun dummy `{ printf("nothing...\n"); `}


### PR DESCRIPTION
The new name is shorter, easier to remember and more standard. I may soon extend these annotations to provide information per platform, mainly to provide ldflags for Android only.