### PR TITLE
Fix virtual types in string

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -1522,8 +1522,6 @@ class FlatBuffer
 	super FlatText
 	super Buffer
 
-	redef type SELFTYPE: FlatBuffer
-
 	redef var chars: Sequence[Char] = new FlatBufferCharView(self)
 
 	private var capacity: Int = 0

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -877,7 +877,7 @@ end
 abstract class String
 	super Text
 
-	redef type SELFTYPE: String
+	redef type SELFTYPE: String is fixed
 
 	redef fun to_s do return self
 
@@ -1399,7 +1399,7 @@ end
 abstract class Buffer
 	super Text
 
-	redef type SELFTYPE: Buffer
+	redef type SELFTYPE: Buffer is fixed
 
 	# Specific implementations MUST set this to `true` in order to invalidate caches
 	protected var is_dirty = true

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -439,10 +439,10 @@ abstract class Text
 	# REQUIRE: `left >= 0.0 and left <= 1.0`
 	# ENSURE: `self.length <= length implies result.length == length`
 	# ENSURE: `self.length >= length implies result == self`
-	fun justify(length: Int, left: Float): SELFTYPE
+	fun justify(length: Int, left: Float): String
 	do
 		var diff = length - self.length
-		if diff <= 0 then return self
+		if diff <= 0 then return to_s
 		assert left >= 0.0 and left <= 1.0
 		var before = (diff.to_f * left).to_i
 		return " " * before + self + " " * (diff-before)
@@ -711,7 +711,7 @@ abstract class Text
 	#     assert "a&b-<>\"x\"/'".html_escape      ==  "a&amp;b-&lt;&gt;&#34;x&#34;&#47;&#39;"
 	#
 	# SEE: <https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content>
-	fun html_escape: SELFTYPE
+	fun html_escape: String
 	do
 		var buf = new FlatBuffer
 

--- a/lib/standard/string_search.nit
+++ b/lib/standard/string_search.nit
@@ -370,16 +370,16 @@ redef class Text
 	# Split `self` using `p` as separator.
 	#
 	#     assert "hello world".split('o')          ==  ["hell", " w", "rld"]
-	fun split(p: Pattern): Array[SELFTYPE]
+	fun split(p: Pattern): Array[String]
 	do
 		var matches = p.split_in(self)
-		var res = new Array[SELFTYPE].with_capacity(matches.length)
+		var res = new Array[String].with_capacity(matches.length)
 		for m in matches do res.add(m.to_s)
 		return res
 	end
 
 	# @deprecated alias for `split`
-	fun split_with(p: Pattern): Array[SELFTYPE] do return self.split(p)
+	fun split_with(p: Pattern): Array[String] do return self.split(p)
 
 	# Split `self` on the first `=`
 	#
@@ -396,7 +396,7 @@ redef class Text
 	#
 	#     assert "hlelo".replace("le", "el")	     ==  "hello"
 	#     assert "hello".replace('l', "")	     ==  "heo"
-	fun replace(p: Pattern, string: SELFTYPE): SELFTYPE
+	fun replace(p: Pattern, string: SELFTYPE): String
 	do
 		return self.split_with(p).join(string)
 	end


### PR DESCRIPTION
`SELFTYPE` in String is used to dintinguish buffers from strings. Unfortunately it is sometime badly used.

This series try to at least improve thing so that operations on buffers do not crash at runtime.

Still, I think there is something fishy in the String vs Buffer API