### PR TITLE
Simplify management of primitive types

### DIFF
--- a/src/astbuilder.nit
+++ b/src/astbuilder.nit
@@ -32,7 +32,7 @@ class ASTBuilder
 	# Make a new Int literal
 	fun make_int(value: Int): AIntExpr
 	do
-		return new ADecIntExpr.make(value, mmodule.get_primitive_class("Int").mclass_type)
+		return new ADecIntExpr.make(value, mmodule.int_type)
 	end
 
 	# Make a new instatiation

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1421,20 +1421,16 @@ abstract class AbstractCompilerVisitor
 	# Generate an integer value
 	fun int_instance(value: Int): RuntimeVariable
 	do
-		var res = self.new_var(self.get_class("Int").mclass_type)
-		self.add("{res} = {value};")
+		var t = mmodule.int_type
+		var res = new RuntimeVariable("{value.to_s}l", t, t)
 		return res
 	end
 
 	# Generate an integer value
 	fun bool_instance(value: Bool): RuntimeVariable
 	do
-		var res = self.new_var(self.get_class("Bool").mclass_type)
-		if value then
-			self.add("{res} = 1;")
-		else
-			self.add("{res} = 0;")
-		end
+		var s = if value then "1" else "0"
+		var res = new RuntimeVariable(s, bool_type, bool_type)
 		return res
 	end
 

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2283,7 +2283,7 @@ redef class AAttrPropdef
 
 				v.assign(res, value)
 				if not useiset then
-					var true_v = v.new_expr("1", v.bool_type)
+					var true_v = v.bool_instance(true)
 					v.write_attribute(guard, arguments.first, true_v)
 				end
 				v.add("\}")
@@ -2298,7 +2298,7 @@ redef class AAttrPropdef
 				var ret = self.mpropdef.static_mtype
 				var useiset = ret.ctype == "val*" and not ret isa MNullableType
 				if not useiset then
-					v.write_attribute(self.mlazypropdef.mproperty, arguments.first, v.new_expr("1", v.bool_type))
+					v.write_attribute(self.mlazypropdef.mproperty, arguments.first, v.bool_instance(true))
 				end
 			end
 		else
@@ -2696,7 +2696,7 @@ redef class AOrElseExpr
 end
 
 redef class AIntExpr
-	redef fun expr(v) do return v.new_expr("{self.value.to_s}", self.mtype.as(not null))
+	redef fun expr(v) do return v.int_instance(self.value.as(not null))
 end
 
 redef class AFloatExpr
@@ -2769,11 +2769,11 @@ redef class AOrangeExpr
 end
 
 redef class ATrueExpr
-	redef fun expr(v) do return v.new_expr("1", self.mtype.as(not null))
+	redef fun expr(v) do return v.bool_instance(true)
 end
 
 redef class AFalseExpr
-	redef fun expr(v) do return v.new_expr("0", self.mtype.as(not null))
+	redef fun expr(v) do return v.bool_instance(false)
 end
 
 redef class ANullExpr

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1426,11 +1426,37 @@ abstract class AbstractCompilerVisitor
 		return res
 	end
 
+	# Generate a char value
+	fun char_instance(value: Char): RuntimeVariable
+	do
+		var t = mmodule.char_type
+		var res = new RuntimeVariable("'{value.to_s.escape_to_c}'", t, t)
+		return res
+	end
+
+	# Generate a float value
+	#
+	# FIXME pass a Float, not a string
+	fun float_instance(value: String): RuntimeVariable
+	do
+		var t = mmodule.float_type
+		var res = new RuntimeVariable("{value}", t, t)
+		return res
+	end
+
 	# Generate an integer value
 	fun bool_instance(value: Bool): RuntimeVariable
 	do
 		var s = if value then "1" else "0"
 		var res = new RuntimeVariable(s, bool_type, bool_type)
+		return res
+	end
+
+	# Generate the `null` value
+	fun null_instance: RuntimeVariable
+	do
+		var t = compiler.mainmodule.model.null_type
+		var res = new RuntimeVariable("((val*)NULL)", t, t)
 		return res
 	end
 
@@ -2696,11 +2722,11 @@ redef class AIntExpr
 end
 
 redef class AFloatExpr
-	redef fun expr(v) do return v.new_expr("{self.n_float.text}", self.mtype.as(not null)) # FIXME use value, not n_float
+	redef fun expr(v) do return v.float_instance("{self.n_float.text}") # FIXME use value, not n_float
 end
 
 redef class ACharExpr
-	redef fun expr(v) do return v.new_expr("'{self.value.to_s.escape_to_c}'", self.mtype.as(not null))
+	redef fun expr(v) do return v.char_instance(self.value.as(not null))
 end
 
 redef class AArrayExpr
@@ -2773,7 +2799,7 @@ redef class AFalseExpr
 end
 
 redef class ANullExpr
-	redef fun expr(v) do return v.new_expr("NULL", self.mtype.as(not null))
+	redef fun expr(v) do return v.null_instance
 end
 
 redef class AIsaExpr

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1078,9 +1078,6 @@ abstract class AbstractCompilerVisitor
 		self.writer = new CodeWriter(compiler.files.last)
 	end
 
-	# Force to get the primitive class named `name` or abort
-	fun get_class(name: String): MClass do return self.compiler.mainmodule.get_primitive_class(name)
-
 	# Force to get the primitive property named `name` in the instance `recv` or abort
 	fun get_property(name: String, recv: MType): MMethod
 	do
@@ -1416,6 +1413,11 @@ abstract class AbstractCompilerVisitor
 		end
 	end
 
+	# The currently processed module
+	#
+	# alias for `compiler.mainmodule`
+	fun mmodule: MModule do return compiler.mainmodule
+
 	# Generate an integer value
 	fun int_instance(value: Int): RuntimeVariable
 	do
@@ -1439,14 +1441,14 @@ abstract class AbstractCompilerVisitor
 	# Generate a string value
 	fun string_instance(string: String): RuntimeVariable
 	do
-		var mtype = self.get_class("String").mclass_type
+		var mtype = mmodule.string_type
 		var name = self.get_name("varonce")
 		self.add_decl("static {mtype.ctype} {name};")
 		var res = self.new_var(mtype)
 		self.add("if (likely({name}!=NULL)) \{")
 		self.add("{res} = {name};")
 		self.add("\} else \{")
-		var native_mtype = self.get_class("NativeString").mclass_type
+		var native_mtype = mmodule.native_string_type
 		var nat = self.new_var(native_mtype)
 		self.add("{nat} = \"{string.escape_to_c}\";")
 		var length = self.int_instance(string.length)

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -402,7 +402,7 @@ class GlobalCompilerVisitor
 
 	redef fun native_array_instance(elttype: MType, length: RuntimeVariable): RuntimeVariable
 	do
-		var ret_type = self.get_class("NativeArray").get_mtype([elttype])
+		var ret_type = mmodule.native_array_type(elttype)
 		ret_type = anchor(ret_type).as(MClassType)
 		return self.new_expr("NEW_{ret_type.c_name}({length})", ret_type)
 	end
@@ -894,10 +894,10 @@ class GlobalCompilerVisitor
 	redef fun array_instance(array, elttype)
 	do
 		elttype = self.anchor(elttype)
-		var arraytype = self.get_class("Array").get_mtype([elttype])
+		var arraytype = mmodule.array_type(elttype)
 		var res = self.init_instance(arraytype)
 		self.add("\{ /* {res} = array_instance Array[{elttype}] */")
-		var nat = self.new_var(self.get_class("NativeArray").get_mtype([elttype]))
+		var nat = self.new_var(mmodule.native_array_type(elttype))
 		nat.is_exact = true
 		self.add("{nat} = NEW_{nat.mtype.c_name}({array.length});")
 		for i in [0..array.length[ do
@@ -991,7 +991,7 @@ private class CustomizedRuntimeFunction
 		for i in [0..mmethoddef.msignature.arity[ do
 			var mtype = mmethoddef.msignature.mparameters[i].mtype
 			if i == mmethoddef.msignature.vararg_rank then
-				mtype = v.get_class("Array").get_mtype([mtype])
+				mtype = v.mmodule.array_type(mtype)
 			end
 			mtype = v.resolve_for(mtype, selfvar)
 			comment.append(", {mtype}")

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -643,7 +643,7 @@ class SeparateErasureCompilerVisitor
 
 	redef fun native_array_instance(elttype, length)
 	do
-		var nclass = self.get_class("NativeArray")
+		var nclass = mmodule.native_array_class
 		var mtype = nclass.get_mtype([elttype])
 		var res = self.new_var(mtype)
 		res.is_exact = true

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -195,31 +195,40 @@ redef class MModule
 	private var flatten_mclass_hierarchy_cache: nullable POSet[MClass] = null
 
 	# The primitive type `Object`, the root of the class hierarchy
-	fun object_type: MClassType
-	do
-		var res = self.object_type_cache
-		if res != null then return res
-		res = self.get_primitive_class("Object").mclass_type
-		self.object_type_cache = res
-		return res
-	end
-
-	private var object_type_cache: nullable MClassType
+	var object_type: MClassType = self.get_primitive_class("Object").mclass_type is lazy
 
 	# The type `Pointer`, super class to all extern classes
 	var pointer_type: MClassType = self.get_primitive_class("Pointer").mclass_type is lazy
 
 	# The primitive type `Bool`
-	fun bool_type: MClassType
-	do
-		var res = self.bool_type_cache
-		if res != null then return res
-		res = self.get_primitive_class("Bool").mclass_type
-		self.bool_type_cache = res
-		return res
-	end
+	var bool_type: MClassType = self.get_primitive_class("Bool").mclass_type is lazy
 
-	private var bool_type_cache: nullable MClassType
+	# The primitive type `Int`
+	var int_type: MClassType = self.get_primitive_class("Int").mclass_type is lazy
+
+	# The primitive type `Char`
+	var char_type: MClassType = self.get_primitive_class("Char").mclass_type is lazy
+
+	# The primitive type `Float`
+	var float_type: MClassType = self.get_primitive_class("Float").mclass_type is lazy
+
+	# The primitive type `String`
+	var string_type: MClassType = self.get_primitive_class("String").mclass_type is lazy
+
+	# The primitive type `NativeString`
+	var native_string_type: MClassType = self.get_primitive_class("NativeString").mclass_type is lazy
+
+	# A primitive type of `Array`
+	fun array_type(elt_type: MType): MClassType do return array_class.get_mtype([elt_type])
+
+	# The primitive class `Array`
+	var array_class: MClass = self.get_primitive_class("Array") is lazy
+
+	# A primitive type of `NativeArray`
+	fun native_array_type(elt_type: MType): MClassType do return native_array_class.get_mtype([elt_type])
+
+	# The primitive class `NativeArray`
+	var native_array_class: MClass = self.get_primitive_class("NativeArray") is lazy
 
 	# The primitive type `Sys`, the main type of the program, if any
 	fun sys_type: nullable MClassType

--- a/src/transform.nit
+++ b/src/transform.nit
@@ -73,12 +73,6 @@ private class TransformVisitor
 		node.full_transform_visitor(self)
 	end
 
-	# Get a primitive class or display a fatal error on `location`.
-	fun get_class(location: AExpr, name: String): MClass
-	do
-		return mmodule.get_primitive_class(name)
-	end
-
 	# Get a primitive method or display a fatal error on `location`.
 	fun get_method(location: AExpr, name: String, recv: MClass): MMethod
 	do

--- a/src/vm.nit
+++ b/src/vm.nit
@@ -177,15 +177,6 @@ class VirtualMachine super NaiveInterpreter
 		recv.vtable = recv.mtype.as(MClassType).mclass.vtable
 	end
 
-	# Create a virtual table for this `MClass` if not already done
-	redef fun get_primitive_class(name: String): MClass
-	do
-		var mclass = super
-
-		if not mclass.loaded then create_class(mclass)
-
-		return mclass
-	end
 
 	# Initialize the internal representation of an object (its attribute values)
 	# `init_instance` is the initial value of attributes


### PR DESCRIPTION
Add direct methods to access primitive types

Simplify and improve the generation of primitive values in the compiler.

More (and improved) `*_instance` methods are now available in AbstractCompilerVisitor.
One of the point is the simplification of the generated C so that less local variables are generated, maybe this will also help the C compiler to work faster.