### PR TITLE
Nitunit works with groups and markdown files

### DIFF
--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -12,13 +12,15 @@ nitunit [*options*] FILE...
 
 Unit testing in Nit can be achieved in two ways:
 
-* using `DocUnits` in code comments
+* using `DocUnits` in code comments or in markdown files
 * using `TestSuites` with test unit files
 
-`DocUnits` are executable pieces of code found in the documentation of modules,
+`DocUnits` are executable pieces of code found in the documentation of groups, modules,
 classes and properties.
 They are used for documentation purpose, they should be kept simple and illustrative.
 More advanced unit testing can be done using TestSuites.
+
+`DocUnits` can also be used in any markdown files.
 
 `TestSuites` are test files coupled to a tested module.
 They contain a list of test methods called TestCase.
@@ -105,6 +107,14 @@ Such `nitish` piece of code can be used to enclose examples that cannot compile 
 The `nitunit` command is used to test Nit files:
 
     $ nitunit foo.nit
+
+Groups (directories) can be given to test the documentation of the group and of all its Nit files:
+
+    $ nitunit lib/foo
+
+Finally, standard markdown documents can be checked with:
+
+    $ nitunit foo.md
 
 ## Working with `TestSuites`
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -385,7 +385,7 @@ redef class ModelBuilder
 		var readme = dirpath2.join_path("README.md")
 		if not readme.file_exists then readme = dirpath2.join_path("README")
 		if readme.file_exists then
-			var mdoc = new MDoc
+			var mdoc = new MDoc(new Location(new SourceFile.from_string(readme, ""),0,0,0,0))
 			var s = new FileReader.open(readme)
 			while not s.eof do
 				mdoc.content.add(s.read_line)

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -455,6 +455,26 @@ redef class ModelBuilder
 		return nmodule
 	end
 
+	# Remove Nit source files from a list of arguments.
+	#
+	# Items of `args` that can be loaded as a nit file will be removed from `args` and returned.
+	fun filter_nit_source(args: Array[String]): Array[String]
+	do
+		var keep = new Array[String]
+		var res = new Array[String]
+		for a in args do
+			var l = identify_file(a)
+			if l == null then
+				keep.add a
+			else
+				res.add a
+			end
+		end
+		args.clear
+		args.add_all(keep)
+		return res
+	end
+
 	# Try to load a module using a path.
 	# Display an error if there is a problem (IO / lexer / parser) and return null.
 	# Note: usually, you do not need this method, use `get_mmodule_by_name` instead.

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -385,17 +385,24 @@ redef class ModelBuilder
 		var readme = dirpath2.join_path("README.md")
 		if not readme.file_exists then readme = dirpath2.join_path("README")
 		if readme.file_exists then
-			var mdoc = new MDoc(new Location(new SourceFile.from_string(readme, ""),0,0,0,0))
-			var s = new FileReader.open(readme)
-			while not s.eof do
-				mdoc.content.add(s.read_line)
-			end
+			var mdoc = load_markdown(readme)
 			mgroup.mdoc = mdoc
 			mdoc.original_mentity = mgroup
 		end
 		mgroup.filepath = dirpath
 		mgroups[rdp] = mgroup
 		return mgroup
+	end
+
+	# Load a markdown file as a documentation object
+	fun load_markdown(filepath: String): MDoc
+	do
+		var mdoc = new MDoc(new Location(new SourceFile.from_string(filepath, ""),0,0,0,0))
+		var s = new FileReader.open(filepath)
+		while not s.eof do
+			mdoc.content.add(s.read_line)
+		end
+		return mdoc
 	end
 
 	# Force the identification of all ModulePath of the group and sub-groups.

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -466,7 +466,11 @@ redef class ModelBuilder
 		# Look for the module
 		var file = identify_file(filename)
 		if file == null then
-			toolcontext.error(null, "Error: cannot find module `{filename}`.")
+			if filename.file_exists then
+				toolcontext.error(null, "Error: `{filename}` is not a Nit source file.")
+			else
+				toolcontext.error(null, "Error: cannot find module `{filename}`.")
+			end
 			return null
 		end
 

--- a/src/location.nit
+++ b/src/location.nit
@@ -55,6 +55,8 @@ class Location
 	var file: nullable SourceFile
 
 	# The starting line number (starting from 1)
+	#
+	# If `line_start==0` then the whole file is considered
 	var line_start: Int
 
 	# The stopping line number (starting from 1)
@@ -129,8 +131,11 @@ class Location
 		var file_part = ""
 		if file != null then
 			file_part = file.filename
-			if file.filename.length > 0 then file_part += ":"
 		end
+
+		if line_start <= 0 then return file_part
+
+		if file != null and file.filename.length > 0 then file_part += ":"
 
 		if line_start == line_end then
 			if column_start == column_end then
@@ -181,6 +186,8 @@ class Location
 
 		var l = self
 		var i = l.line_start
+		if i <= 0 then return ""
+
 		var line_start = l.file.line_starts[i-1]
 		var line_end = line_start
 		var string = l.file.string

--- a/src/model/mdoc.nit
+++ b/src/model/mdoc.nit
@@ -16,6 +16,7 @@
 module mdoc
 
 import model_base
+import location
 
 # Structured documentation of a `MEntity` object
 class MDoc
@@ -27,6 +28,9 @@ class MDoc
 	# The entity where the documentation is originally attached to.
 	# This gives some context to resolve identifiers or to run examples.
 	var original_mentity: nullable MEntity = null is writable
+
+	# The original location of the doc for error messages
+	var location: Location
 end
 
 redef class MEntity

--- a/src/modelbuilder_base.nit
+++ b/src/modelbuilder_base.nit
@@ -375,7 +375,7 @@ redef class ADoc
 	do
 		var res = mdoc_cache
 		if res != null then return res
-		res = new MDoc
+		res = new MDoc(location)
 		for c in n_comment do
 			var text = c.text
 			if text.length < 2 then

--- a/src/neo.nit
+++ b/src/neo.nit
@@ -365,7 +365,10 @@ class NeoModel
 		node.labels.add "MEntity"
 		node.labels.add model_name
 		node["name"] = mentity.name
-		if mentity.mdoc != null then node["mdoc"] = new JsonArray.from(mentity.mdoc.content)
+		if mentity.mdoc != null then
+			node["mdoc"] = new JsonArray.from(mentity.mdoc.content)
+			node["mdoc_location"] = mentity.mdoc.location.to_s
+		end
 		return node
 	end
 
@@ -867,6 +870,9 @@ class NeoModel
 		#TODO filepath
 		var parts = loc.split_with(":")
 		var file = new SourceFile.from_string(parts[0], "")
+		if parts.length == 1 then
+			return new Location(file, 0, 0, 0, 0)
+		end
 		var pos = parts[1].split_with("--")
 		var pos1 = pos[0].split_with(",")
 		var pos2 = pos[1].split_with(",")
@@ -919,7 +925,8 @@ class NeoModel
 			for e in node["mdoc"].as(JsonArray) do
 				lines.add e.to_s#.replace("\n", "\\n")
 			end
-			var mdoc = new MDoc
+			var location = to_location(node["mdoc_location"].to_s)
+			var mdoc = new MDoc(location)
 			mdoc.content.add_all(lines)
 			mdoc.original_mentity = mentity
 			mentity.mdoc = mdoc

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -53,7 +53,9 @@ end
 var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
-var mmodules = modelbuilder.parse_full(args)
+var module_files = modelbuilder.filter_nit_source(args)
+
+var mmodules = modelbuilder.parse_full(module_files)
 modelbuilder.run_phases
 
 if toolcontext.opt_gen_unit.value then
@@ -66,6 +68,15 @@ var page = new HTMLTag("testsuites")
 if toolcontext.opt_full.value then mmodules = model.mmodules
 
 for a in args do
+	if not a.file_exists then
+		toolcontext.fatal_error(null, "Error: cannot load file or module `{a}`.")
+	end
+	# Try to load the file as a markdown document
+	var mdoc = modelbuilder.load_markdown(a)
+	page.add modelbuilder.test_mdoc(mdoc)
+end
+
+for a in module_files do
 	var g = modelbuilder.get_mgroup(a)
 	if g == null then continue
 	page.add modelbuilder.test_group(g)

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -65,6 +65,12 @@ var page = new HTMLTag("testsuites")
 
 if toolcontext.opt_full.value then mmodules = model.mmodules
 
+for a in args do
+	var g = modelbuilder.get_mgroup(a)
+	if g == null then continue
+	page.add modelbuilder.test_group(g)
+end
+
 for m in mmodules do
 	page.add modelbuilder.test_markdown(m)
 	page.add modelbuilder.test_unit(m)

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -438,4 +438,33 @@ redef class ModelBuilder
 
 		return ts
 	end
+
+	# Test a document object unrelated to a Nit entity
+	fun test_mdoc(mdoc: MDoc): HTMLTag
+	do
+		var ts = new HTMLTag("testsuite")
+		var file = mdoc.location.to_s
+
+		toolcontext.info("nitunit: doc-unit file {file}", 2)
+
+		ts.attr("package", file)
+
+		var prefix = toolcontext.test_dir / "file"
+		var d2m = new NitUnitExecutor(toolcontext, prefix, null, ts)
+
+		var tc
+
+		total_entities += 1
+		doc_entities += 1
+
+		tc = new HTMLTag("testcase")
+		# NOTE: jenkins expects a '.' in the classname attr
+		tc.attr("classname", "nitunit.<file>")
+		tc.attr("name", file)
+
+		d2m.extract(mdoc, tc)
+		d2m.run_tests
+
+		return ts
+	end
 end

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -404,4 +404,38 @@ redef class ModelBuilder
 
 		return ts
 	end
+
+	# Extracts and executes all the docunits in the readme of the `mgroup`
+	# Returns a JUnit-compatible `<testsuite>` XML element that contains the results of the executions.
+	fun test_group(mgroup: MGroup): HTMLTag
+	do
+		var ts = new HTMLTag("testsuite")
+		toolcontext.info("nitunit: doc-unit group {mgroup}", 2)
+
+		# usually, only the default module must be imported in the unit test.
+		var o = mgroup.default_mmodule
+
+		ts.attr("package", mgroup.full_name)
+
+		var prefix = toolcontext.test_dir
+		prefix = prefix.join_path(mgroup.to_s)
+		var d2m = new NitUnitExecutor(toolcontext, prefix, o, ts)
+
+		var tc
+
+		total_entities += 1
+		var mdoc = mgroup.mdoc
+		if mdoc == null then return ts
+
+		doc_entities += 1
+		tc = new HTMLTag("testcase")
+		# NOTE: jenkins expects a '.' in the classname attr
+		tc.attr("classname", "nitunit." + mgroup.full_name)
+		tc.attr("name", "<group>")
+		d2m.extract(mdoc, tc)
+
+		d2m.run_tests
+
+		return ts
+	end
 end

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -25,8 +25,8 @@ class NitUnitExecutor
 	# The prefix of the generated Nit source-file
 	var prefix: String
 
-	# The module to import
-	var mmodule: MModule
+	# The module to import, if any
+	var mmodule: nullable MModule
 
 	# The XML node associated to the module
 	var testsuite: HTMLTag
@@ -278,7 +278,9 @@ class NitUnitExecutor
 		f = new FileWriter.open(file)
 		f.write("# GENERATED FILE\n")
 		f.write("# Docunits extracted from comments\n")
-		f.write("import {mmodule.name}\n")
+		if mmodule != null then
+			f.write("import {mmodule.name}\n")
+		end
 		f.write("\n")
 		return f
 	end
@@ -294,7 +296,11 @@ class NitUnitExecutor
 			toolcontext.error(null, "Cannot find nitg. Set envvar NIT_DIR.")
 			toolcontext.check_errors
 		end
-		var cmd = "{nitg} --ignore-visibility --no-color '{file}' -I {mmodule.location.file.filename.dirname} >'{file}.out1' 2>&1 </dev/null -o '{file}.bin'"
+		var opts = new Array[String]
+		if mmodule != null then
+			opts.add "-I {mmodule.location.file.filename.dirname}"
+		end
+		var cmd = "{nitg} --ignore-visibility --no-color '{file}' {opts.join(" ")} >'{file}.out1' 2>&1 </dev/null -o '{file}.bin'"
 		var res = sys.system(cmd)
 		return res
 	end
@@ -302,8 +308,8 @@ end
 
 # A unit-test to run
 class DocUnit
-	# The original comment node
-	var ndoc: ADoc
+	# The doc that contains self
+	var mdoc: MDoc
 
 	# The XML node that contains the information about the execution
 	var testcase: HTMLTag

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -4,3 +4,4 @@ test_nitunit.nit --gen-suite --only-show --private
 test_nitunit2.nit -o $WRITE
 test_doc2.nit --no-color -o $WRITE
 test_nitunit3 --no-color -o $WRITE
+test_nitunit_md.md --no-color -o $WRITE

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -3,3 +3,4 @@ test_nitunit.nit --gen-suite --only-show
 test_nitunit.nit --gen-suite --only-show --private
 test_nitunit2.nit -o $WRITE
 test_doc2.nit --no-color -o $WRITE
+test_nitunit3 --no-color -o $WRITE

--- a/tests/sav/nitunit_args6.res
+++ b/tests/sav/nitunit_args6.res
@@ -1,0 +1,14 @@
+test_nitunit3/README.md: Error: There is a block of code that is not valid Nit, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,1: Syntax error: unknown token ;..
+test_nitunit3/README.md: ERROR: nitunit.test_nitunit3.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
+
+DocUnits:
+Entities: 2; Documented ones: 2; With nitunits: 2; Failures: 2
+
+TestSuites:
+No test cases found
+Class suites: 0; Test Cases: 0; Failures: 0
+<testsuites><testsuite package="test_nitunit3"><testcase classname="nitunit.test_nitunit3" name="&lt;group&gt;"><failure message="test_nitunit3&#47;README.md: Invalid block of code. At 1,1: Syntax error: unknown token ;.."></failure><system-err></system-err><system-out>assert false
+assert true
+</system-out><error message="Runtime error: Assert failed (.nitunit&#47;test_nitunit3-0.nit:7)
+"></error></testcase></testsuite><testsuite package="test_nitunit3"><testcase classname="nitunit.test_nitunit3.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true
+</system-out></testcase></testsuite><testsuite></testsuite></testsuites>

--- a/tests/sav/nitunit_args7.res
+++ b/tests/sav/nitunit_args7.res
@@ -1,0 +1,13 @@
+test_nitunit_md.md: ERROR: nitunit.<file>.test_nitunit_md.md (in .nitunit/file-0.nit): Runtime error: Assert failed (.nitunit/file-0.nit:8)
+
+DocUnits:
+Entities: 1; Documented ones: 1; With nitunits: 1; Failures: 1
+
+TestSuites:
+No test cases found
+Class suites: 0; Test Cases: 0; Failures: 0
+<testsuites><testsuite package="test_nitunit_md.md"><testcase classname="nitunit.&lt;file&gt;" name="test_nitunit_md.md"><system-err></system-err><system-out>var a = 1
+assert 1 == 1
+assert false
+</system-out><error message="Runtime error: Assert failed (.nitunit&#47;file-0.nit:8)
+"></error></testcase></testsuite></testsuites>

--- a/tests/test_nitunit3/README.md
+++ b/tests/test_nitunit3/README.md
@@ -1,0 +1,13 @@
+Bla bla
+
+~~~
+assert false
+~~~
+
+~~~
+;'\][]
+~~~
+
+~~~
+assert true
+~~~

--- a/tests/test_nitunit3/test_nitunit3.nit
+++ b/tests/test_nitunit3/test_nitunit3.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test
+#
+#     assert true
+module test_nitunit3

--- a/tests/test_nitunit_md.md
+++ b/tests/test_nitunit_md.md
@@ -1,0 +1,15 @@
+# Test
+
+~~~
+var a = 1
+~~~
+
+~~~raw
+ignored
+~~~
+
+~~~
+assert 1 == 1
+~~~
+
+    assert false


### PR DESCRIPTION
A lot of work but quite straightforward. Nit can be a really nice language when doing maintenance of old code.

The first part ot the PR updates the nitdoc to test documentation of groups (as requested by #1201)
The second part of the PR (I planned to do 2 PR but the second was more easy to do than expected) makes that nitunit can also process sand-alone markdown files (documentation, wiki pages, etc.).

Example:

~~~
-- foo/
   |-- README.md
   `-- foo.nit
~~~

~~~sh
# to test all entities of a module (classes, methods, etc.)
$ nitunit foo/foo.nit
# to test all entities of a group (the group and all its modules)
$ nitunit foo
# to test a given markdown file
$ nitunit foo/README.md
~~~

Close: #1201