### PR TITLE
Better Vim documentation on classes (with special attention to the doc of Container)

### DIFF
--- a/lib/standard/collection/abstract_collection.nit
+++ b/lib/standard/collection/abstract_collection.nit
@@ -203,7 +203,7 @@ end
 #
 # Used to pass arguments by reference.
 #
-# Also used when one want to give asingle element when a full
+# Also used when one want to give a single element when a full
 # collection is expected
 class Container[E]
 	super Collection[E]

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -283,7 +283,7 @@ fun Nitdoc()
 		for line in readfile(path)
 			let words = split(line, '#====#', 1)
 			let name = get(words, 0, '')
-			if name =~ '^' . word
+			if name =~ '^' . word . '\>'
 				" It fits our word, get long doc
 				let desc = get(words,3,'')
 				let desc = join(split(desc, '#nnnn#', 1), "\n")

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -52,7 +52,7 @@ redef class MEntity
 	private fun field_separator: String do return "#====#"
 	private fun line_separator: String do return "#nnnn#"
 
-	private fun write_to_stream(stream: Writer)
+	private fun write_doc(mainmodule: MModule, stream: Writer)
 	do
 		# 1. Short name for autocompletion
 		stream.write complete_name
@@ -168,7 +168,7 @@ private class AutocompletePhase
 		# Got all known modules
 		var model = mainmodule.model
 		for mmodule in model.mmodules do
-			mmodule.write_to_stream modules_stream
+			mmodule.write_doc(mainmodule, modules_stream)
 		end
 
 		# TODO list other modules from the Nit lib
@@ -184,15 +184,15 @@ private class AutocompletePhase
 				for prop in mclass.all_mproperties(mainmodule, public_visibility) do
 					if prop isa MMethod and prop.is_init then
 						mclass_intro.target_constructor = prop.intro
-						mclass_intro.write_to_stream constructors_stream
+						mclass_intro.write_doc(mainmodule, constructors_stream)
 					end
 				end
 				mclass_intro.target_constructor = null
 			end
 
 			# Always add to types and classes
-			mclass.mclass_type.write_to_stream classes_stream
-			mclass.mclass_type.write_to_stream types_stream
+			mclass.mclass_type.write_doc(mainmodule, classes_stream)
+			mclass.mclass_type.write_doc(mainmodule, types_stream)
 		end
 
 		# Get all known properties
@@ -202,7 +202,7 @@ private class AutocompletePhase
 
 			# Is it a virtual type?
 			if mproperty isa MVirtualTypeProp then
-				mproperty.intro.write_to_stream types_stream
+				mproperty.intro.write_doc(mainmodule, types_stream)
 				continue
 			end
 
@@ -210,7 +210,7 @@ private class AutocompletePhase
 			var first_letter = mproperty.name.chars.first
 			if first_letter == '@' or first_letter == '_' then continue
 
-			mproperty.intro.write_to_stream properties_stream
+			mproperty.intro.write_doc(mainmodule, properties_stream)
 		end
 
 		# Close streams

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -226,6 +226,8 @@ redef class MClassType
 			end
 		end
 	end
+
+	redef fun complete_mdoc do return mclass.intro.mdoc
 end
 
 private class AutocompletePhase

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -78,6 +78,7 @@ redef class MEntity
 			for i in 2.times do stream.write line_separator
 			stream.write mdoc.content.join(line_separator)
 		end
+		write_extra_doc(mainmodule, stream)
 
 		stream.write "\n"
 	end
@@ -89,6 +90,9 @@ redef class MEntity
 
 	# Doc to use in completion
 	private fun complete_mdoc: nullable MDoc do return mdoc
+
+	# Extra auto documentation to append to the `stream`
+	private fun write_extra_doc(mainmodule: MModule, stream: Writer) do end
 end
 
 redef class MMethodDef
@@ -145,6 +149,82 @@ redef class MClassDef
 		end
 
 		return mdoc
+	end
+end
+
+redef class MClassType
+	redef fun write_extra_doc(mainmodule, stream)
+	do
+		# Super classes
+		stream.write line_separator*2
+		stream.write "## Class hierarchy"
+
+		var direct_supers = [for s in mclass.in_hierarchy(mainmodule).direct_greaters do s.name]
+		if not direct_supers.is_empty then
+			alpha_comparator.sort direct_supers
+			stream.write line_separator
+			stream.write "* Direct super classes: "
+			stream.write direct_supers.join(", ")
+		end
+
+		var supers = [for s in mclass.in_hierarchy(mainmodule).greaters do s.name]
+		supers.remove mclass.name
+		if not supers.is_empty then
+			alpha_comparator.sort supers
+			stream.write line_separator
+			stream.write "* All super classes: "
+			stream.write supers.join(", ")
+		end
+
+		var direct_subs = [for s in mclass.in_hierarchy(mainmodule).direct_smallers do s.name]
+		if not direct_subs.is_empty then
+			alpha_comparator.sort direct_subs
+			stream.write line_separator
+			stream.write "* Direct sub classes: "
+			stream.write direct_subs.join(", ")
+		end
+
+		var subs = [for s in mclass.in_hierarchy(mainmodule).smallers do s.name]
+		subs.remove mclass.name
+		if not subs.is_empty then
+			alpha_comparator.sort subs
+			stream.write line_separator
+			stream.write "* All sub classes: "
+			stream.write subs.join(", ")
+		end
+
+		# List other properties
+		stream.write line_separator*2
+		stream.write "## Properties"
+		stream.write line_separator
+		var props = mclass.all_mproperties(mainmodule, protected_visibility).to_a
+		alpha_comparator.sort props
+		for prop in props do
+			if mclass.name == "Object" or prop.intro.mclassdef.mclass.name != "Object" then
+
+				if prop.visibility == public_visibility then
+					stream.write "+ "
+				else stream.write "~ " # protected_visibility
+
+				if prop isa MMethod then
+					if prop.is_init and prop.name != "init" then stream.write "init "
+					if prop.is_new and prop.name != "new" then stream.write "new "
+				end
+
+				stream.write prop.name
+
+				if prop isa MMethod then
+					stream.write prop.intro.msignature.to_s
+				end
+
+				var mdoc = prop.intro.mdoc
+				if mdoc != null then
+					stream.write "  # "
+					stream.write mdoc.content.first
+				end
+				stream.write line_separator
+			end
+		end
 	end
 end
 

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1191,7 +1191,7 @@ class MGenericType
 		for t in arguments do
 			args.add t.full_name
 		end
-		return "{mclass.full_name}[{args.join(", ")}]}"
+		return "{mclass.full_name}[{args.join(", ")}]"
 	end
 
 	redef var c_name is lazy do


### PR DESCRIPTION
Calling Nitdoc() or Ctrl-D on the word `Container` will now display the following in the preview window.

~~~
# standard::Container[standard::Container::E]

A collection that contains only one item.

Used to pass arguments by reference.

Also used when one want to give a single element when a full
collection is expected

## Class hierarchy
* Direct super classes: Collection
* All super classes: Collection, Object
* Direct sub classes: ListNode
* All sub classes: ListNode

## Properties
+ count(item: E): Int  # How many occurrences of `item` are in the collection?
+ first: E  # Return the first item of the collection
+ has(item: E): Bool  # Is `item` in the collection ?
+ has_all(other: Collection[E]): Bool  # Does the collection contain at least each element of `other`?
+ has_exactly(other: Collection[E]): Bool  # Does the collection contain exactly all the elements of `other`?
+ has_only(item: E): Bool  # Is the collection contain only `item`?
+ is_empty: Bool  # Is there no item in the collection?
+ item: E  # The stored item
+ item=(item: E)  # The stored item
+ iterator: Iterator[E]  # Get a new iterator on the collection.
+ join(sep: Text): String  # Concatenate and separate each elements with `sep`.
+ length: Int  # Number of items in the collection.
+ rand: E  # Return a random element form the collection
+ to_a: Array[E]  # Build a new array from a collection
~~~