### PR TITLE
More lazyness in standard

### DIFF
--- a/lib/standard/collection/abstract_collection.nit
+++ b/lib/standard/collection/abstract_collection.nit
@@ -416,7 +416,14 @@ interface MapRead[K, V]
 		return default
 	end
 
-	# Alias for `keys.has`
+	# Is there an item associated with `key`?
+	#
+	#     var x = new HashMap[String, Int]
+	#     x["four"] = 4
+	#     assert x.has_key("four") == true
+	#     assert x.has_key("five") == false
+	#
+	# By default it is a synonymous to `keys.has` but could be redefined with a direct implementation.
 	fun has_key(key: K): Bool do return self.keys.has(key)
 
 	# Get a new iterator on the map.
@@ -987,6 +994,8 @@ interface CoupleMap[K, V]
 			return c.second
 		end
 	end
+
+	redef fun has_key(key) do return couple_at(key) != null
 end
 
 # Iterator on CoupleMap

--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -618,8 +618,8 @@ class ArrayMap[K, E]
 		end
 	end
 
-	redef var keys: RemovableCollection[K] = new ArrayMapKeys[K, E](self)
-	redef var values: RemovableCollection[E] = new ArrayMapValues[K, E](self)
+	redef var keys: RemovableCollection[K] = new ArrayMapKeys[K, E](self) is lazy
+	redef var values: RemovableCollection[E] = new ArrayMapValues[K, E](self) is lazy
 
 	# O(1)
 	redef fun length do return _items.length

--- a/lib/standard/collection/hash_collection.nit
+++ b/lib/standard/collection/hash_collection.nit
@@ -272,8 +272,8 @@ class HashMap[K, V]
 		enlarge(0)
 	end
 
-	redef var keys: RemovableCollection[K] = new HashMapKeys[K, V](self)
-	redef var values: RemovableCollection[V] = new HashMapValues[K, V](self)
+	redef var keys: RemovableCollection[K] = new HashMapKeys[K, V](self) is lazy
+	redef var values: RemovableCollection[V] = new HashMapValues[K, V](self) is lazy
 	redef fun has_key(k) do return node_at(k) != null
 end
 

--- a/lib/standard/collection/hash_collection.nit
+++ b/lib/standard/collection/hash_collection.nit
@@ -274,6 +274,7 @@ class HashMap[K, V]
 
 	redef var keys: RemovableCollection[K] = new HashMapKeys[K, V](self)
 	redef var values: RemovableCollection[V] = new HashMapValues[K, V](self)
+	redef fun has_key(k) do return node_at(k) != null
 end
 
 # View of the keys of a HashMap

--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -254,6 +254,7 @@ class Stdout
 		_file = new NativeFile.native_stdout
 		path = "/dev/stdout"
 		_is_writable = true
+		set_buffering_mode(256, sys.buffer_mode_line)
 	end
 end
 
@@ -997,10 +998,6 @@ private extern class NativeFile `{ FILE* `}
 end
 
 redef class Sys
-
-	init do
-		if stdout isa FileStream then stdout.as(FileStream).set_buffering_mode(256, buffer_mode_line)
-	end
 
 	# Standard input
 	var stdin: PollableReader = new Stdin is protected writable

--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -1000,13 +1000,13 @@ end
 redef class Sys
 
 	# Standard input
-	var stdin: PollableReader = new Stdin is protected writable
+	var stdin: PollableReader = new Stdin is protected writable, lazy
 
 	# Standard output
-	var stdout: Writer = new Stdout is protected writable
+	var stdout: Writer = new Stdout is protected writable, lazy
 
 	# Standard output for errors
-	var stderr: Writer = new Stderr is protected writable
+	var stderr: Writer = new Stderr is protected writable, lazy
 
 	# Enumeration for buffer mode full (flushes when buffer is full)
 	fun buffer_mode_full: Int is extern "file_Sys_Sys_buffer_mode_full_0"

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -1052,7 +1052,7 @@ class FlatString
 	# Indes in _items of the last item of the string
 	private var index_to: Int is noinit
 
-	redef var chars: SequenceRead[Char] = new FlatStringCharView(self)
+	redef var chars: SequenceRead[Char] = new FlatStringCharView(self) is lazy
 
 	redef fun [](index)
 	do
@@ -1522,7 +1522,7 @@ class FlatBuffer
 	super FlatText
 	super Buffer
 
-	redef var chars: Sequence[Char] = new FlatBufferCharView(self)
+	redef var chars: Sequence[Char] = new FlatBufferCharView(self) is lazy
 
 	private var capacity: Int = 0
 


### PR DESCRIPTION
Make lazy some attributes of often used classes. So that the attribute creation cost only when they are really used.

More impact that initially imagined:

for nitc/nitc/nitc
before: 7.188
after: 7.008 (-2.5%)