### PR TITLE
Ropefix

### DIFF
--- a/lib/standard/ropes.nit
+++ b/lib/standard/ropes.nit
@@ -155,7 +155,7 @@ private class Concat
 		else
 			var r = right
 			var rlen = r.length
-			if rlen + slen > maxlen then return new Concat(left, new Concat(r, s))
+			if rlen + slen > maxlen then return new Concat(self, s)
 			return new Concat(left, r + s)
 		end
 	end

--- a/lib/standard/ropes.nit
+++ b/lib/standard/ropes.nit
@@ -74,7 +74,7 @@ end
 private class Concat
 	super RopeString
 
-	redef var length: Int
+	redef var length: Int is noinit
 
 	redef fun substrings do return new RopeSubstrings(self)
 
@@ -98,10 +98,8 @@ private class Concat
 	# Right child of the node
 	var right: String
 
-	init(l: String, r: String) is old_style_init do
-		left = l
-		right = r
-		length = l.length + r.length
+	init do
+		length = left.length + right.length
 	end
 
 	redef fun output do
@@ -780,17 +778,15 @@ end
 private class RopeChars
 	super StringCharView
 
-	var tgt: RopeString
-
-	init(s: RopeString) is old_style_init do tgt = s
+	redef type SELFTYPE: RopeString
 
 	redef fun [](i) do
-		return tgt[i]
+		return target[i]
 	end
 
-	redef fun iterator_from(i) do return new RopeIter.from(tgt, i)
+	redef fun iterator_from(i) do return new RopeIter.from(target, i)
 
-	redef fun reverse_iterator_from(i) do return new RopeReviter.from(tgt, i)
+	redef fun reverse_iterator_from(i) do return new RopeReviter.from(target, i)
 
 end
 


### PR DESCRIPTION
A few modifications to ropes, I discovered that the `+` routine used to create too many Concat nodes passed a certain point, which inceased the RAM use of Strings unnecessarily (might help with #1106's example program, on my machine the memory went from 200M+ used to 20M).

While I was at it, I removed a few old-style-inits that were no longer necessary.

Some others however I could not remove, maybe there is a way I can do so, but with the spec of the new constructors I'm not entirely sure how to do so without retaining unnneeded information or complexifying instanciation, that'll have to wait.