### PR TITLE
String memory fixes

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -1911,15 +1911,22 @@ redef class Int
 		end
 	end
 
+	# C function to calculate the length of the `NativeString` to receive `self`
+	private fun int_to_s_len: Int is extern "native_int_length_str"
+
 	# C function to convert an nit Int to a NativeString (char*)
-	private fun native_int_to_s: NativeString is extern "native_int_to_s"
+	private fun native_int_to_s(nstr: NativeString, strlen: Int) is extern "native_int_to_s"
 
 	# return displayable int in base 10 and signed
 	#
 	#     assert 1.to_s            == "1"
 	#     assert (-123).to_s       == "-123"
 	redef fun to_s do
-		return native_int_to_s.to_s
+		var nslen = int_to_s_len
+		var ns = new NativeString(nslen + 1)
+		ns[nslen] = '\0'
+		native_int_to_s(ns, nslen + 1)
+		return ns.to_s_with_length(nslen)
 	end
 
 	# return displayable int in hexadecimal

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -2018,23 +2018,6 @@ redef class Float
 
 		return p1 + "." + p2
 	end
-
-	# `self` representation with `nb` digits after the '.'.
-	#
-	#     assert 12.345.to_precision_native(1) == "12.3"
-	#     assert 12.345.to_precision_native(2) == "12.35"
-	#     assert 12.345.to_precision_native(3) == "12.345"
-	#     assert 12.345.to_precision_native(4) == "12.3450"
-	fun to_precision_native(nb: Int): String import NativeString.to_s `{
-		int size;
-		char *str;
-
-		size = snprintf(NULL, 0, "%.*f", (int)nb, recv);
-		str = malloc(size + 1);
-		sprintf(str, "%.*f", (int)nb, recv );
-
-		return NativeString_to_s( str );
-	`}
 end
 
 redef class Char

--- a/lib/standard/string_nit.c
+++ b/lib/standard/string_nit.c
@@ -11,10 +11,12 @@
 
 #include "string_nit.h"
 
+// Returns the length of `recv` as a `char*` (excluding the null character)
+long native_int_length_str(long recv){
+	return snprintf(NULL, 0, "%ld", recv);
+}
+
 // Integer to NativeString method
-char* native_int_to_s(long recv){
-	int len = snprintf(NULL, 0, "%ld", recv);
-	char* str = malloc(len+1);
-	sprintf(str, "%ld", recv);
-	return str;
+void native_int_to_s(long recv, char* str, long buflen){
+	snprintf(str, buflen, "%ld", recv);
 }

--- a/lib/standard/string_nit.h
+++ b/lib/standard/string_nit.h
@@ -13,6 +13,7 @@
  * another product.
  */
 
-char* native_int_to_s(long recv);
+long native_int_length_str(long recv);
+void native_int_to_s(long recv, char* str, long buflen);
 
 #endif

--- a/lib/standard/time.nit
+++ b/lib/standard/time.nit
@@ -135,7 +135,9 @@ extern class Tm `{struct tm *`}
 		c_format = String_to_cstring(format);
 
 		res = strftime(buf, 100, c_format, recv);
-		return NativeString_to_s(buf);
+		String s = NativeString_to_s_with_copy(buf);
+		free(buf);
+		return s;
 	`}
 
 	redef fun to_s do return asctime.replace("\n", "")

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -857,8 +857,15 @@ redef class AMethPropdef
 				return v.int_instance(args[0].to_i.bin_xor(args[1].to_i))
 			else if pname == "bin_not" then
 				return v.int_instance(args[0].to_i.bin_not)
+			else if pname == "int_to_s_len" then
+				return v.int_instance(recvval.to_s.length)
 			else if pname == "native_int_to_s" then
-				return v.native_string_instance(recvval.to_s)
+				var s = recvval.to_s
+				var srecv = args[1].val.as(Buffer)
+				srecv.clear
+				srecv.append(s)
+				srecv.add('\0')
+				return null
 			else if pname == "strerror_ext" then
 				return v.native_string_instance(recvval.strerror)
 			end

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -970,13 +970,13 @@ redef class AMethPropdef
 				if fromval < 0 then
 					debug("Illegal access on {recvval} for element {fromval}/{recvval.length}")
 				end
-				if fromval + lenval >= recvval.length then
+				if fromval + lenval > recvval.length then
 					debug("Illegal access on {recvval} for element {fromval}+{lenval}/{recvval.length}")
 				end
 				if toval < 0 then
 					debug("Illegal access on {destval} for element {toval}/{destval.length}")
 				end
-				if toval + lenval >= destval.length then
+				if toval + lenval > destval.length then
 					debug("Illegal access on {destval} for element {toval}+{lenval}/{destval.length}")
 				end
 				recvval.as(FlatBuffer).copy(fromval, lenval, destval, toval)


### PR DESCRIPTION
Another step towards the closure of #1106 and #69, this PR removes several calls to `malloc` in `lib/standard` C code and replaces them by some of the solutions proposed in #1106 to handle the allocation of Strings.

@xymus: Your review is more than welcome since we're dealing with extern code, it might be a good time to specify and document how to properly allocate extern data structures to avoid leaking code such as the ones we had.