### PR TITLE
Enable tagging of primitive types

### DIFF
--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -207,7 +207,7 @@ function bench_nitc-s_options()
 
 	plot "$name.gnu"
 }
-bench_nitc-s_options "slower" --hardening --no-shortcut-equal --no-union-attribute --no-shortcut-range --no-inline-intern "--no-gcc-directive likely --no-gcc-directive noreturn"
+bench_nitc-s_options "slower" --hardening --no-shortcut-equal --no-union-attribute --no-shortcut-range --no-inline-intern "--no-gcc-directive likely --no-gcc-directive noreturn" "--no-tag-primitives"
 bench_nitc-s_options "nocheck" --no-check-null --no-check-autocast --no-check-attr-isset --no-check-covariance --no-check-assert
 bench_nitc-s_options "faster" --skip-dead-methods --inline-coloring-numbers --inline-some-methods --direct-call-monomorph "--inline-some-methods --direct-call-monomorph" ""
 

--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -356,6 +356,16 @@ Usually you do not need them since they make the generated code slower.
 `--no-shortcut-equal`
 :   Always call == in a polymorphic way.
 
+`--no-tag-primitive`
+:   Use only boxes for primitive types.
+
+The separate compiler uses tagged values to encode common primitive types like Int, Bool and Char.
+This option disables tags and forces such primitive values to be boxed.
+The drawback is that each boxing costs a memory allocation thus increases the amount of work for the garbage collector.
+
+However, in some cases, it is possible that this option improves performance since the absence of tags simplify the implementation
+of OO mechanisms like method calls or equality tests.
+
 `--no-inline-intern`
 :   Do not inline call to intern methods.
 

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -29,6 +29,8 @@ redef class ToolContext
 	var opt_no_union_attribute = new OptionBool("Put primitive attibutes in a box instead of an union", "--no-union-attribute")
 	# --no-shortcut-equate
 	var opt_no_shortcut_equate = new OptionBool("Always call == in a polymorphic way", "--no-shortcut-equal")
+	# --no-tag-primitives
+	var opt_no_tag_primitives = new OptionBool("Use only boxes for primitive types", "--no-tag-primitives")
 
 	# --colors-are-symbols
 	var opt_colors_are_symbols = new OptionBool("Store colors as symbols (link-boost)", "--colors-are-symbols")
@@ -65,6 +67,7 @@ redef class ToolContext
 		self.option_context.add_option(self.opt_no_inline_intern)
 		self.option_context.add_option(self.opt_no_union_attribute)
 		self.option_context.add_option(self.opt_no_shortcut_equate)
+		self.option_context.add_option(self.opt_no_tag_primitives)
 		self.option_context.add_option(opt_colors_are_symbols, opt_trampoline_call, opt_guard_call, opt_direct_call_monomorph0, opt_substitute_monomorph, opt_link_boost)
 		self.option_context.add_option(self.opt_inline_coloring_numbers, opt_inline_some_methods, opt_direct_call_monomorph, opt_skip_dead_methods, opt_semi_global)
 		self.option_context.add_option(self.opt_colo_dead_methods)
@@ -163,6 +166,7 @@ class SeparateCompiler
 		modelbuilder.toolcontext.info("Property coloring", 2)
 		compiler.new_file("{c_name}.classes")
 		compiler.do_property_coloring
+		compiler.compile_class_infos
 		for m in mainmodule.in_importation.greaters do
 			for mclass in m.intro_mclasses do
 				#if mclass.kind == abstract_kind or mclass.kind == interface_kind then continue
@@ -217,6 +221,11 @@ class SeparateCompiler
 		self.header.add_decl("struct instance \{ const struct type *type; const struct class *class; nitattribute_t attrs[]; \}; /* general C type representing a Nit instance. */")
 		self.header.add_decl("struct types \{ int dummy; const struct type *types[]; \}; /* a list types (used for vts, fts and unresolved lists). */")
 		self.header.add_decl("typedef struct instance val; /* general C type representing a Nit instance. */")
+
+		if not modelbuilder.toolcontext.opt_no_tag_primitives.value then
+			self.header.add_decl("extern const struct class *class_info[];")
+			self.header.add_decl("extern const struct type *type_info[];")
+		end
 	end
 
 	fun compile_header_attribute_structs
@@ -800,6 +809,8 @@ class SeparateCompiler
 		if mtype.ctype != "val*" or mtype.mclass.name == "Pointer" then
 			# Is a primitive type or the Pointer class, not any other extern class
 
+			if mtype.is_tagged then return
+
 			#Build instance struct
 			self.header.add_decl("struct instance_{c_name} \{")
 			self.header.add_decl("const struct type *type;")
@@ -915,6 +926,58 @@ class SeparateCompiler
 			v.add("return {res};")
 		end
 		v.add("\}")
+	end
+
+	# Compile structures used to map tagged primitive values to their classes and types.
+	# This method also determines which class will be tagged.
+	fun compile_class_infos
+	do
+		if modelbuilder.toolcontext.opt_no_tag_primitives.value then return
+
+		# Note: if you change the tagging scheme, do not forget to update
+		# `autobox` and `extract_tag`
+		var class_info = new Array[nullable MClass].filled_with(null, 4)
+		for t in box_kinds.keys do
+			# Note: a same class can be associated to multiple slots if one want to
+			# use some Huffman coding.
+			if t.name == "Int" then
+				class_info[1] = t
+			else if t.name == "Char" then
+				class_info[2] = t
+			else if t.name == "Bool" then
+				class_info[3] = t
+			else
+				continue
+			end
+			t.mclass_type.is_tagged = true
+		end
+
+		# Compile the table for classes. The tag is used as an index
+		var v = self.new_visitor
+		v.add_decl "const struct class *class_info[4] = \{"
+		for t in class_info do
+			if t == null then
+				v.add_decl("NULL,")
+			else
+				var s = "class_{t.c_name}"
+				v.require_declaration(s)
+				v.add_decl("&{s},")
+			end
+		end
+		v.add_decl("\};")
+
+		# Compile the table for types. The tag is used as an index
+		v.add_decl "const struct type *type_info[4] = \{"
+		for t in class_info do
+			if t == null then
+				v.add_decl("NULL,")
+			else
+				var s = "type_{t.c_name}"
+				v.require_declaration(s)
+				v.add_decl("&{s},")
+			end
+		end
+		v.add_decl("\};")
 	end
 
 	# Add a dynamic test to ensure that the type referenced by `t` is a live type
@@ -1076,8 +1139,30 @@ class SeparateCompilerVisitor
 		else if value.mtype.ctype == "val*" and mtype.ctype == "val*" then
 			return value
 		else if value.mtype.ctype == "val*" then
+			if mtype.is_tagged then
+				if mtype.name == "Int" then
+					return self.new_expr("(long)({value})>>2", mtype)
+				else if mtype.name == "Char" then
+					return self.new_expr("(char)((long)({value})>>2)", mtype)
+				else if mtype.name == "Bool" then
+					return self.new_expr("(short int)((long)({value})>>2)", mtype)
+				else
+					abort
+				end
+			end
 			return self.new_expr("((struct instance_{mtype.c_name}*){value})->value; /* autounbox from {value.mtype} to {mtype} */", mtype)
 		else if mtype.ctype == "val*" then
+			if value.mtype.is_tagged then
+				if value.mtype.name == "Int" then
+					return self.new_expr("(val*)({value}<<2|1)", mtype)
+				else if value.mtype.name == "Char" then
+					return self.new_expr("(val*)((long)({value})<<2|2)", mtype)
+				else if value.mtype.name == "Bool" then
+					return self.new_expr("(val*)((long)({value})<<2|3)", mtype)
+				else
+					abort
+				end
+			end
 			var valtype = value.mtype.as(MClassType)
 			if mtype isa MClassType and mtype.mclass.kind == extern_kind and mtype.mclass.name != "NativeString" then
 				valtype = compiler.mainmodule.pointer_type
@@ -1140,11 +1225,25 @@ class SeparateCompilerVisitor
 		end
 	end
 
+	# Returns a C expression containing the tag of the value as a long.
+	#
+	# If the C expression is evaluated to 0, it means there is no tag.
+	# Thus the expression can be used as a condition.
+	fun extract_tag(value: RuntimeVariable): String
+	do
+		assert value.mtype.ctype == "val*"
+		return "((long){value}&3)" # Get the two low bits
+	end
+
 	# Returns a C expression of the runtime class structure of the value.
 	# The point of the method is to work also with primitive types.
 	fun class_info(value: RuntimeVariable): String
 	do
 		if value.mtype.ctype == "val*" then
+			if can_be_primitive(value) and not compiler.modelbuilder.toolcontext.opt_no_tag_primitives.value then
+				var tag = extract_tag(value)
+				return "({tag}?class_info[{tag}]:{value}->class)"
+			end
 			return "{value}->class"
 		else
 			compiler.undead_types.add(value.mtype)
@@ -1158,6 +1257,10 @@ class SeparateCompilerVisitor
 	fun type_info(value: RuntimeVariable): String
 	do
 		if value.mtype.ctype == "val*" then
+			if can_be_primitive(value) and not compiler.modelbuilder.toolcontext.opt_no_tag_primitives.value then
+				var tag = extract_tag(value)
+				return "({tag}?type_info[{tag}]:{value}->type)"
+			end
 			return "{value}->type"
 		else
 			compiler.undead_types.add(value.mtype)
@@ -1743,6 +1846,8 @@ class SeparateCompilerVisitor
 				self.add("{res} = {value1} == {value2};")
 			else if value2.mtype.ctype != "val*" then
 				self.add("{res} = 0; /* incompatible types {value1.mtype} vs. {value2.mtype}*/")
+			else if value1.mtype.is_tagged then
+				self.add("{res} = ({value2} != NULL) && ({self.autobox(value2, value1.mtype)} == {value1});")
 			else
 				var mtype1 = value1.mtype.as(MClassType)
 				self.require_declaration("class_{mtype1.c_name}")
@@ -1779,6 +1884,13 @@ class SeparateCompilerVisitor
 			else if t2.ctype != "val*" then
 				incompatible = true
 			else if can_be_primitive(value2) then
+				if t1.is_tagged then
+					self.add("{res} = {value1} == {value2};")
+					return res
+				end
+				if not compiler.modelbuilder.toolcontext.opt_no_tag_primitives.value then
+					test.add("(!{extract_tag(value2)})")
+				end
 				test.add("{value1}->class == {value2}->class")
 			else
 				incompatible = true
@@ -1786,6 +1898,13 @@ class SeparateCompilerVisitor
 		else if t2.ctype != "val*" then
 			primitive = t2
 			if can_be_primitive(value1) then
+				if t2.is_tagged then
+					self.add("{res} = {value1} == {value2};")
+					return res
+				end
+				if not compiler.modelbuilder.toolcontext.opt_no_tag_primitives.value then
+					test.add("(!{extract_tag(value1)})")
+				end
 				test.add("{value1}->class == {value2}->class")
 			else
 				incompatible = true
@@ -1804,12 +1923,24 @@ class SeparateCompilerVisitor
 			end
 		end
 		if primitive != null then
+			if primitive.is_tagged then
+				self.add("{res} = {value1} == {value2};")
+				return res
+			end
 			test.add("((struct instance_{primitive.c_name}*){value1})->value == ((struct instance_{primitive.c_name}*){value2})->value")
 		else if can_be_primitive(value1) and can_be_primitive(value2) then
+			if not compiler.modelbuilder.toolcontext.opt_no_tag_primitives.value then
+				test.add("(!{extract_tag(value1)}) && (!{extract_tag(value2)})")
+			end
 			test.add("{value1}->class == {value2}->class")
 			var s = new Array[String]
 			for t, v in self.compiler.box_kinds do
+				if t.mclass_type.is_tagged then continue
 				s.add "({value1}->class->box_kind == {v} && ((struct instance_{t.c_name}*){value1})->value == ((struct instance_{t.c_name}*){value2})->value)"
+			end
+			if s.is_empty then
+				self.add("{res} = {value1} == {value2};")
+				return res
 			end
 			test.add("({s.join(" || ")})")
 		else
@@ -2133,6 +2264,12 @@ class SeparateRuntimeFunction
 			v2.add "\}"
 		end
 	end
+end
+
+redef class MType
+	# Are values of `self` tagged?
+	# If false, it means that the type is not primitive, or is boxed.
+	var is_tagged = false
 end
 
 redef class MEntity

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -39,6 +39,11 @@ redef class ToolContext
 		if opt_no_check_all.value then
 			opt_no_check_erasure_cast.value = true
 		end
+
+		# Temporary disabled. TODO: implement tagging in the erasure compiler.
+		if opt_erasure.value then
+			opt_no_tag_primitives.value = true
+		end
 	end
 
 	var erasure_compiler_phase = new ErasureCompilerPhase(self, null)

--- a/tests/base_attr.nit
+++ b/tests/base_attr.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class Int

--- a/tests/base_attr_def.nit
+++ b/tests/base_attr_def.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class Int

--- a/tests/base_attr_init_val2.nit
+++ b/tests/base_attr_init_val2.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import end
-class Object
+interface Object
 end
 class Int
 end

--- a/tests/base_empty_module.nit
+++ b/tests/base_empty_module.nit
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 import end
-class Object
+interface Object
 end

--- a/tests/base_eq_null_notnull.nit
+++ b/tests/base_eq_null_notnull.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 	fun ==(o: nullable Object): Bool do return self.is_same_instance(o)
 	fun !=(o: nullable Object): Bool do return not (self == o)
 	fun is_same_instance(other: nullable Object): Bool is intern

--- a/tests/base_gen.nit
+++ b/tests/base_gen.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 	fun i_to_s(i: Int)
 	do
 		i.output

--- a/tests/base_gen2.nit
+++ b/tests/base_gen2.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 	fun output is abstract
 end
 

--- a/tests/base_gen_int.nit
+++ b/tests/base_gen_int.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 	fun i_to_s(i: Int)
 	do
 		i.output

--- a/tests/base_simple.nit
+++ b/tests/base_simple.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class Int

--- a/tests/base_types_formal_and_virtual.nit
+++ b/tests/base_types_formal_and_virtual.nit
@@ -14,7 +14,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class Int

--- a/tests/base_types_formal_and_virtual2.nit
+++ b/tests/base_types_formal_and_virtual2.nit
@@ -14,7 +14,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class Int

--- a/tests/base_types_formal_and_virtual4.nit
+++ b/tests/base_types_formal_and_virtual4.nit
@@ -14,7 +14,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class A[E: Object]

--- a/tests/base_var_type_evolution_null5.nit
+++ b/tests/base_var_type_evolution_null5.nit
@@ -14,7 +14,7 @@
 
 import end
 
-class Object
+interface Object
 	fun ==(o: nullable Object): Bool do return self.is_same_instance(o)
 	fun !=(o: nullable Object): Bool do return not self.is_same_instance(o)
 	fun is_same_instance(other: nullable Object): Bool is intern

--- a/tests/base_var_type_evolution_null_while.nit
+++ b/tests/base_var_type_evolution_null_while.nit
@@ -14,7 +14,7 @@
 
 import end
 
-class Object
+interface Object
 	fun ==(o: nullable Object): Bool do return self.is_same_instance(o)
 	fun !=(o: nullable Object): Bool do return not self.is_same_instance(o)
 	fun is_same_instance(other: nullable Object): Bool is intern

--- a/tests/base_var_type_evolution_nullable.nit
+++ b/tests/base_var_type_evolution_nullable.nit
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import end
-class Object
+interface Object
 	fun ==(o: nullable Object): Bool do return self.is_same_instance(o)
 	fun !=(o: nullable Object): Bool do return not self == o
 	fun is_same_instance(o: nullable Object): Bool is intern

--- a/tests/error_constraint_raf.nit.broken
+++ b/tests/error_constraint_raf.nit.broken
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 import kernel
-class Object[E: Object]
+interface Object[E: Object]
 end

--- a/tests/error_needed_types.nit
+++ b/tests/error_needed_types.nit
@@ -1,7 +1,7 @@
 
 import end#alt7#
 #alt7#import kernel
-class Object#alt7#
+interface Object#alt7#
 end#alt7#
 
 #alt6#class A

--- a/tests/error_prop_glob.nit
+++ b/tests/error_prop_glob.nit
@@ -16,7 +16,7 @@
 
 import end
 
-class Object
+interface Object
 end
 
 class A

--- a/tests/test_prog/platform/platform.nit
+++ b/tests/test_prog/platform/platform.nit
@@ -18,7 +18,7 @@ module platform
 import end
 
 # Root of everything.
-class Object
+interface Object
 	# Used for comparisons.
 	type OTHER: nullable Object
 


### PR DESCRIPTION
Another old optimization since it was present in PRM, the Australopithecus compiler.

This PR bring back tagging of the primitives types Int, Bool and Char.

Previously, all primitive types where boxed. 
It means that when a Bool, or any primitive object, must be manipulated in a polymorphic way (i.e. as an Object in a `val*`), a small box is allocated that contain the value and the reference (the `val*`) points to the box.
The boxes use the layout of real objects (with a pointer to the class table and everything) so that boxes are compatible with the various implementation of OO mechanism, eg `obj->class->vtf[METHODID]` to implement a method invocation.

Basically boxes work like Java auxiliary classes (eg. `Integer`) except that they are fully transparent for the user and, more important, a implementation detail unrelated to the specification of the language.
Therefore, one can provide a different implementation, like tagging, without worrying about breaking the specification and existing programs.

The principle of tagging is that `val*` values are overloaded to store primitive value in addition to genuine pointers to allocated object.
The two low bits of the `val*` (so 4 combinations) is used to distinguish if the value is a real pointer (in this case, bits are 00) or one of the masqueraded common type (Int, Bool and Char).
If it is a pointer there is nothing to do and the value can be used as is.
If it is a primitive value, then the real value is stored in the remaining bits (but shifted).
The trick works because allocated objects are aligned so that pointer of genuine allocated object have always their last two bits at 00.

The advantage of tagging is that this reduces the cost of manipulating primitive values in a polymorphic way, especially this reduce the numerous allocations of short lived boxes that is slow to do and increase the workload of the GC.
By comparison, with tagging, masquerading a Bool as a `val*` is easily done with few bit-to-bit operations.

Unfortunately, tagging is not a panacea since `val*` is not always a real pointer and require specific and additional protection to avoid doing `obj->class` in the case of `obj` is in fact a tagged value.
Therefore tagging add a minimal but systematic overhead to OO mechanisms like calls, type tests and equality tests.

After quick tests, the numbers are encouraging.

For nitc/nitc/nitc:
before: 0m6.796s
after: 0m6.452s (-5%, not that bad)

Benches where run and tagging was either comparable or better than systematic boxing:

![](https://cloud.githubusercontent.com/assets/135828/6656784/b5a38698-cb67-11e4-96a4-c46f7df2331f.png)

Especially `lib/ai/examples/queens.nit` get the best of it with a -20% improvement.
That make sense because it use arrays of integers to model the states of the n-queen problem. And unfortunately arrays are implemented in a homogeneous way where elements are always polymorphic `val*` values.
Once generics and collections are implemented in an heterogeneous way for primitive types, the benefit of tagging should be reevaluated.

Note: funnily, the main commit of the series, the one that implements tagging, is only made of insertions of lines (no deletion or changes) and it only modifies a single file.
