### PR TITLE
lib/glesv2: intro framebuffer related services and try a new style

### DIFF
--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -619,6 +619,51 @@ fun glHint(target: GLHintTarget, mode: GLHintMode) `{
 	glHint(target, mode);
 `}
 
+# Completeness status of a framebuffer object
+fun glCheckFramebufferStatus(target: GLFramebufferTarget): GLFramebufferStatus `{
+	return glCheckFramebufferStatus(target);
+`}
+
+# Return value of `glCheckFramebufferStatus`
+extern class GLFramebufferStatus
+	super GLEnum
+
+	redef fun to_s
+	do
+		if self == gl_FRAMEBUFFER_COMPLETE then return "complete"
+		if self == gl_FRAMEBUFFER_INCOMPLETE_ATTACHMENT then return "incomplete attachment"
+		if self == gl_FRAMEBUFFER_INCOMPLETE_DIMENSIONS then return "incomplete dimension"
+		if self == gl_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT then return "incomplete missing attachment"
+		if self == gl_FRAMEBUFFER_UNSUPPORTED then return "unsupported"
+		return "unknown"
+	end
+end
+
+# The framebuffer is complete
+fun gl_FRAMEBUFFER_COMPLETE: GLFramebufferStatus `{
+	return GL_FRAMEBUFFER_COMPLETE;
+`}
+
+# Not all framebuffer attachment points are framebuffer attachment complete
+fun gl_FRAMEBUFFER_INCOMPLETE_ATTACHMENT: GLFramebufferStatus `{
+	return GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+`}
+
+# Not all attached images have the same width and height
+fun gl_FRAMEBUFFER_INCOMPLETE_DIMENSIONS: GLFramebufferStatus `{
+	return GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS;
+`}
+
+# No images are attached to the framebuffer
+fun gl_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: GLFramebufferStatus `{
+	return GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT;
+`}
+
+# The combination of internal formats of the attached images violates an implementation-dependent set of restrictions
+fun gl_FRAMEBUFFER_UNSUPPORTED: GLFramebufferStatus `{
+	return GL_FRAMEBUFFER_UNSUPPORTED;
+`}
+
 # Hint target for `glHint`
 extern class GLHintTarget
 	super GLEnum

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -584,6 +584,36 @@ class GLES
 	var capabilities = new GLCapabilities is lazy
 end
 
+# Bind `framebuffer` to a framebuffer target
+#
+# In OpenGL ES 2.0, `target` must be `gl_FRAMEBUFFER`.
+fun glBindFramebuffer(target: GLFramebufferTarget, framebuffer: Int) `{
+	glBindFramebuffer(target, framebuffer);
+`}
+
+# Target of `glBindFramebuffer`
+extern class GLFramebufferTarget
+	super GLEnum
+end
+
+# Target both reading and writing on the framebuffer with `glBindFramebuffer`
+fun gl_FRAMEBUFFER: GLFramebufferTarget `{ return GL_FRAMEBUFFER; `}
+
+# Bind `renderbuffer` to a renderbuffer target
+#
+# In OpenGL ES 2.0, `target` must be `gl_RENDERBUFFER`.
+fun glBindRenderbuffer(target: GLRenderbufferTarget, renderbuffer: Int) `{
+	glBindRenderbuffer(target, renderbuffer);
+`}
+
+# Target of `glBindRenderbuffer`
+extern class GLRenderbufferTarget
+	super GLEnum
+end
+
+# Target a renderbuffer with `glBindRenderbuffer`
+fun gl_RENDERBUFFER: GLRenderbufferTarget `{ return GL_RENDERBUFFER; `}
+
 # Entry point to OpenGL server-side capabilities
 class GLCapabilities
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -614,6 +614,33 @@ end
 # Target a renderbuffer with `glBindRenderbuffer`
 fun gl_RENDERBUFFER: GLRenderbufferTarget `{ return GL_RENDERBUFFER; `}
 
+# Specify implementation specific hints
+fun glHint(target: GLHintTarget, mode: GLHintMode) `{
+	glHint(target, mode);
+`}
+
+# Hint target for `glHint`
+extern class GLHintTarget
+	super GLEnum
+end
+
+# Indicates the quality of filtering when generating mipmap images
+fun gl_GENERATE_MIPMAP_HINT: GLHintTarget `{ return GL_GENERATE_MIPMAP_HINT; `}
+
+# Hint mode for `glHint`
+extern class GLHintMode
+	super GLEnum
+end
+
+# The most efficient option should be chosen
+fun gl_FASTEST: GLHintMode `{ return GL_FASTEST; `}
+
+# The most correct, or highest quality, option should be chosen
+fun gl_NICEST: GLHintMode `{ return GL_NICEST; `}
+
+# No preference
+fun gl_DONT_CARE: GLHintMode `{ return GL_DONT_CARE; `}
+
 # Entry point to OpenGL server-side capabilities
 class GLCapabilities
 


### PR DESCRIPTION
The main point of this PR is to try a new naming convention for the glesv2 module.

Ideas behind this convention:
1. Be as close as possible to the C API: use the same function and macro names. 
2. Modify those names only for compatibility with the Nit language: the macros cannot begin with `GL_` so use `gl_` instead.
3. Apply types and other Nity features when they can help and don't interfere with the original API.

It differs from the previous convention of renaming all entities to the Nit style. It is not heavier in the module definition but should be easier for the users.

In practice, to convert OpenGL ES C code to Nit you would need to change the prefix `GL_` to `gl_`, and remove `;`.

In C:
~~~
glBindFramebuffer(GL_FRAMEBUFFER, my_fbo);
glBindRenderbuffer(GL_RENDERBUFFER, my_renderbuffer);
return glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
~~~

In Nit:
~~~
glBindFramebuffer(gl_FRAMEBUFFER, my_fbo)
glBindRenderbuffer(gl_RENDERBUFFER, my_renderbuffer)
return glCheckFramebufferStatus(gl_FRAMEBUFFER) == gl_FRAMEBUFFER_COMPLETE
~~~

What do you think of the new naming convention? I would convert the whole module to it.