### PR TITLE
Global for filenames

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -856,6 +856,12 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 
 		v.add("return 0;")
 		v.add("\}")
+
+		for m in mainmodule.in_importation.greaters do
+			var f = "FILE_"+m.c_name
+			v.add "const char {f}[] = \"{m.location.file.filename.escape_to_c}\";"
+			provide_declaration(f, "extern const char {f}[];")
+		end
 	end
 
 	# Copile all C functions related to the [incr|decr]_ref features of the FFI
@@ -1525,8 +1531,11 @@ abstract class AbstractCompilerVisitor
 
 	fun add_raw_abort
 	do
-		if self.current_node != null and self.current_node.location.file != null then
-			self.add("PRINT_ERROR(\" (%s:%d)\\n\", \"{self.current_node.location.file.filename.escape_to_c}\", {current_node.location.line_start});")
+		if self.current_node != null and self.current_node.location.file != null and
+				self.current_node.location.file.mmodule != null then
+			var f = "FILE_{self.current_node.location.file.mmodule.c_name}"
+			self.require_declaration(f)
+			self.add("PRINT_ERROR(\" (%s:%d)\\n\", {f}, {current_node.location.line_start});")
 		else
 			self.add("PRINT_ERROR(\"\\n\");")
 		end

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -527,6 +527,12 @@ redef class ModelBuilder
 		nmodules.add(nmodule)
 		self.mmodule2nmodule[mmodule] = nmodule
 
+		var source = nmodule.location.file
+		if source != null then
+			assert source.mmodule == null
+			source.mmodule = mmodule
+		end
+
 		if decl != null then
 			# Extract documentation
 			var ndoc = decl.n_doc
@@ -671,6 +677,11 @@ redef class MGroup
 		return module_paths.length > 1 or mmodules.length > 1 or not in_nesting.direct_smallers.is_empty or mdoc != null
 	end
 
+end
+
+redef class SourceFile
+	# Associated mmodule, once created
+	var mmodule: nullable MModule = null
 end
 
 redef class AStdImport


### PR DESCRIPTION
This PR remove the remaining big variability for nitc when generating separate files: the path of nit module in runtime error messages.
When compiling a same module but from different current working directories, the relative path of the module changed. Thus causing unnecessary difference in the generated C source code that made ccache unhappy.

Before
~~~
$ ccache -C
$ time nitc src/nitc.nit
user	2m8.264s
$ cd src
$ time nitc nitc.nit
user	2m8.676s
~~~

After
~~~
$ ccache -C
$ time nitc src/nitc.nit
user	2m9.180s
$ cd src
$ time nitc nitc.nit
user	0m9.812s
~~~

Note: some files are still different after the PR

* main.c because it contains the real filepath
* c_function_hash.c same
* _ffi.? because the pragma lines indicate the original relative file

Note 2: `.nit_compile` directories are still created by default in the current directory and let unclean. cf #792