### PR TITLE
Optimize variable access in the nitvm

### DIFF
--- a/src/interpreter/debugger.nit
+++ b/src/interpreter/debugger.nit
@@ -225,7 +225,7 @@ class Debugger
 	# Auto continues the execution until the end or until an error is encountered
 	var autocontinue = false
 
-	redef type FRAME: Frame
+	redef type FRAME: InterpreterFrame
 
 	#######################################################################
 	##                  Execution of statement function                  ##
@@ -1411,7 +1411,7 @@ redef class AMethPropdef
 	# Not supposed to be used by anyone else than the Debugger.
 	private fun rt_call(v: Debugger, mpropdef: MMethodDef, args: Array[Instance]): nullable Instance
 	do
-		var f = new Frame(self, self.mpropdef.as(not null), args)
+		var f = new InterpreterFrame(self, self.mpropdef.as(not null), args)
 		var curr_instances = v.frame.map
 		for i in curr_instances.keys do
 			f.map[i] = curr_instances[i]

--- a/src/interpreter/debugger.nit
+++ b/src/interpreter/debugger.nit
@@ -225,6 +225,8 @@ class Debugger
 	# Auto continues the execution until the end or until an error is encountered
 	var autocontinue = false
 
+	redef type FRAME: Frame
+
 	#######################################################################
 	##                  Execution of statement function                  ##
 	#######################################################################
@@ -867,7 +869,7 @@ class Debugger
 	# If the variable *variable_name* is an argument of the function being executed in the frame *frame*
 	# The function returns its position in the arguments
 	# Else, it returns -1
-	private fun get_position_of_variable_in_arguments(frame: Frame, variable_name: String): Int
+	private fun get_position_of_variable_in_arguments(frame: FRAME, variable_name: String): Int
 	do
 		var identifiers = get_identifiers_in_current_instruction(get_function_arguments(frame.mpropdef.location.text))
 		for i in [0 .. identifiers.length-1] do
@@ -1053,7 +1055,7 @@ class Debugger
 	#######################################################################
 
 	# Seeks a variable from the current frame called 'variable_path', can introspect complex objects using function get_variable_in_mutable_instance
-	private fun seek_variable(variable_path: String, frame: Frame): nullable Instance
+	private fun seek_variable(variable_path: String, frame: FRAME): nullable Instance
 	do
 		var full_variable = variable_path.split_with(".")
 
@@ -1073,7 +1075,7 @@ class Debugger
 	end
 
 	# Gets a variable 'variable_name' contained in the frame 'frame'
-	private fun get_variable_in_frame(variable_name: String, frame: Frame): nullable Instance
+	private fun get_variable_in_frame(variable_name: String, frame: FRAME): nullable Instance
 	do
 		if variable_name == "self" then
 			if frame.arguments.length >= 1 then return frame.arguments.first

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -115,7 +115,7 @@ class NaiveInterpreter
 
 	# Is a return executed?
 	# Set this mark to skip the evaluation until the end of the specified method frame
-	var returnmark: nullable Frame = null
+	var returnmark: nullable FRAME = null
 
 	# Is a break or a continue executed?
 	# Set this mark to skip the evaluation until a labeled statement catch it with `is_escape`
@@ -283,11 +283,14 @@ class NaiveInterpreter
 		return res
 	end
 
+	# The virtual type of the frames used in the execution engine
+	type FRAME: Frame
+
 	# The current frame used to store local variables of the current method executed
-	fun frame: Frame do return frames.first
+	fun frame: FRAME do return frames.first
 
 	# The stack of all frames. The first one is the current one.
-	var frames = new List[Frame]
+	var frames = new List[FRAME]
 
 	# Return a stack trace. One line per function
 	fun stack_trace: String

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -323,7 +323,7 @@ class NaiveInterpreter
 	# *`args` Arguments of the call
 	fun new_frame(node: ANode, mpropdef: MPropDef, args: Array[Instance]): FRAME
 	do
-		return new Frame(node, mpropdef, args)
+		return new InterpreterFrame(node, mpropdef, args)
 	end
 
 	# Exit the program with a message
@@ -352,14 +352,14 @@ class NaiveInterpreter
 	# Retrieve the value of the variable in the current frame
 	fun read_variable(v: Variable): Instance
 	do
-		var f = frames.first
+		var f = frames.first.as(InterpreterFrame)
 		return f.map[v]
 	end
 
 	# Assign the value of the variable in the current frame
 	fun write_variable(v: Variable, value: Instance)
 	do
-		var f = frames.first
+		var f = frames.first.as(InterpreterFrame)
 		f.map[v] = value
 	end
 
@@ -679,7 +679,7 @@ class PrimitiveInstance[E]
 end
 
 # Information about local variables in a running method
-class Frame
+abstract class Frame
 	# The current visited node
 	# The node is stored by frame to keep a stack trace
 	var current_node: ANode
@@ -688,9 +688,16 @@ class Frame
 	var mpropdef: MPropDef
 	# Arguments of the method (the first is the receiver)
 	var arguments: Array[Instance]
+	# Indicate if the expression has an array comprehension form
+	var comprehension: nullable Array[Instance] = null
+end
+
+# Implementation of a Frame with a Hashmap to store local variables
+class InterpreterFrame
+	super Frame
+
 	# Mapping between a variable and the current value
 	private var map: Map[Variable, Instance] = new HashMap[Variable, Instance]
-	var comprehension: nullable Array[Instance] = null
 end
 
 redef class ANode

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -22,6 +22,7 @@ import frontend
 import parser_util
 import vm
 import vm_optimizations
+import variables_numbering
 
 # Create a tool context to handle options and paths
 var toolcontext = new ToolContext

--- a/src/nitvm.nit
+++ b/src/nitvm.nit
@@ -19,6 +19,7 @@ module nitvm
 
 import vm
 import vm_optimizations
+import variables_numbering
 import frontend
 
 # Create a tool context to handle options and paths

--- a/src/variables_numbering.nit
+++ b/src/variables_numbering.nit
@@ -1,0 +1,223 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2015 Julien Pagès <julien.pages@lirmm.fr>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Handle all numbering operations related to local variables in the Nit virtual machine
+module variables_numbering
+
+import vm
+
+redef class VirtualMachine
+
+	# Number the variables in `n`.
+	# Do nothing if `n` is null
+	fun numbering(n: nullable AExpr, position: Int): Int
+	do
+		if n == null then return position
+
+		var pos = n.numbering(self, position)
+		return pos
+	end
+end
+
+redef class Variable
+	# The position in the environment
+	var position: Int
+end
+
+redef class AExpr
+	# Give a position to each variable declared in the node.
+	# NOTE: Do not call this method directly, but use `v.numbering`
+	# This method is here to be implemented by subclasses.
+	# *`v` The current instance of the virtual machine
+	# *`position` The first available position in the environment a variable can have
+	# Return the next available position a variable can have
+	public fun numbering(v: VirtualMachine, position: Int): Int
+	do
+		return position
+	end
+end
+
+redef class APropdef
+	# Indicate if the variables numbering has been done
+	private var is_numbering: Bool = false
+
+	# The size of the environment to create to call this method
+	private var environment_size: Int = 0
+end
+
+redef class AMethPropdef
+	# Assign a position in the environment to each local variable of `mpropdef`
+	# *`v` The current VirtualMachine
+	# *`mpropdef` The method to number
+	private fun numbering_variables(v: VirtualMachine, mpropdef: MMethodDef)
+	do
+		# The position in the environment
+		var position = 0
+
+		# The `self` variable has the first position
+		if self.selfvariable != null then
+			self.selfvariable.position = position
+			position += 1
+		end
+
+		# Number the parameters
+		for i in [0..mpropdef.msignature.arity[ do
+			var variable = self.n_signature.n_params[i].variable
+			variable.as(not null).position = position
+			position += 1
+		end
+
+		# Recursively go into the AST nodes to number all local variables
+		if n_block != null then
+			position = v.numbering(self.n_block, position)
+		end
+
+		is_numbering = true
+
+		# The size of the environment to create to execute a call to this method
+		environment_size = position
+	end
+end
+
+redef class AAttrPropdef
+	# Assign a position in the environment to each local variable of `mpropdef`
+	# *`v` The current VirtualMachine
+	private fun numbering_variables(v: VirtualMachine)
+	do
+		# The position in the environment
+		var position = 0
+
+		# The `self` variable has the first position
+		if self.selfvariable != null then
+			self.selfvariable.position = position
+			position += 1
+		end
+
+		# Recursively go into the AST nodes to number all local variables
+		if n_block != null then
+			position = v.numbering(self.n_block, position)
+		end
+
+		is_numbering = true
+
+		# The size of the environment to create to execute a call to this method
+		environment_size = position
+	end
+end
+
+redef class AVardeclExpr
+	redef fun numbering(v, position)
+	do
+		# Attribute a position to this variable
+		self.variable.as(not null).position = position
+		position += 1
+
+		# Recursively continue to numbering the variables
+		position = v.numbering(self.n_expr, position)
+
+		# `position` is the next available position in the environment
+		return position
+	end
+end
+
+redef class ABlockExpr
+	redef fun numbering(v, position)
+	do
+		for e in self.n_expr do
+			position = v.numbering(e, position)
+		end
+		return position
+	end
+end
+
+redef class AIfExpr
+	redef fun numbering(v, position)
+	do
+		# Attribute numbers separetely for the two branches
+		var pos = v.numbering(self.n_then, position)
+		var pos1 = v.numbering(self.n_else, position)
+
+		if pos > pos1 then
+			return pos
+		else
+			return pos1
+		end
+	end
+end
+
+redef class AIfexprExpr
+	redef fun numbering(v, position)
+	do
+		# Attribute numbers separetely for the two branches
+		var pos = v.numbering(self.n_then, position)
+		var pos1 = v.numbering(self.n_else, position)
+
+		if pos > pos1 then
+			return pos
+		else
+			return pos1
+		end
+	end
+end
+
+redef class ADoExpr
+	redef fun numbering(v, position)
+	do
+		return v.numbering(self.n_block, position)
+	end
+end
+
+redef class AWhileExpr
+	redef fun numbering(v, position)
+	do
+		return v.numbering(self.n_block, position)
+	end
+end
+
+redef class ALoopExpr
+	redef fun numbering(v, position)
+	do
+		return v.numbering(self.n_block, position)
+	end
+end
+
+redef class AForExpr
+	redef fun numbering(v, position)
+	do
+		# Give a position to each variable declared in the header of the for
+		if self.variables.length == 1 then
+			self.variables.first.position = position
+			self.variables[0].position = position
+			position += 1
+		else if self.variables.length == 2 then
+			self.variables[0].position = position
+			position += 1
+			self.variables[1].position = position
+			position += 1
+		end
+		return v.numbering(self.n_block, position)
+	end
+end
+
+redef class AArrayExpr
+	redef fun numbering(v, position)
+	do
+		for nexpr in self.n_exprs do
+			position = v.numbering(nexpr, position)
+		end
+		return position
+	end
+end


### PR DESCRIPTION
The first commit change the way variables are accessed in the vm.

For each method or attribute block (to init them), we recursively go into the AST to find each variable declaration in order to give them a fixed position (in the environment).
This is a small recursion since we only need to go deeper for block constructions.

During execution, the access are made by using this position instead of using the old ```HashMap[Variable, Instance]``` of the interpreter. 

The second commit completely replace the frames of the interpreter to avoid allocation of these hashmaps in the virtual machine, the commit is pretty verbose but this is mainly code from the interpreter.

The overall gain is good since the vm is now faster than the interpreter :)

For the small benchmark ```nitvm src/nit.nit tests/base_simple3.nit```, we have 2.9 seconds with nitvm before.
Now, nitvm take 2.67 seconds, 2.83 for niti: 8% better.
The overall gain on a few benchmarks I made are between 5% and little more than 10% but always positive.

Pro: faster
Con: work will be required to maintain the two engines...