### PR TITLE
Guard call

### DIFF
--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -345,11 +345,29 @@ function bench_linkboost()
 	run_compiler "nitc-sct" ./nitc --separate --colors-are-symbols --trampoline-call
 	prepare_res "$name-nitc-sl.dat" "nitc-sl" "nitc with --separate --link-boost"
 	run_compiler "nitc-scts" ./nitc --separate --link-boost
-	prepare_res "$name-nitc-sg.dat" "nitc-sg" "nitc with --separate --semi-global"
-	run_compiler "nitc-sg" ./nitc --separate --semi-global
+	prepare_res "$name-nitc-scgc.dat" "nitc-scgc" "nitc with --separate --colors-are-symbols --guard-call"
+	run_compiler "nitc-scgc" ./nitc --separate --colors-are-symbols --guard-call
+	prepare_res "$name-nitc-scd.dat" "nitc-scd" "nitc with --separate --colors-are-symbols --direct-call-monomorph0"
+	run_compiler "nitc-scd" ./nitc --separate --colors-are-symbols --direct-call-monomorph0
 	plot "$name.gnu"
 }
 bench_linkboost
+
+function bench_call_monomorph()
+{
+	name="$FUNCNAME"
+	skip_test "$name" && return
+	prepare_res "$name-nitc.dat" "nitc" "nitc with --separate"
+	run_compiler "nitc" ./nitc
+	prepare_res "$name-nitc-d0.dat" "nitc-d0" "nitc with --separate --direct-call-monomorph0"
+	run_compiler "nitc-d0" ./nitc --direct-call-monomorph0
+	prepare_res "$name-nitc-d1.dat" "nitc-d" "nitc with --separate --direct-call-monomorph"
+	run_compiler "nitc-d1" ./nitc --direct-call-monomorph
+	prepare_res "$name-nitc-d2.dat" "nitc-d2" "nitc with --separate --direct-call-monomorph2"
+	run_compiler "nitc-d2" ./nitc --direct-call-monomorph --direct-call-monomorph0
+	plot "$name.gnu"
+}
+bench_call_monomorph
 
 if test -n "$html"; then
 	echo >>"$html" "</body></html>"


### PR DESCRIPTION
Add option `--guard-call` as an alternative implementation of the link-time optimization `--substitute-monomorph`

The idea is to have the standard VFT call guarded by a symbol when the call is monomorphic.
So the sequence is independent of any client and is roughly

~~~
if SYMBOL != null then
   SYMBOL(ARGS)
else
   (SELF->VFT[COLOR])(ARGS)
end
~~~

where the value of the SYMBOL is set for each specific program at link-time: null when the call is polymorphic and the address of the single target when the call is monomorphic.

Benches show that, on my computer, there is from 0% to 10% in loss so this alternative implementation is pure overcost :)
Still keep it because, I coded it and works, and it may worth something on other architectures.

The benchs shows some quick results:

* first (sc, red) is default
* second (sl, green) is `--substitute-monomorph`, the previous impl
* third (gc, blue) is `--guard-call``, the new one
* last (cd, purple) is `--direct-call-monomorph0`, the optimal with direct calls directly inserted in a global way

![bench_linkboost](https://cloud.githubusercontent.com/assets/135828/6342973/794b2a92-bc13-11e4-9b22-cc43e6cda473.png)

Even if the result is deceiving, the PR does some cleanup and refactorization, so we got that goin for us,  which is nice.