### PR TITLE
Vim autocomplete search in doc and 2 new useful Vim functions

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -37,6 +37,7 @@ Ensure that `~/.vimrc` contains
  * Automatic indentation
  * Syntax checker (require [Syntastic][2]).
  * Autocomplete for whole projects using module importations
+ * Show documentation in preview window
 
   [2]: https://github.com/scrooloose/syntastic
 
@@ -93,3 +94,14 @@ will use general metadata in the plugin directory.
 
 The metadata files from nitpick are stored in `~/.vim/nit/`. This location can be customized with
 the environment variable `NIT_VIM_DIR`.
+
+## Documentation in preview window
+
+You can display the documentation for the entity under the cursor with `:call Nitdoc()`.
+It will use the same metadata files as the omnifunc and the preview window.
+You may want to map the function to a shortcut by adding the following code to `~/.vimrc`.
+
+~~~
+" Map displaying Nitdoc to Ctrl-D
+map <C-d> :call Nitdoc()<enter>
+~~~

--- a/misc/README.md
+++ b/misc/README.md
@@ -38,6 +38,7 @@ Ensure that `~/.vimrc` contains
  * Syntax checker (require [Syntastic][2]).
  * Autocomplete for whole projects using module importations
  * Show documentation in preview window
+ * Search declarations and usages of the word under the cursor
 
   [2]: https://github.com/scrooloose/syntastic
 
@@ -104,4 +105,15 @@ You may want to map the function to a shortcut by adding the following code to `
 ~~~
 " Map displaying Nitdoc to Ctrl-D
 map <C-d> :call Nitdoc()<enter>
+~~~
+
+## Search declarations and usages of the word under the cursor
+
+The function `NitGitGrep` calls `git grep` to find declarations and usages of the word under the cursor.
+It displays the results in the preview window.
+You may want to map the function to a shortcut by adding the following code to `~/.vimrc`.
+
+~~~
+" Map the NitGitGrep function to Ctrl-G
+map <C-g> :call NitGitGrep()<enter>
 ~~~

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -131,10 +131,10 @@ fun NitOmnifuncAddFromFile(base, matches, path)
 		if name == a:base
 			" Exact match
 			call NitOmnifuncAddAMatch(a:matches, words, name)
-		elseif name =~ '^'.a:base
+		elseif name =~? '^'.a:base
 			" Common-prefix match
 			call NitOmnifuncAddAMatch(prefix_matches, words, name)
-		elseif name =~ a:base
+		elseif name =~? a:base
 			" Substring match
 			call NitOmnifuncAddAMatch(substring_matches, words, name)
 		endif

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -310,6 +310,32 @@ fun Nitdoc()
 	redraw!
 endfun
 
+" Call `git grep` on the word under the cursor
+"
+" Shows declarations first, then all matches, in the preview window.
+fun NitGitGrep()
+	let word = expand("<cword>")
+	let out = tempname()
+	execute 'silent !(git grep "\\(module\\|class\\|universal\\|interface\\|var\\|fun\\) '.word.'";'.
+		\'echo; git grep '.word.') > '.out
+
+	" Open the preview window on a temp file
+	execute "silent pedit " . out
+
+	" Change to preview window
+	wincmd P
+
+	" Set options
+	setlocal buftype=nofile
+	setlocal noswapfile
+	setlocal syntax=none
+	setlocal bufhidden=delete
+
+	" Change back to the source buffer
+	wincmd p
+	redraw!
+endfun
+
 " Activate the omnifunc on Nit files
 autocmd FileType nit set omnifunc=NitOmnifunc
 

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -110,13 +110,17 @@ endfun
 " Internal function to search for lines in `path` corresponding to the partial
 " word `base`. Adds found and formated match to `matches`.
 "
-" Will order the results in 3 levels:
+" Will order the results in 5 levels:
 " 1. Exact matches
 " 2. Common prefix matches
 " 3. Substring matches
+" 4. Synopsis matches
+" 5. Doc matches
 fun NitOmnifuncAddFromFile(base, matches, path)
 	let prefix_matches = []
 	let substring_matches = []
+	let synopsis_matches = []
+	let doc_matches = []
 
 	let path = NitMetadataFile(a:path)
 	if empty(path)
@@ -137,12 +141,20 @@ fun NitOmnifuncAddFromFile(base, matches, path)
 		elseif name =~? a:base
 			" Substring match
 			call NitOmnifuncAddAMatch(substring_matches, words, name)
+		elseif get(words, 2, '') =~? a:base
+			" Match in the synopsis
+			call NitOmnifuncAddAMatch(synopsis_matches, words, name)
+		elseif get(words, 3, '') =~? a:base
+			" Match in the longer doc
+			call NitOmnifuncAddAMatch(synopsis_matches, words, name)
 		endif
 	endfor
 
 	" Assemble the final match list
 	call extend(a:matches, sort(prefix_matches))
 	call extend(a:matches, sort(substring_matches))
+	call extend(a:matches, sort(synopsis_matches))
+	call extend(a:matches, sort(doc_matches))
 endfun
 
 " Internal function to search parse the information from a metadata line

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -71,10 +71,10 @@ redef class MEntity
 
 		# 4. Full doc with extra
 		stream.write field_separator
+		stream.write "# "
+		stream.write full_name
+		write_signature_to_stream(stream)
 		if mdoc != null then
-			stream.write "# "
-			stream.write full_name
-			write_signature_to_stream(stream)
 			for i in 2.times do stream.write line_separator
 			stream.write mdoc.content.join(line_separator)
 		end


### PR DESCRIPTION
* The omnifunc for Nit search for autocomplete suggestions in the doc. So if you write `12.modulo`, then hit `Ctrl-X Ctrl-O` (launching the omnifunc), it will suggest `%` to replace the `modulo` part. This is useful when guessing the name of the wanted entity.

* The Nitdoc function can be mapped to `Ctrl-D` to show the doc associated to the word under the cursor. There is still no semantic analysis here, so it will list all possible docs.

* The NitGitGrep function can be mapped to `Ctrl-G` to find instances of the word under the cursor in the currect directory using `git grep`. It will first try to display any definitions and then its uses. This one is a bit trickier to use, but it can be very useful.

----
Bonus hint! You can select the size of the preview window to 5 lines with `set previewheight=5` (@Morriar)