### PR TITLE
Fix default call to `srand`

### DIFF
--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -999,6 +999,7 @@ end
 redef class Sys
 
 	init do
+		super
 		if stdout isa FileStream then stdout.as(FileStream).set_buffering_mode(256, buffer_mode_line)
 	end
 


### PR DESCRIPTION
Brings back the feature from #916.

The constructor of Sys behaves like a legacy construtor, so an explicit call to super is needed. It is not declared as such, so maybe it is hard coded somewhere?

@privat There may well be a cleaner fix for this, I'm open to suggestions.