### PR TITLE
compiler: fast path is the hot path in once and literal strings

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1443,7 +1443,7 @@ abstract class AbstractCompilerVisitor
 		var name = self.get_name("varonce")
 		self.add_decl("static {mtype.ctype} {name};")
 		var res = self.new_var(mtype)
-		self.add("if ({name}) \{")
+		self.add("if (likely({name}!=NULL)) \{")
 		self.add("{res} = {name};")
 		self.add("\} else \{")
 		var native_mtype = self.get_class("NativeString").mclass_type
@@ -2823,7 +2823,7 @@ redef class AOnceExpr
 		v.add_decl("static {mtype.ctype} {name};")
 		v.add_decl("static int {guard};")
 		var res = v.new_var(mtype)
-		v.add("if ({guard}) \{")
+		v.add("if (likely({guard})) \{")
 		v.add("{res} = {name};")
 		v.add("\} else \{")
 		var i = v.expr(self.n_expr, mtype)


### PR DESCRIPTION
`once` structure and literal strings are implemented with a guard so that
onced-expression and literal strings are evaluated/created once then
stored in a static variable.

This patch just informs GCC that the fast path (get the saved value)
it the frequent path. It's up to GCC to do something useful with this
information.

It seems it does since number for nitc/nitc/nitc are

before: 0m7.324s
after: 0m7.156s (-2.3%)