### PR TITLE
Intro NitActivity an Android entry point in pure Nit, Java, and C (almost no NDK)

### DIFF
--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -8,3 +8,6 @@ android:
 	mkdir -p bin/ res/
 	../../contrib/inkscape_tools/bin/svg_to_icons art/icon.svg --android --out res/
 	../../bin/nitc -o bin/calculator.apk src/calculator_android.nit
+
+android-install: android
+	adb install -r bin/calculator.apk

--- a/examples/calculator/src/calculator_android.nit
+++ b/examples/calculator/src/calculator_android.nit
@@ -26,7 +26,8 @@ module calculator_android is
 		android:screenOrientation="portrait""""
 end
 
-import android
+# FIXME the next line should import `android` only when it uses nit_activity
+import android::log
 import android::ui
 
 import calculator_logic

--- a/examples/calculator/src/calculator_android.nit
+++ b/examples/calculator/src/calculator_android.nit
@@ -20,10 +20,8 @@ module calculator_android is
 	app_version(0, 1, git_revision)
 	java_package "org.nitlanguage.calculator"
 
-	# Use a translucent background and lock in portrait mode
-	android_manifest_activity """
-		android:theme="@android:style/Theme.Holo.Wallpaper"
-		android:screenOrientation="portrait""""
+	# Lock in portrait mode
+	android_manifest_activity """android:screenOrientation="portrait""""
 end
 
 # FIXME the next line should import `android` only when it uses nit_activity
@@ -32,7 +30,9 @@ import android::ui
 
 import calculator_logic
 
-redef class App
+redef class Activity
+	super EventCatcher
+
 	private var context = new CalculatorContext
 
 	# The main display, at the top of the screen
@@ -44,7 +44,7 @@ redef class App
 	# Has this window been initialized?
 	private var inited = false
 
-	redef fun init_window
+	redef fun on_start
 	do
 		super
 
@@ -52,8 +52,7 @@ redef class App
 		inited = true
 
 		# Setup UI
-		var context = native_activity
-		var layout = new NativeLinearLayout(context)
+		var layout = new NativeLinearLayout(native)
 		layout.set_vertical
 
 		# Display screen
@@ -70,12 +69,13 @@ redef class App
 		           ["="]]
 
 		for line in ops do
-			var buts_layout = new NativeLinearLayout(context)
+			var buts_layout = new NativeLinearLayout(native)
 			buts_layout.set_horizontal
 			layout.add_view_with_weight(buts_layout, 1.0)
 
 			for op in line do
 				var but = new Button
+				but.event_catcher = self
 				but.text = op
 				but.text_size = 40
 				buts_layout.add_view_with_weight(but.native, 1.0)
@@ -83,7 +83,7 @@ redef class App
 			end
 		end
 
-		context.content_view = layout
+		native.content_view = layout
 	end
 
 	redef fun catch_event(event)

--- a/examples/calculator/src/calculator_android.nit
+++ b/examples/calculator/src/calculator_android.nit
@@ -86,6 +86,32 @@ redef class Activity
 		native.content_view = layout
 	end
 
+	redef fun on_save_instance_state(state)
+	do
+		super
+
+		var nity = new Bundle.from(state)
+		nity["context"] = context.to_json
+	end
+
+	redef fun on_restore_instance_state(state)
+	do
+		super
+
+		var nity = new Bundle.from(state)
+		if not nity.has("context") then return
+
+		var json = nity.string("context")
+		if json == null then return
+
+		context = new CalculatorContext.from_json(json)
+	end
+
+	redef fun on_resume
+	do
+		display.text = context.display_text
+	end
+
 	redef fun catch_event(event)
 	do
 		if event isa ClickEvent then

--- a/lib/android/NitActivity.java
+++ b/lib/android/NitActivity.java
@@ -1,0 +1,111 @@
+/* This file is part of NIT ( http://www.nitlanguage.org ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nit.app;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+/*
+ * Entry point to Nit applications on Android, redirect most calls to Nit
+ */
+public class NitActivity extends Activity {
+
+	// Nit activity associated to `this`
+	protected int nitActivity = 0;
+
+	/*
+	 * Calls to Nit or to the C framework
+	 */
+
+	static {
+		System.loadLibrary("main");
+	}
+
+	/*
+	 * Callbacks to Nit through C
+	 */
+	protected native int nitRegisterActivity();
+	protected native void nitOnCreate(int activity, Bundle savedInstanceState);
+	protected native void nitOnStart(int activity);
+	protected native void nitOnRestart(int activity);
+	protected native void nitOnResume(int activity);
+	protected native void nitOnPause(int activity);
+	protected native void nitOnStop(int activity);
+	protected native void nitOnDestroy(int activity);
+	protected native void nitOnSaveInstanceState(int activity, Bundle savedInstanceState);
+	protected native void nitOnRestoreInstanceState(int activity, Bundle savedInstanceState);
+
+	/*
+	 * Implementation of OS callbacks
+	 */
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		nitActivity = nitRegisterActivity();
+
+		nitOnCreate(nitActivity, savedInstanceState);
+	}
+
+	@Override
+	protected void onStart() {
+		super.onStart();
+		nitOnStart(nitActivity);
+	}
+
+	@Override
+	protected void onRestart() {
+		super.onRestart();
+		nitOnRestart(nitActivity);
+	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+		nitOnResume(nitActivity);
+	}
+
+	@Override
+	protected void onPause() {
+		super.onPause();
+		nitOnPause(nitActivity);
+	}
+
+	@Override
+	protected void onStop() {
+		super.onStop();
+		nitOnStop(nitActivity);
+	}
+
+	@Override
+	protected void onDestroy() {
+		super.onDestroy();
+		nitOnDestroy(nitActivity);
+	}
+
+	@Override
+	public void onSaveInstanceState(Bundle savedInstanceState) {
+		super.onSaveInstanceState(savedInstanceState);
+		nitOnSaveInstanceState(nitActivity, savedInstanceState);
+	}
+
+	@Override
+	public void onRestoreInstanceState(Bundle savedInstanceState) {
+		super.onRestoreInstanceState(savedInstanceState);
+		nitOnRestoreInstanceState(nitActivity, savedInstanceState);
+	}
+}

--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -54,6 +54,11 @@ integer as argument. They are applied in the Android manifest as
 
     See http://developer.android.com/guide/topics/manifest/uses-sdk-element.html
 
+* The annotation `android_activity` defines a Java class used as an
+  entrypoint to your application. As of now, this annotation should
+  only be used by low level implementations of Nit on Android.
+  It's usefulness will be extended in the future to customize user applications.
+
 ## Project entry points
 
 Importing `android::landscape` or `android::portrait` locks the generated

--- a/lib/android/aware.nit
+++ b/lib/android/aware.nit
@@ -27,4 +27,5 @@ module aware is
 	new_annotation android_manifest
 	new_annotation android_manifest_application
 	new_annotation android_manifest_activity
+	new_annotation android_activity
 end

--- a/lib/android/dalvik.nit
+++ b/lib/android/dalvik.nit
@@ -58,14 +58,14 @@ redef class Sys
 		// Retrieve main activity
 		jclass class_activity = (*env)->GetObjectClass(env, native_activity);
 		if (class_activity == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retreiving activity class");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retrieving activity class");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}
 
 		jmethodID class_activity_getClassLoader = (*env)->GetMethodID(env, class_activity, "getClassLoader", "()Ljava/lang/ClassLoader;");
 		if (class_activity_getClassLoader == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retreiving 'getClassLoader' method");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retrieving 'getClassLoader' method");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}
@@ -73,14 +73,14 @@ redef class Sys
 		// Call activity.getClassLoader
 		jobject instance_class_loader = (*env)->CallObjectMethod(env, native_activity, class_activity_getClassLoader);
 		if (instance_class_loader == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retreiving class loader instance");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retrieving class loader instance");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}
 
 		jclass class_class_loader = (*env)->GetObjectClass(env, instance_class_loader);
 		if (class_class_loader == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retreiving class of class loader");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retrieving class of class loader");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}
@@ -88,7 +88,7 @@ redef class Sys
 		// Get the method ClassLoader.findClass
 		jmethodID class_class_loader_findClass = (*env)->GetMethodID(env, class_class_loader, "findClass", "(Ljava/lang/String;)Ljava/lang/Class;");
 		if (class_class_loader_findClass == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retreiving 'findClass' method");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed retrieving 'findClass' method");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}
@@ -109,7 +109,7 @@ redef class Sys
 
 		jclass java_class = (*env)->CallObjectMethod(env, instance_class_loader, class_loader_findClass, class_name);
 		if (java_class == NULL) {
-			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed loading targetted class");
+			__android_log_print(ANDROID_LOG_ERROR, "Nit", "Failed loading targeted class");
 			(*env)->ExceptionDescribe(env);
 			exit(1);
 		}

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -36,7 +36,10 @@
 #   which is a subclass of `Activity` and `Context` (in Java). It represent
 #   main activity of the running application. Use it to get anything related
 #   to the `Context` and as anchor to execute Java UI code.
-module native_app_glue is ldflags "-landroid"
+module native_app_glue is
+	ldflags "-landroid"
+	android_activity "android.app.NativeActivity"
+end
 
 import platform
 import log

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -148,7 +148,7 @@ redef class App
 	`}
 
 	# Notification from the Android framework to generate a new saved state
-	# 
+	#
 	# You can use the `shared_preferences` module or `NativeAppGlue::saved_state`.
 	fun save_state do end
 
@@ -175,7 +175,7 @@ redef class App
 	fun stop do end
 
 	# Notification from the Android framework, `native_activity` is being destroyed
-	# 
+	#
 	# Clean up and exit.
 	fun destroy do end
 
@@ -197,7 +197,7 @@ redef class App
 	fun input_changed do end
 
 	# Notification from the Android framework, the window has been resized.
-	# 
+	#
 	# Please redraw with its new size.
 	fun window_resized do end
 
@@ -205,7 +205,7 @@ redef class App
 	fun window_redraw_needed do end
 
 	# Notification from the Android framework, the content area of the window has changed
-	# 
+	#
 	# Raised when the soft input window being shown or hidden, and similar events.
 	fun content_rect_changed do end
 
@@ -227,7 +227,7 @@ redef class App
 
 		struct android_app *app_glue = App_native_app_glue(recv);
 		struct android_poll_source* source = (struct android_poll_source*)data;
-		
+
 		// Process this event.
 		if (source != NULL) source->process(app_glue, source);
 	`}
@@ -255,13 +255,13 @@ extern class NdkNativeActivity `{ ANativeActivity * `}
 
 	# Path to this application's internal data directory.
 	fun internal_data_path: NativeString `{ return (char*)recv->internalDataPath; `}
-    
+
 	# Path to this application's external (removable/mountable) data directory.
 	fun external_data_path: NativeString `{ return (char*)recv->externalDataPath; `}
-    
+
 	# The platform's SDK version code.
 	fun sdk_version: Int `{ return recv->sdkVersion; `}
-    
+
 	# This is the native instance of the application.  It is not used by
 	# the framework, but can be set by the application to its own instance
 	# state.

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -40,7 +40,7 @@ module native_app_glue is ldflags "-landroid"
 
 import platform
 import log
-import activities
+import dalvik
 
 in "C header" `{
 	#include <android_native_app_glue.h>
@@ -123,6 +123,10 @@ extern class NativeNativeActivity in "Java" `{ android.app.NativeActivity `}
 	super NativeActivity
 end
 
+redef class Sys
+	redef fun jvm do return app.native_app_glue.ndk_native_activity.vm
+end
+
 redef class App
 	redef fun setup
 	do
@@ -135,8 +139,7 @@ redef class App
 	# The underlying implementation using the Android native_app_glue framework
 	fun native_app_glue: NativeAppGlue `{ return native_app_glue_data; `}
 
-	# The main Java Activity of this application
-	fun native_activity: NativeActivity do return native_app_glue.ndk_native_activity.java_native_activity
+	redef fun native_activity do return native_app_glue.ndk_native_activity.java_native_activity
 
 	# Set `native_app_glue` command handler to our C implementation which
 	# will callback self.

--- a/lib/android/nit_activity.nit
+++ b/lib/android/nit_activity.nit
@@ -1,0 +1,251 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Some documentation of this module has been adapted from the
+# Android Open Source Project.
+
+# Core implementation of `app.nit` on Android using a custom Java entry point
+#
+# This module is implemented in 3 languages:
+#
+# * The Java code, in `NitActivity.java` acts as the entry point registered
+#   to the Android OS. It relays most of the Android callbacks to C.
+#   In theory, there may be more than one instance of `NitActivity` alive at
+#   a given time. They hold a reference to the corresponding Nit `Activity`
+#   in the attribute `nitActivity`.
+#
+# * The C code is defined in the top part of this source file. It acts as a
+#   glue between Java and Nit by relaying calls between both languages.
+#   It keeps a global variables reference to the Java VM and the Nit `App`.
+#
+# * The Nit code defines the `Activity` class with the callbacks from Android.
+#   The callback methods should be redefined by user modules.
+#
+# The main is invoked when the native library is dynamically linked by
+# the Java virtual machine. For this reason, the main _must_ execute quickly,
+# on the main UI thread at least.
+module nit_activity is
+	extra_java_files "NitActivity.java"
+	android_activity "nit.app.NitActivity"
+end
+
+import platform
+import log
+import activities
+import bundle
+import dalvik
+
+in "C body" `{
+
+	#include <jni.h>
+	#include <android/log.h>
+
+	// Nit's App running instance
+	App global_app;
+
+	// Java VM that launched this program
+	JavaVM *global_jvm;
+
+	// JNI callback on loading this program
+	jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+		// Set aside the Java VM
+		global_jvm = vm;
+
+		// Invoke Nit system and main
+		main(0, NULL);
+
+		return JNI_VERSION_1_2;
+	}
+
+	/*
+	 * Implementations of NitActivity.java native methods
+	 */
+
+	JNIEXPORT jint JNICALL Java_nit_app_NitActivity_nitRegisterActivity
+	  (JNIEnv *env, jobject java_activity)
+	{
+		Activity nit_activity = App_register_activity(global_app, java_activity);
+		Activity_incr_ref(nit_activity);
+		return (jint)(void*)nit_activity;
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnCreate
+	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	{
+		Activity_on_create((Activity)nit_activity, saved_state);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnStart
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_start((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnRestart
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_restart((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnResume
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_resume((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnPause
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_pause((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnStop
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_stop((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnDestroy
+	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	{
+		Activity_on_destroy((Activity)nit_activity);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnSaveInstanceState
+	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	{
+		Activity_on_save_instance_state((Activity)nit_activity, saved_state);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnRestoreInstanceState
+	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	{
+		Activity_on_restore_instance_state((Activity)nit_activity, saved_state);
+	}
+`}
+
+# Wrapper to our Java `NitActivity`
+extern class NativeNitActivity in "Java" `{ nit.app.NitActivity `}
+	super NativeActivity
+end
+
+redef class Sys
+	redef fun jvm `{ return global_jvm; `}
+end
+
+redef class App
+	# Known activities
+	var activities = new Array[Activity]
+
+	# The main Java Activity of this application
+	redef fun native_activity do return activities.first.native
+
+	redef fun setup do set_global_app
+
+	# Register app in C
+	private fun set_global_app import register_activity,
+	Activity.on_create, Activity.on_destroy,
+	Activity.on_start, Activity.on_restart, Activity.on_stop,
+	Activity.on_pause, Activity.on_resume,
+	Activity.on_save_instance_state, Activity.on_restore_instance_state `{
+		App_incr_ref(recv);
+		global_app = recv;
+	`}
+
+	# Create the Nit side to this new `native` Java activity, and return it to Java
+	private fun register_activity(native: NativeNitActivity): Activity
+	do
+		native = native.new_global_ref
+		var activity = new Activity(native)
+		activities.add activity
+		return activity
+	end
+end
+
+# An Android activity
+#
+# You must implement the callbacks (prefixed with `on_`) to follow the
+# standard Android life-cycle.
+class Activity
+	# Native Java activity
+	var native: NativeActivity
+
+	# Notification from Android, the activity is created
+	#
+	# Do your normal static set up here.
+	#
+	# If available, `save_state` contains the activity's previous state
+	# as registered by `on_save_instance_state`.
+	#
+	# Followed by `on_start`.
+	fun on_create(save_state: NativeBundle) do end
+
+	# Notification from Android, the activity has been restarted
+	#
+	# Followed by `on_start`.
+	fun on_restart do end
+
+	# Notification from Android, the activity has been started
+	#
+	# Followed by `on_resume` or `on_stop`.
+	fun on_start do end
+
+	# Notification from Android, the activity has been resumed
+	#
+	# Followed by `on_pause`
+	fun on_resume do end
+
+	# Notification from Android, the activity has been paused
+	#
+	# Followed by `on_resume` or `on_stop`.
+	fun on_pause do end
+
+	# Notification from Android, the activity has been stopped
+	#
+	# Followed by `on_restart` or `on_destroy`.
+	fun on_stop do end
+
+	# Notification from Android, the activity is being destroyed
+	#
+	# Clean up and exit.
+	fun on_destroy
+	do
+		native.delete_global_ref
+		app.activities.remove self
+	end
+
+	# Notification from Android, the activity is being re-initialized from a `save_state`
+	#
+	# Occurs after `on_start`.
+	fun on_restore_instance_state(save_state: NativeBundle) do end
+
+	# Notification from Android, the activity may be stopped, save state
+	#
+	# Occurs before `on_stop` and, without guarantee, before or after `on_pause`.
+	fun on_save_instance_state(save_state: NativeBundle) do end
+
+	# Notification from Android, the system is running low on memory
+	#
+	# Try to reduce your memory use.
+	fun on_low_memory do end
+
+	# Notification from Android, the current window of the activity has lost or gained focus
+	fun on_window_focus_changed(has_focus: Bool) do end
+
+	# Notification from Android, the current device configuration has changed
+	fun on_configuration_changed do end
+end
+
+# Set up global data in C and leave it to Android to callback Java, which we relay to Nit
+app.setup

--- a/lib/android/ui.nit
+++ b/lib/android/ui.nit
@@ -106,43 +106,8 @@ end
 
 redef extern class NativeActivity
 
-	# Fill this entire `NativeActivity` with `popup`
-	#
-	# This is a workaround for the use on `takeSurface` in `NativeActivity.java`
-	#
-	# TODO replace NativeActivity by our own NitActivity
-	private fun dedicate_to_popup(popup: NativePopupWindow, popup_layout: NativeViewGroup) in "Java" `{
-		final LinearLayout final_main_layout = new LinearLayout(recv);
-		final ViewGroup final_popup_layout = popup_layout;
-		final PopupWindow final_popup = popup;
-		final Activity final_recv = recv;
-
-		recv.runOnUiThread(new Runnable() {
-			@Override
-			public void run()  {
-				MarginLayoutParams params = new MarginLayoutParams(
-					LinearLayout.LayoutParams.MATCH_PARENT,
-					LinearLayout.LayoutParams.MATCH_PARENT);
-
-				final_recv.setContentView(final_main_layout, params);
-
-				final_popup.showAtLocation(final_popup_layout, Gravity.TOP, 0, 40);
-			}
-		});
-	`}
-
 	# Set the main layout of this activity
-	fun content_view=(layout: NativeViewGroup)
-	do
-		var popup = new NativePopupWindow(self)
-		popup.content_view = layout
-		dedicate_to_popup(popup, layout)
-	end
-
-	# Set the real content view of this activity, without hack
-	#
-	# TODO bring use this instead of the hack with `dedicate_to_pupup`
-	private fun real_content_view=(layout: NativeViewGroup) in "Java" `{
+	fun content_view=(layout: NativeViewGroup) in "Java" `{
 		final ViewGroup final_layout = layout;
 		final Activity final_recv = recv;
 

--- a/lib/android/ui.nit
+++ b/lib/android/ui.nit
@@ -34,7 +34,7 @@
 # ~~~
 module ui is min_api_version 14
 
-import native_app_glue
+import nit_activity
 import pthreads::concurrent_collections
 
 in "Java" `{
@@ -78,30 +78,6 @@ end
 
 redef class App
 	super EventCatcher
-
-	# Queue of events to be received by the main thread
-	var event_queue = new ConcurrentList[AppEvent]
-
-	# Call `react` on all `AppEvent` available in `event_queue`
-	protected fun loop_on_ui_callbacks
-	do
-		var queue = event_queue
-		while not queue.is_empty do
-			var event = queue.pop
-			event.react
-		end
-	end
-
-	redef fun run
-	do
-		loop
-			# Process Android events
-			poll_looper 100
-
-			# Process app.nit events
-			loop_on_ui_callbacks
-		end
-	end
 end
 
 redef extern class NativeActivity
@@ -186,23 +162,18 @@ class Button
 
 	init
 	do
-		var native = new NativeButton(app.native_activity, app.event_queue, self)
+		var native = new NativeButton(app.native_activity, self)
 		self.native = native.new_global_ref
 	end
 
-	# Click event on the Main thread
+	# Click event
 	#
 	# By default, this method calls `app.catch_event`. It can be specialized
 	# with custom behavior or the receiver of `catch_event` can be changed
 	# with `event_catcher=`.
 	fun click(event: AppEvent) do event_catcher.catch_event(event)
 
-	# Click event on the UI thread
-	#
-	# This method is called on the UI thread and redirects the event to `click`
-	# throught `App::event_queue`. In most cases, you should implement `click`
-	# and leave `click_ui` as is.
-	fun click_ui do app.event_queue.add(new ClickEvent(self))
+	private fun click_from_native do click(new ClickEvent(self))
 end
 
 # An Android editable text field
@@ -213,7 +184,7 @@ class EditText
 
 	init
 	do
-		var native = new NativeEditText(app.native_activity)
+		var native = new NativeEditText(app.activities.first.native)
 		self.native = native.new_global_ref
 	end
 end
@@ -352,14 +323,15 @@ extern class NativeButton in "Java" `{ android.widget.Button `}
 
 	redef type SELF: NativeButton
 
-	new (context: NativeActivity, queue: ConcurrentList[AppEvent], sender_object: Object) import Button.click_ui in "Java" `{
+	new (context: NativeActivity, sender_object: Object)
+	import Button.click_from_native in "Java" `{
 		final int final_sender_object = sender_object;
 
 		return new Button(context){
 			@Override
 			public boolean onTouchEvent(MotionEvent event) {
 				if(event.getAction() == MotionEvent.ACTION_DOWN) {
-					Button_click_ui(final_sender_object);
+					Button_click_from_native(final_sender_object);
 					return true;
 				}
 				return false;

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -169,7 +169,7 @@ extern class JavaVM `{JavaVM *`}
 		return env;
 	`}
 
-	fun attach_current_thread: JniEnv `{
+	fun attach_current_thread: JniEnv import jni_error `{
 		JNIEnv *env;
 	#ifdef ANDROID
 		// the signature is different (better actually) on Android

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -181,14 +181,15 @@ $(call import-module,android/native_app_glue)
 
 		### generate AndroidManifest.xml
 		dir = android_project_root
-		"""<?xml version="1.0" encoding="utf-8"?>
+		var manifest_file = new FileWriter.open("{dir}/AndroidManifest.xml")
+		manifest_file.write """
+<?xml version="1.0" encoding="utf-8"?>
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="{{{app_package}}}"
         android:versionCode="{{{project.version_code}}}"
         android:versionName="{{{app_version}}}">
 
-    <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk
         android:minSdkVersion="{{{app_min_api}}}"
         android:targetSdkVersion="{{{app_target_api}}}"
@@ -200,22 +201,23 @@ $(call import-module,android/native_app_glue)
 		android:debuggable="{{{not release}}}"
 		{{{icon_declaration}}}
 		android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation">
+"""
 
-        <!-- Our activity is the built-in NativeActivity framework class.
-             This will take care of integrating with our NDK code. -->
-        <activity android:name="android.app.NativeActivity"
+		for activity in project.activities do
+			manifest_file.write """
+        <activity android:name="{{{activity}}}"
                 android:label="@string/app_name"
                 {{{project.manifest_activity_attributes.join("\n")}}}
                 {{{icon_declaration}}}>
-            <!-- Tell NativeActivity the name of our .so -->
-            <meta-data android:name=\"android.app.lib_name\"
-                    android:value=\"main\" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+"""
+		end
 
+		manifest_file.write """
 {{{project.manifest_application_lines.join("\n")}}}
 
     </application>
@@ -224,7 +226,7 @@ $(call import-module,android/native_app_glue)
 
 </manifest>
 <!-- END_INCLUDE(manifest) -->
-		""".write_to_file("{dir}/AndroidManifest.xml")
+"""
 
 		### Link to png sources
 		# libpng is not available on Android NDK

--- a/src/platform/android_annotations.nit
+++ b/src/platform/android_annotations.nit
@@ -56,6 +56,9 @@ class AndroidProject
 	# Maximum API level on which the application will be allowed to run
 	var max_api: nullable Int = null
 
+	# Activities to declare in the manifest
+	var activities = new Array[String]
+
 	redef fun to_s do return """
 name: {{{name or else "null"}}}
 namespace: {{{java_package or else "null"}}}
@@ -112,6 +115,12 @@ redef class ModelBuilder
 
 		annots = collect_annotations_on_modules("android_manifest_activity", mmodule)
 		for an in annots do project.manifest_activity_attributes.add an.arg_as_string(self) or else ""
+
+		annots = collect_annotations_on_modules("android_activity", mmodule)
+		for an in annots do
+			var activity = an.arg_as_string(self)
+			if activity != null then project.activities.add activity
+		end
 
 		# Get the date and time (down to the minute) as string
 		var local_time = new Tm.localtime


### PR DESCRIPTION
This PR could be described in 3 steps.

* Clean up lib/android and move up `dalvik` in the module hierarchy.
* Intro NitActivity.java (the most important commit)
* Update calculator (only) to use the new NitActivity with all its perks.

See the doc of the nit_activity module for the details on the polyglot implementation, copied hre for your convenience:

This module is implemented in 3 languages:

* The Java code, in `NitActivity.java` acts as the entry point registered
   to the Android OS. It relays most of the Android callbacks to C.
   In theory, there may be more than one instance of `NitActivity` alive at
   a given time. They hold a reference to the corresponding Nit `Activity`
   in the attribute `nitActivity`.

* The C code is defined in the top part of this source file. It acts as a
   glue between Java and Nit by relaying calls between both languages.
   It keeps a global variables reference to the Java VM and the Nit `App`.

* The Nit code defines the `Activity` class with the callbacks from Android.
   The callback methods should be redefined by user modules.