### PR TITLE
ldflags for Android

### DIFF
--- a/lib/android/aware.nit
+++ b/lib/android/aware.nit
@@ -14,17 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module platform is
-	platform("android")
-	new_annotation java_package
-	new_annotation min_api_version
-	new_annotation max_api_version
-	new_annotation target_api_version
-	new_annotation android_manifest
-	new_annotation android_manifest_application
-	new_annotation android_manifest_activity
-end
-
-import java
-import app
-import aware
+# Android compatibility module
+#
+# Defines the `@android` annotation used to tag `ldflags` annotations.
+module aware is new_annotation(android)

--- a/lib/android/log.nit
+++ b/lib/android/log.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Advanced Android logging services
-module log
+module log is ldflags "-llog"
 
 import platform
 

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -36,7 +36,7 @@
 #   which is a subclass of `Activity` and `Context` (in Java). It represent
 #   main activity of the running application. Use it to get anything related
 #   to the `Context` and as anchor to execute Java UI code.
-module native_app_glue
+module native_app_glue is ldflags "-landroid"
 
 import platform
 import log

--- a/lib/egl.nit
+++ b/lib/egl.nit
@@ -21,7 +21,12 @@
 # C library. If a method or class is not documented in Nit, refer to
 # the official documentation by the Khronos Group at:
 # http://www.khronos.org/registry/egl/sdk/docs/man/xhtml/
-module egl is pkgconfig
+module egl is
+	pkgconfig
+	ldflags("-lEGL")@android
+end
+
+import android::aware
 
 in "C Header" `{
 	#include <EGL/egl.h>

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -33,8 +33,10 @@ module glesv2 is
 	pkgconfig
 	new_annotation glsl_vertex_shader
 	new_annotation glsl_fragment_shader
+	ldflags("-lGLESv2")@android
 end
 
+import android::aware
 
 in "C Header" `{
 	#include <GLES2/gl2.h>

--- a/lib/mnit_android/android_assets.nit
+++ b/lib/mnit_android/android_assets.nit
@@ -21,7 +21,7 @@
 # * The Android ndk
 # * zlib (which is included in the Android ndk)
 # * libpng which must be provided by the Nit compilation framework
-module android_assets
+module android_assets is ldflags "-lz"
 
 import mnit
 import android_app

--- a/lib/mnit_android/android_opengles1.nit
+++ b/lib/mnit_android/android_opengles1.nit
@@ -16,7 +16,7 @@
 
 # Adapts OpenGL ES 1.0 for use on Android by offering services to get
 # a handler to the native display and window.
-module android_opengles1
+module android_opengles1 is ldflags "-lEGL -lGLESv1_CM"
 
 import android_app
 import android

--- a/src/c_tools.nit
+++ b/src/c_tools.nit
@@ -125,7 +125,7 @@ end
 class ExternCFile
 	super ExternFile
 
-	# Additional specific CC compiler -c flags
+	# Custom options for the C compiler (CFLAGS)
 	var cflags: String
 
 	redef fun hash do return filename.hash

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2990,7 +2990,7 @@ redef class MModule
 
 	# Give requided addinional system libraries (as given to LD_LIBS)
 	# Note: can return null instead of an empty set
-	fun collect_linker_libs: nullable Set[String] do return null
+	fun collect_linker_libs: nullable Array[String] do return null
 end
 
 # Create a tool context to handle options and paths

--- a/src/compiler/compiler_ffi.nit
+++ b/src/compiler/compiler_ffi.nit
@@ -49,6 +49,7 @@ extern void nitni_global_ref_incr(void*);
 extern void nitni_global_ref_decr(void*);
 """
 
+		var cflags = self.cflags[""].join(" ")
 		nitni_ccu.write_as_nitni(self, v.compiler.modelbuilder.compile_dir)
 
 		for file in nitni_ccu.files do
@@ -76,11 +77,8 @@ extern void nitni_global_ref_decr(void*);
 
 	redef fun collect_linker_libs
 	do
-		var s = ldflags
-		if s.is_empty then return null
-		var res = new ArraySet[String]
-		res.add s
-		return res
+		if not self.ldflags.keys.has("") then return null
+		return self.ldflags[""]
 	end
 
 	private var compiled_callbacks = new Array[NitniCallback]

--- a/src/ffi/c.nit
+++ b/src/ffi/c.nit
@@ -72,8 +72,14 @@ redef class Location
 end
 
 redef class MModule
-	var cflags = "" is writable
-	var ldflags = "" is writable
+	# FIXME make nullable the key of `cflags`, `ldflags` and `cppflags` when
+	# supported by the bootstrap
+
+	# Custom options for the C compiler (CFLAGS)
+	var cflags = new MultiHashMap[String, String]
+
+	# Custom options for the C linker (LDFLAGS)
+	var ldflags = new MultiHashMap[String, String]
 
 	# Additional libraries needed for the compilation
 	# Will be used with pkg-config

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -27,7 +27,8 @@ end
 redef class MModule
 	private var cpp_file: nullable CPPCompilationUnit = null
 
-	var cppflags = "" is writable
+	# Custom options for the C++ compiler (CPPFLAGS)
+	var cppflags = new MultiHashMap[String, String]
 end
 
 class CPPLanguage
@@ -133,7 +134,7 @@ class CPPLanguage
 		mmodule.ffi_files.add(file)
 
 		# add linked option to support C++
-		mmodule.ldflags = "{mmodule.ldflags} -lstdc++"
+		mmodule.ldflags.add_one("", "-lstdc++")
 	end
 
 	redef fun compile_callback(callback, mmodule, mainmodule, ecc)
@@ -180,7 +181,7 @@ class ExternCppFile
 	var mmodule: MModule
 
 	redef fun makefile_rule_name do return "{filename.basename("")}.o"
-	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cppflags} -c {filename.basename("")} -o {filename.basename("")}.o"
+	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cppflags[""].join(" ")} -c {filename.basename("")} -o {filename.basename("")}.o"
 	redef fun compiles_to_o_file do return true
 end
 

--- a/src/ffi/ffi.nit
+++ b/src/ffi/ffi.nit
@@ -60,6 +60,8 @@ redef class MModule
 			if mod.uses_ffi then ffi_ccu.header_custom.add("#include \"{mod.c_name}._ffi.h\"\n")
 		end
 
+		var cflags = self.cflags[""].join(" ")
+
 		ffi_ccu.write_as_impl(self, compdir)
 		for filename in ffi_ccu.files do
 			var f = new ExternCFile(filename, cflags)

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -242,8 +242,8 @@ redef class MModule
 	# Tell the C compiler where to find jni.h and how to link with libjvm
 	private fun insert_compiler_options
 	do
-		cflags = "{cflags} -I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
-		ldflags = "{ldflags} -L $(JNI_LIB_PATH) -ljvm"
+		cflags.add_one("", "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/")
+		ldflags.add_one("", "-L $(JNI_LIB_PATH) -ljvm")
 	end
 
 	# Name of the generated Java class where to store all implementation methods of this module

--- a/src/ffi/objc.nit
+++ b/src/ffi/objc.nit
@@ -154,7 +154,7 @@ private class ObjCCompilationUnit
 
 		files.add compdir/c_file
 
-		mmodule.ldflags = "{mmodule.ldflags} -lobjc"
+		mmodule.ldflags.add_one("", "-lobjc")
 
 		return new ExternObjCFile(compdir/c_file, mmodule)
 	end

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -34,6 +34,8 @@ end
 class AndroidPlatform
 	super Platform
 
+	redef fun name do return "android"
+
 	redef fun supports_libgc do return true
 
 	redef fun supports_libunwind do return false

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -138,11 +138,20 @@ class AndroidToolchain
 			end
 		end
 
-		## Generate delagating makefile
+		## Generate delegating makefile
 		dir = "{android_project_root}/jni/"
 		"""
 include $(call all-subdir-makefiles)
 		""".write_to_file("{dir}/Android.mk")
+
+		# Gather ldflags for Android
+		var ldflags = new Array[String]
+		var platform_name = "android"
+		for mmodule in compiler.mainmodule.in_importation.greaters do
+			if mmodule.ldflags.keys.has(platform_name) then
+				ldflags.add_all mmodule.ldflags[platform_name]
+			end
+		end
 
 		### generate makefile into "{compile_dir}/Android.mk"
 		dir = compile_dir
@@ -154,7 +163,7 @@ LOCAL_CFLAGS	:= -D ANDROID -D WITH_LIBGC
 LOCAL_MODULE    := main
 LOCAL_SRC_FILES := \\
 {{{cfiles.join(" \\\n")}}}
-LOCAL_LDLIBS    := -llog -landroid -lEGL -lGLESv1_CM -lz libgc.a
+LOCAL_LDLIBS    := {{{ldflags.join(" ")}}} libgc.a
 LOCAL_STATIC_LIBRARIES := android_native_app_glue png
 
 include $(BUILD_SHARED_LIBRARY)

--- a/src/platform/emscripten.nit
+++ b/src/platform/emscripten.nit
@@ -31,6 +31,7 @@ end
 class EmscriptenPlatform
 	super Platform
 
+	redef fun name do return "emscripten"
 	redef fun supports_libunwind do return false
 	redef fun supports_libgc do return false
 	redef fun supports_linker_script do return false

--- a/src/platform/platform.nit
+++ b/src/platform/platform.nit
@@ -104,6 +104,10 @@ end
 #
 # Services will be added to this class in other modules.
 class Platform
+
+	# Simple lower-case name of the platform
+	fun name: nullable String do return null
+
 	# Does the platform provide and support the library `unwind`?
 	fun supports_libunwind: Bool do return true
 

--- a/src/platform/pnacl.nit
+++ b/src/platform/pnacl.nit
@@ -31,6 +31,8 @@ end
 class PnaclPlatform
 	super Platform
 
+	redef fun name do return "pnacl"
+
 	redef fun supports_libunwind do return false
 
 	redef fun no_main do return true


### PR DESCRIPTION
For the same module, cflags and ldflags can vary per platform. This new annotation on annotations targets a platform for each cflags or ldflags. By default, the target platform is that of the host. It will probably need to be clarified on more modules once we support more platforms.

It will be used to load (or not load) OpenGL ES v1.0 vs 2.0 and libandroid in future PR. For now, only `calculator` should save on linking with OpenGL.

I hesitated between different annotations before settling on `@android`:
* `@target(android)` makes it clear that it is the target, but it gets a bit heavy to read: `module android_opengles1 is ldflags("-lEGL -lGLESv1_CM")@target(android)`
* `@only(android)` makes it clear that only Android is affected by this annotation.
* but `@android` is easy to read and clear enough to fit with an already complex syntax.

TODO `cflags@android` declarations are accepted but unused at this time.  