### PR TITLE
Vim omnifunc diffentiate between types, class declaration and instanciation

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -81,7 +81,8 @@ The omnifunc applies a simple heuristic to recognize what kind of entities to di
 (This is a simplification some behaviors are missing.)
 
 * If the cursor follows `import`, it will list known modules.
-* If it follows `new`, `super` or `class` it will list known classes.
+* If it follows `new` it will list known classes with their constructors.
+* If it follows `super`, `class`, `isa` or `as` it will list known classes.
 * If it follows a `.`, it will list properties.
 * If on an extern method declaration, it will list classes and properties.
 * Otherwise, it will list keywords and properties.

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -139,7 +139,7 @@ fun NitOmnifuncAddAMatch(matches, words, name)
 	let desc = get(a:words, 3, '')
 	let desc = join(split(desc, '#nnnn#', 1), "\n")
 	if strlen(pretty) > 40
-		let pretty = pretty[:37] . '...'
+		let pretty = pretty[:39] . '…'
 	endif
 	call add(a:matches, {'word': a:name, 'abbr': pretty, 'menu': synopsis, 'info': desc, 'dup': 1})
 endfun

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -188,12 +188,24 @@ fun NitOmnifunc(findstart, base)
 			call NitOmnifuncAddFromFile(a:base, matches, 'modules.txt')
 		endif
 
-		" Classes
-		if count(['new', 'super', 'class', 'nullable'], prev_word) > 0 ||
+		" Classes (instanciable only)
+		if prev_word == 'new'
+			let handled = 1
+			call NitOmnifuncAddFromFile(a:base, matches, 'constructors.txt')
+		endif
+
+		" Other class references
+		if count(['class', 'super'], prev_word) > 0
+			let handled = 1
+			call NitOmnifuncAddFromFile(a:base, matches, 'classes.txt')
+		endif
+
+		" Types
+		if count(['class', 'super', 'nullable', 'isa', 'as'], prev_word) > 0 ||
 		 \ line_prev_cursor =~ '[' || prev_char == ':' ||
 		 \ (line_prev_cursor =~ 'fun' && line_prev_cursor =~ 'import' && (prev_word == 'import' || prev_char == ','))
 			let handled = 1
-			call NitOmnifuncAddFromFile(a:base, matches, 'classes.txt')
+			call NitOmnifuncAddFromFile(a:base, matches, 'types.txt')
 		endif
 
 		" Properties

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -138,6 +138,10 @@ private class AutocompletePhase
 			var intro_mmodule = mproperty.intro_mclassdef.mmodule
 			if not mainmodule.is_visible(intro_mmodule, public_visibility) then continue
 
+			# Skip properties beginning with @ or _
+			var first_letter = mproperty.name.chars.first
+			if first_letter == '@' or first_letter == '_' then continue
+
 			mproperty.intro.write_to_stream properties_stream
 		end
 


### PR DESCRIPTION
The main improvement is the knowledge of constructors. They will be suggested along with their class after a `new`, ex: `new Arr`, it will autocomplete to `Array[E]`, `Array[E].with_items`, etc. It will also show their corresponding documentation.

Also detect the keywords `isa` and `as`.