### PR TITLE
Reuse Array Iterators

### DIFF
--- a/tests/sav/test_new_native_alt1.res
+++ b/tests/sav/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/standard/collection/array.nit:894)
+Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/standard/collection/array.nit:909)
 NativeString
 N
 Nit


### PR DESCRIPTION
on nitc/nitc/nit this reduce a lot the number of allocated iterators.

before:

* 0m7.168s
* 2,706,498 new ArrayIterator
* the second most allocated class (after NativeArray)

after:

* 0m7.060s (-1.5%)
* 785,781 new ArrayIterator (-70%)
* the 7th most allocated class