### PR TITLE
Inline intern methods in standard objects

### DIFF
--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1852,7 +1852,10 @@ class SeparateCompilerVisitor
 		var nclass = self.get_class("NativeArray")
 		var recv = "((struct instance_{nclass.c_name}*){arguments[0]})->values"
 		if pname == "[]" then
-			self.ret(self.new_expr("{recv}[{arguments[1]}]", ret_type.as(not null)))
+			# Because the objects are boxed, return the box to avoid unnecessary (or broken) unboxing/reboxing
+			var res = self.new_expr("{recv}[{arguments[1]}]", compiler.mainmodule.object_type)
+			res.mcasttype = ret_type.as(not null)
+			self.ret(res)
 			return
 		else if pname == "[]=" then
 			self.add("{recv}[{arguments[1]}]={arguments[2]};")

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1163,6 +1163,12 @@ class SeparateCompilerVisitor
 				return direct_call(tgs.first, args)
 			end
 		end
+		# Shortcut intern methods as they are not usually redefinable
+		if callsite.mpropdef.is_intern and callsite.mproperty.name != "object_id" then
+			# `object_id` is the only redefined intern method, so it can not be directly called.
+			# TODO find a less ugly approach?
+			return direct_call(callsite.mpropdef, args)
+		end
 		return super
 	end
 

--- a/tests/sav/nitg-sg/fixme/test_gen.res
+++ b/tests/sav/nitg-sg/fixme/test_gen.res
@@ -1,1 +1,0 @@
-UNDEFINED


### PR DESCRIPTION
Those in primitive types where already inlined, this time it is the ones in Object, NativeArray and other.

A special case remain for `object_id` since the value in standard objects is redefined in primitive type.
So this one is not inlined.

The gain in nitc/nitc/nitc is less that I expected but not that bad.
before: 0m7.276s
after: 0m7.100s (-2.5%)

Bonus: an old bug related to native arrays in --semi-global related to inlining is also fixed.