### PR TITLE
Autosuperinit in refinements

### DIFF
--- a/src/parser/parser_nodes.nit
+++ b/src/parser/parser_nodes.nit
@@ -1598,7 +1598,7 @@ class ALabel
 	var n_kwlabel: TKwlabel is writable, noinit
 
 	# The name of the label, if any
-	var n_id: nullable TId is writable
+	var n_id: nullable TId is writable, noinit
 end
 
 # Expression and statements
@@ -2222,7 +2222,7 @@ class ASelfExpr
 	super AExpr
 
 	# The `self` keyword
-	var n_kwself: nullable TKwself is writable
+	var n_kwself: nullable TKwself = null is writable
 end
 
 # When there is no explicit receiver, `self` is implicit

--- a/src/semantize/auto_super_init.nit
+++ b/src/semantize/auto_super_init.nit
@@ -71,9 +71,6 @@ redef class AMethPropdef
 			return
 		end
 
-		# FIXME: THIS IS STUPID (be here to keep the old code working)
-		if not mpropdef.mclassdef.is_intro then return
-
 		# Do we inherit for a constructor?
 		var skip = true
 		for cd in mclassdef.in_hierarchy.direct_greaters do

--- a/src/semantize/auto_super_init.nit
+++ b/src/semantize/auto_super_init.nit
@@ -102,6 +102,7 @@ redef class AMethPropdef
 		if not mpropdef.is_intro then
 			auto_super_call = true
 			mpropdef.has_supercall = true
+			modelbuilder.toolcontext.info("Auto-super call for {mpropdef}", 4)
 			return
 		end
 
@@ -136,6 +137,7 @@ redef class AMethPropdef
 
 			var callsite = new CallSite(self, recvtype, mmodule, anchor, true, candidate, candidatedef, msignature, false)
 			auto_super_inits.add(callsite)
+			modelbuilder.toolcontext.info("Old-style auto-super init for {mpropdef} to {candidate.full_name}", 4)
 		end
 
 		# No old style? The look for new-style super constructors (called from a old style constructor)
@@ -170,6 +172,7 @@ redef class AMethPropdef
 
 			var callsite = new CallSite(self, recvtype, mmodule, anchor, true, the_root_init_mmethod, candidatedef, msignature, false)
 			auto_super_inits.add(callsite)
+			modelbuilder.toolcontext.info("Auto-super init for {mpropdef} to {the_root_init_mmethod.full_name}", 4)
 		end
 		if auto_super_inits.is_empty then
 			modelbuilder.error(self, "Error: No constructors to call implicitely in {mpropdef}. Call one explicitely.")

--- a/tests/base_init_raf2.nit
+++ b/tests/base_init_raf2.nit
@@ -1,0 +1,36 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base_init
+
+redef class A
+	init
+	do
+		'a'.output
+	end
+end
+
+redef class B
+	init
+	do
+		'b'.output
+	end
+end
+
+redef class C
+	init
+	do
+		'c'.output
+	end
+end

--- a/tests/sav/base_init_raf2.res
+++ b/tests/sav/base_init_raf2.res
@@ -1,0 +1,3 @@
+Aa
+AaBb
+Aac


### PR DESCRIPTION
Remove an old FIXME for compatibility with the old nitc that prevents the inclusion of autosuperinit calls in refinements.

Close #1186 (thus bring back the the feature from #916)