### PR TITLE
Makefile: initial make use --semi-global

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NITCOPT=
+NITCOPT=--semi-global
 OLDNITCOPT=
 OBJS=nitc nitpick nit nitdoc nitls nitunit nitpretty nitmetrics nitx nitlight nitdbg_client nitserial
 SRCS=$(patsubst %,%.nit,$(OBJS))


### PR DESCRIPTION
The produced tools in bin/ should be faster to use then.