### PR TITLE
Optimize get_or_null

### DIFF
--- a/examples/rosettacode/doors_with_classes.nit
+++ b/examples/rosettacode/doors_with_classes.nit
@@ -20,10 +20,12 @@ class Door
 	end
 end
 
-var doors = new Array[Door]
-for door in [0..100[ do doors.add(new Door)
-
 var n = 100
+if args.length > 0 then n = args.first.to_i
+
+var doors = new Array[Door]
+for door in [0..n[ do doors.add(new Door)
+
 for visit in [0..n[ do
 	var i = visit
 	while i < n do

--- a/lib/more_collections.nit
+++ b/lib/more_collections.nit
@@ -36,8 +36,9 @@ class MultiHashMap[K, V]
 	# If there is no array associated, then create it.
 	fun add_one(k: K, v: V)
 	do
-		if self.has_key(k) then
-			self[k].add(v)
+		var x = self.get_or_null(k)
+		if x != null then
+			x.add(v)
 		else
 			self[k] = [v]
 		end
@@ -67,22 +68,19 @@ class HashMap2[K1, K2, V]
 	fun [](k1: K1, k2: K2): nullable V
 	do
 		var level1 = self.level1
-		if not level1.has_key(k1) then return null
-		var level2 = level1[k1]
-		if not level2.has_key(k2) then return null
-		return level2[k2]
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return null
+		return level2.get_or_null(k2)
 	end
 
 	# Set `v` the value associated to the keys `k1` and `k2`.
 	fun []=(k1: K1, k2: K2, v: V)
 	do
 		var level1 = self.level1
-		var level2: HashMap[K2, V]
-		if not level1.has_key(k1) then
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then
 			level2 = new HashMap[K2, V]
 			level1[k1] = level2
-		else
-			level2 = level1[k1]
 		end
 		level2[k2] = v
 	end
@@ -91,10 +89,8 @@ class HashMap2[K1, K2, V]
 	fun remove_at(k1: K1, k2: K2)
 	do
 		var level1 = self.level1
-
-		if not level1.has_key(k1) then return
-
-		var level2 = level1[k1]
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return
 		level2.keys.remove(k2)
 	end
 end
@@ -116,8 +112,8 @@ class HashMap3[K1, K2, K3, V]
 	fun [](k1: K1, k2: K2, k3: K3): nullable V
 	do
 		var level1 = self.level1
-		if not level1.has_key(k1) then return null
-		var level2 = level1[k1]
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return null
 		return level2[k2, k3]
 	end
 
@@ -125,12 +121,10 @@ class HashMap3[K1, K2, K3, V]
 	fun []=(k1: K1, k2: K2, k3: K3, v: V)
 	do
 		var level1 = self.level1
-		var level2: HashMap2[K2, K3, V]
-		if not level1.has_key(k1) then
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then
 			level2 = new HashMap2[K2, K3, V]
 			level1[k1] = level2
-		else
-			level2 = level1[k1]
 		end
 		level2[k2, k3] = v
 	end
@@ -139,10 +133,8 @@ class HashMap3[K1, K2, K3, V]
 	fun remove_at(k1: K1, k2: K2, k3: K3)
 	do
 		var level1 = self.level1
-
-		if not level1.has_key(k1) then return
-
-		var level2 = level1[k1]
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return
 		level2.remove_at(k2, k3)
 	end
 end

--- a/lib/standard/collection/hash_collection.nit
+++ b/lib/standard/collection/hash_collection.nit
@@ -235,6 +235,16 @@ class HashMap[K, V]
 		end
 	end
 
+	redef fun get_or_null(key)
+	do
+		var c = node_at(key)
+		if c == null then
+			return null
+		else
+			return c._value
+		end
+	end
+
 	redef fun iterator: HashMapIterator[K, V] do return new HashMapIterator[K,V](self)
 
 	redef fun length do return _the_length

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -74,11 +74,7 @@ redef class Model
 	# Visibility or modules are not considered
 	fun get_mclasses_by_name(name: String): nullable Array[MClass]
 	do
-		if mclasses_by_name.has_key(name) then
-			return mclasses_by_name[name]
-		else
-			return null
-		end
+		return mclasses_by_name.get_or_null(name)
 	end
 
 	# Collections of properties grouped by their short name
@@ -92,11 +88,7 @@ redef class Model
 	# Visibility or modules are not considered
 	fun get_mproperties_by_name(name: String): nullable Array[MProperty]
 	do
-		if not mproperties_by_name.has_key(name) then
-			return null
-		else
-			return mproperties_by_name[name]
-		end
+		return mproperties_by_name.get_or_null(name)
 	end
 
 	# The only null type

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1905,7 +1905,6 @@ abstract class MProperty
 	# REQUIRE: `mtype.has_mproperty(mmodule, self)`
 	fun lookup_first_definition(mmodule: MModule, mtype: MType): MPROPDEF
 	do
-		assert mtype.has_mproperty(mmodule, self)
 		return lookup_all_definitions(mmodule, mtype).first
 	end
 
@@ -1913,11 +1912,13 @@ abstract class MProperty
 	# Most specific first, most general last
 	fun lookup_all_definitions(mmodule: MModule, mtype: MType): Array[MPROPDEF]
 	do
-		assert not mtype.need_anchor
 		mtype = mtype.as_notnullable
 
 		var cache = self.lookup_all_definitions_cache[mmodule, mtype]
 		if cache != null then return cache
+
+		assert not mtype.need_anchor
+		assert mtype.has_mproperty(mmodule, self)
 
 		#print "select prop {mproperty} for {mtype} in {self}"
 		# First, select all candidates

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1787,6 +1787,9 @@ abstract class MProperty
 	# If mtype does not know mproperty then an empty array is returned.
 	#
 	# If you want the really most specific property, then look at `lookup_first_definition`
+	#
+	# REQUIRE: `not mtype.need_anchor` to simplify the API (no `anchor` parameter)
+	# ENSURE: `not mtype.has_mproperty(mmodule, self) == result.is_empty`
 	fun lookup_definitions(mmodule: MModule, mtype: MType): Array[MPROPDEF]
 	do
 		assert not mtype.need_anchor
@@ -1825,7 +1828,8 @@ abstract class MProperty
 	#
 	# If you want the really most specific property, then look at `lookup_next_definition`
 	#
-	# FIXME: Move to `MPropDef`?
+	# REQUIRE: `not mtype.need_anchor` to simplify the API (no `anchor` parameter)
+	# ENSURE: `not mtype.has_mproperty(mmodule, self) implies result.is_empty`
 	fun lookup_super_definitions(mmodule: MModule, mtype: MType): Array[MPROPDEF]
 	do
 		assert not mtype.need_anchor
@@ -1893,7 +1897,7 @@ abstract class MProperty
 	#
 	# FIXME: the linearization is still unspecified
 	#
-	# REQUIRE: `not mtype.need_anchor`
+	# REQUIRE: `not mtype.need_anchor` to simplify the API (no `anchor` parameter)
 	# REQUIRE: `mtype.has_mproperty(mmodule, self)`
 	fun lookup_first_definition(mmodule: MModule, mtype: MType): MPROPDEF
 	do
@@ -1902,6 +1906,9 @@ abstract class MProperty
 
 	# Return all definitions in a linearization order
 	# Most specific first, most general last
+	#
+	# REQUIRE: `not mtype.need_anchor` to simplify the API (no `anchor` parameter)
+	# REQUIRE: `mtype.has_mproperty(mmodule, self)`
 	fun lookup_all_definitions(mmodule: MModule, mtype: MType): Array[MPROPDEF]
 	do
 		mtype = mtype.as_notnullable


### PR DESCRIPTION
Recent profiling of the interpreter nit shows that a lof of time is used in hashmaps. This PR improves the standard use-path with the safe method `get_or_null` that is more efficient (and simple) than `has_key` followed by `[]`.

The time for `nit doors_with_classes.nit 5000` give

before: 0m5.592s
after: 0m5.208s (-6,7%)

Note: by comparison, the ruby version is 0m2.284s, and the python is 0m0.116s ; there is still a lot of work