### PR TITLE
compiler: improve `poset_from_mtypes` used for type coloring.

### DIFF
--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -995,6 +995,7 @@ class SeparateCompiler
 				v.add_decl("NULL,")
 			else
 				var s = "type_{t.c_name}"
+				undead_types.add(t.mclass_type)
 				v.require_declaration(s)
 				v.add_decl("&{s},")
 			end

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -466,7 +466,7 @@ class SeparateCompiler
 		type_tables = build_type_tables(poset)
 
 		# VT and FT are stored with other unresolved types in the big resolution_tables
-		self.compile_resolution_tables(live_types)
+		self.compute_resolution_tables(live_types)
 
 		return poset
 	end
@@ -527,9 +527,8 @@ class SeparateCompiler
 		return tables
 	end
 
-	protected fun compile_resolution_tables(mtypes: Set[MType]) do
-		# resolution_tables is used to perform a type resolution at runtime in O(1)
-
+	# resolution_tables is used to perform a type resolution at runtime in O(1)
+	private fun compute_resolution_tables(mtypes: Set[MType]) do
 		# During the visit of the body of classes, live_unresolved_types are collected
 		# and associated to
 		# Collect all live_unresolved_types (visited in the body of classes)

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -456,14 +456,9 @@ class SeparateCompiler
 		# Collect types to colorize
 		var live_types = runtime_type_analysis.live_types
 		var live_cast_types = runtime_type_analysis.live_cast_types
-		var mtypes = new HashSet[MType]
-		mtypes.add_all(live_types)
-		for c in self.box_kinds.keys do
-			mtypes.add(c.mclass_type)
-		end
 
 		# Compute colors
-		var poset = poset_from_mtypes(mtypes, live_cast_types)
+		var poset = poset_from_mtypes(live_types, live_cast_types)
 		var colorer = new POSetColorer[MType]
 		colorer.colorize(poset)
 		type_ids = colorer.ids
@@ -471,7 +466,7 @@ class SeparateCompiler
 		type_tables = build_type_tables(poset)
 
 		# VT and FT are stored with other unresolved types in the big resolution_tables
-		self.compile_resolution_tables(mtypes)
+		self.compile_resolution_tables(live_types)
 
 		return poset
 	end


### PR DESCRIPTION
Instead of doing the full matrix mtypes X cast_types, a grouping is done by the base classes of the types so that we compare only types whose base classes are in inheritance.

For nitc/nitc/nitc the result is not that bad:

before:
0m6.584s
17.605 GIr
time passed in poset_from_mtypes: 26.01% (4.579 GIr)

now:
0m5.880s (-10%)
15.088 GIr (-14%)
time passed in poset_from_mtypes: 11.72% (1.768 GIr)

In the best condition, I can now expect to compile in less than 6s.

Note that coloring is still a MAJOR issue in term of compile time since 1/4 of the Ir are used to compute coloration.

 * type_coloring: 17.23%
 * property_coloring: 9.35%