### PR TITLE
Clean up to prepare for NitActivity

### DIFF
--- a/examples/mnit_simple/src/simple_android.nit
+++ b/examples/mnit_simple/src/simple_android.nit
@@ -43,8 +43,7 @@ redef class App
 		android.util.Log.d("mnit_simple", "Java within NIT!!!");
 
 		// - Context needed from now on
-		// NativeActivity is a Java sub-class of Context
-		final android.app.NativeActivity context = App_native_activity(recv);
+		final android.app.Activity context = App_native_activity(recv);
 
 		// Vibration
 		android.os.Vibrator v = (android.os.Vibrator)

--- a/examples/mnit_simple/src/test_bundle.nit
+++ b/examples/mnit_simple/src/test_bundle.nit
@@ -31,13 +31,13 @@ redef class App
 
 	fun test_bundle
 	do
-		var bundle = new Bundle(self)
-		 
+		var bundle = new Bundle
+
 		bundle["anInt"] = 1
 		bundle["aFloat"] = 1.1
 		bundle["aString"] = "A string"
 		bundle["aBool"] = true
-		
+
 		var int_array = new Array[Int]
 		var bool_array = new Array[Bool]
 
@@ -60,7 +60,7 @@ redef class App
 		assert bundle.string("wrongString") == null
 		assert bundle.bool("aBool", false)
 		assert bundle.bool("wrongBool", false) == false
-		
+
 		var int_array_test = bundle.array_of_int("anArrayOfInt")
 		var bool_array_test = bundle.array_of_bool("anArrayOfBool")
 
@@ -71,7 +71,7 @@ redef class App
 			assert bool_array_test[i] == value
 			value = not value
 		end
-		
+
 		assert bundle.size == 6
 		assert bundle.has("aBool")
 		assert not bundle.is_empty
@@ -97,7 +97,7 @@ redef class App
 
 		var deserialized_point_array = bundle.deserialize_array("anArrayOfPoint")
 
-		for i in [0..5] do 
+		for i in [0..5] do
 			var point = new Point(i, i)
 			assert deserialized_point_array[i].to_s == point.to_s
 		end

--- a/lib/android/activities.nit
+++ b/lib/android/activities.nit
@@ -1,0 +1,40 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Android Activities wrapper
+module activities
+
+import platform
+
+# An Android activity context
+extern class NativeContext in "Java" `{ android.content.Context `}
+	super JavaObject
+end
+
+# A wrapper of context
+extern class NativeContextWrapper in "Java" `{ android.content.ContextWrapper `}
+	super NativeContext
+end
+
+# An activity, a single, focused thing a user can do on Android
+extern class NativeActivity in "Java" `{ android.app.Activity `}
+	super NativeContextWrapper
+
+	# HACK for bug #845
+	redef fun new_global_ref: SELF import sys, Sys.jni_env `{
+		Sys sys = NativeActivity_sys(recv);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, recv);
+	`}
+end

--- a/lib/android/bundle/bundle.nit
+++ b/lib/android/bundle/bundle.nit
@@ -18,9 +18,11 @@
 # Android API for various data exchange purposes
 module bundle
 
-import native_app_glue
 import serialization
 import json_serialization
+
+import platform
+import activities
 
 in "Java" `{
 	import android.os.Bundle;
@@ -31,6 +33,8 @@ in "Java" `{
 
 extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	super JavaObject
+
+	new in "Java" `{ return new Bundle(); `}
 
 	fun clone: JavaObject in "Java" `{ return recv.clone(); `}
 	fun size: Int in "Java" `{ return recv.size(); `}
@@ -421,26 +425,10 @@ end
 
 # A class mapping `String` keys to various value types
 class Bundle
-	private var native_bundle: NativeBundle
-	private var context: NativeActivity
+	private var native_bundle: NativeBundle = new NativeBundle is lazy
 
-	init(app: App)
-	do
-		self.context = app.native_activity
-		setup
-	end
-
-	private fun set_vars(native_bundle: NativeBundle)
-	do
-		self.native_bundle = native_bundle.new_global_ref
-	end
-
-	private fun setup import context, set_vars in "Java" `{
-		Activity context = (Activity) Bundle_context(recv);
-		Bundle bundle = new Bundle();
-		
-		Bundle_set_vars(recv, bundle);
-	`}
+	# Get a new `Bundle` wrapping `native_bundle`
+	init from(native_bundle: NativeBundle) do self.native_bundle = native_bundle
 
 	# Returns `true` if the Bundle contains this key
 	fun has(key: String): Bool

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -32,7 +32,7 @@
 #   is on the same thread as Nit and manages the synchronization with the
 #   main Android thread.
 #
-# * `NativeActivity` is implemented in Java by `android.app.NativeActivity`,
+# * `NativeNativeActivity` is implemented in Java by `android.app.NativeActivity`,
 #   which is a subclass of `Activity` and `Context` (in Java). It represent
 #   main activity of the running application. Use it to get anything related
 #   to the `Context` and as anchor to execute Java UI code.
@@ -40,6 +40,7 @@ module native_app_glue is ldflags "-landroid"
 
 import platform
 import log
+import activities
 
 in "C header" `{
 	#include <android_native_app_glue.h>
@@ -114,22 +115,12 @@ in "C body" `{
 	}
 `}
 
-# An Android activity context
-extern class NativeContext in "Java" `{ android.content.Context `}
-	super JavaObject
-end
-
-# A wrapper of context
-extern class NativeContextWrapper in "Java" `{ android.content.ContextWrapper `}
-	super NativeContext
-end
-
 # Android SDK's `android.app.NativeActivity`.
 #
 # Can be used to get anything related to the `Context` of the activity in Java
 # and as anchor to execute Java UI code.
-extern class NativeActivity in "Java" `{ android.app.NativeActivity `}
-	super NativeContextWrapper
+extern class NativeNativeActivity in "Java" `{ android.app.NativeActivity `}
+	super NativeActivity
 end
 
 redef class App

--- a/lib/android/ui.nit
+++ b/lib/android/ui.nit
@@ -38,7 +38,7 @@ import native_app_glue
 import pthreads::concurrent_collections
 
 in "Java" `{
-	import android.app.NativeActivity;
+	import android.app.Activity;
 
 	import android.view.Gravity;
 	import android.view.MotionEvent;
@@ -115,7 +115,7 @@ redef extern class NativeActivity
 		final LinearLayout final_main_layout = new LinearLayout(recv);
 		final ViewGroup final_popup_layout = popup_layout;
 		final PopupWindow final_popup = popup;
-		final NativeActivity final_recv = recv;
+		final Activity final_recv = recv;
 
 		recv.runOnUiThread(new Runnable() {
 			@Override
@@ -144,7 +144,7 @@ redef extern class NativeActivity
 	# TODO bring use this instead of the hack with `dedicate_to_pupup`
 	private fun real_content_view=(layout: NativeViewGroup) in "Java" `{
 		final ViewGroup final_layout = layout;
-		final NativeActivity final_recv = recv;
+		final Activity final_recv = recv;
 
 		recv.runOnUiThread(new Runnable() {
 			@Override
@@ -334,7 +334,7 @@ extern class NativeTextView in "Java" `{ android.widget.TextView `}
 		final TextView final_recv = recv;
 		final String final_value = value;
 
-		((NativeActivity)recv.getContext()).runOnUiThread(new Runnable() {
+		((Activity)recv.getContext()).runOnUiThread(new Runnable() {
 			@Override
 			public void run()  {
 				final_recv.setText(final_value);
@@ -347,7 +347,7 @@ extern class NativeTextView in "Java" `{ android.widget.TextView `}
 		final TextView final_recv = recv;
 		final boolean final_value = value;
 
-		((NativeActivity)recv.getContext()).runOnUiThread(new Runnable() {
+		((Activity)recv.getContext()).runOnUiThread(new Runnable() {
 			@Override
 			public void run()  {
 				final_recv.setEnabled(final_value);


### PR DESCRIPTION
This PR cleans the way to replace our current use of `NativeActivity` by our own `NitActivity` a direct subclass to `Activity`. The result of this PR that we are less dependent on `NativeActivity` and the `native_app_glue` module.

Notable modifications:

* Use Java `Activity` instead of `NativeActivity` wherever possible.
* Rename, to follow convention, Nit `NativeActivity` to `NativeNativeActivity` and `Activity` to `NativeActivity`. Thus all previous Java code using the Java `NativeActivity`, will now use Java `Activity`. The name `NativeNativeActivity` is weird, but temporary as the class will be removed once we have our `NitActivity`.