### PR TITLE
Rewrite the coloration for properties and types.

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -23,6 +23,7 @@ import platform
 import c_tools
 private import annotation
 import mixin
+import counter
 
 # Add compiling options
 redef class ToolContext
@@ -1021,14 +1022,6 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref ) {
 	end
 
 	fun finalize_ffi_for_module(mmodule: MModule) do mmodule.finalize_ffi(self)
-
-	# Division facility
-	# Avoid division by zero by returning the string "n/a"
-	fun div(a,b:Int):String
-	do
-		if b == 0 then return "n/a"
-		return ((a*10000/b).to_f / 100.0).to_precision(2)
-	end
 end
 
 # A file unit (may be more than one file if

--- a/src/compiler/coloring.nit
+++ b/src/compiler/coloring.nit
@@ -274,6 +274,166 @@ class POSetColorer[E: Object]
 	end
 end
 
+# Colorize elements `E` introduced by holders `H` in a `POSet`.
+#
+# Two elements cannot have the same color if they are introduced or inherited by a same holder.
+class POSetGroupColorer[H: Object, E: Object]
+
+	# The associated conflict graph containing the poset.
+	#
+	# The conflict graph is used instead of the original poset so that the conflict graph can be reused
+	# in different coloration based on the same poset.
+	var graph: POSetConflictGraph[H]
+
+	# The elements to color.
+	#
+	# For each holder, the collection of introduced elements is given.
+	#
+	# A single element must not be introduced in more than one holder.
+	var buckets: Map[H, Collection[E]]
+
+	# The associated poset.
+	#
+	# alias for `graph.poset`
+	fun poset: POSet[H] do return graph.poset
+
+	# The resulting coloring
+	#
+	# Each element from buckets is associated to its own color
+	var colors: Map[E, Int] is lazy do
+		for h in graph.poset do
+			used_colors[h] = new HashSet[Int]
+		end
+		compute_colors
+		return colors_cache
+	end
+
+	# Resulting colors
+	private var colors_cache = new HashMap[E, Int]
+
+	# Set of known used colors
+	private var used_colors = new HashMap[H, HashSet[Int]]
+
+	# Build table layout of elements `E` for the holder `h`.
+	#
+	# `null` is used to fill places without elements (holes).
+	fun build_layout(h: H): Array[nullable E]
+	do
+		var table = new Array[nullable E]
+		for s in poset[h].greaters do
+			var bucket = buckets.get_or_null(s)
+			if bucket == null then continue
+			for e in bucket do
+				var color = colors[e]
+				if table.length <= color then
+					for i in [table.length .. color[ do
+						table[i] = null
+					end
+				else
+					assert table[color] == null else print "in {h}, for {color}: {table[color] or else ""} vs {e}"
+				end
+				table[color] = e
+			end
+		end
+		return table
+	end
+
+	# Colorize core, border and crown in that order
+	private fun compute_colors do
+		colors_cache.clear
+		colorize_core
+		colorize_set(graph.border)
+		colorize_set(graph.crown)
+	end
+
+	# Core elements cannot have the same color than:
+	#  * one of their parents
+	#  * one of their conflicting elements
+	private fun colorize_core do
+		for h in graph.order do
+			if not graph.core.has(h) then continue
+
+			var color = inherit_color(h)
+			var mincolor = color
+			var bucket = buckets.get_or_null(h)
+			if bucket == null then continue
+			var conflicts = graph.conflicts[h]
+			var parents = poset[h].greaters
+			for e in bucket do
+				color = next_free_color(color, parents)
+				color = next_free_color(color, conflicts)
+				colors_cache[e] = color
+				used_colors[h].add color
+				#print "{h}: color[{color}] <- {e}"
+				if mincolor == color then mincolor += 1
+				color += 1
+			end
+			min_colors[h] = mincolor
+		end
+	end
+
+	# Other elements inherit color from their direct parents
+	private fun colorize_set(set: Set[H]) do
+		for h in graph.order do
+			if not set.has(h) then continue
+
+			var color = inherit_color(h)
+			var mincolor = color
+			var bucket = buckets.get_or_null(h)
+			if bucket == null then continue
+			var parents = poset[h].greaters
+			for e in bucket do
+				color = next_free_color(color, parents)
+				colors_cache[e] = color
+				used_colors[h].add color
+				#print "{h}: color[{color}] <- {e} (set)"
+				if mincolor == color then mincolor += 1
+				color += 1
+			end
+			min_colors[h] = mincolor
+		end
+	end
+
+	# Get the first available free color.
+	private fun inherit_color(h: H): Int
+	do
+		var res = 0
+		for p in poset[h].direct_greaters do
+			var m = min_colors[p]
+			if m > res then res = m
+		end
+		min_colors[h] = res
+		return res
+	end
+
+	# The first available color for each holder.
+	#
+	# Is used by children to start their coloring.
+	#
+	# Is updated at the end of a coloring step.
+	private var min_colors = new HashMap[H, Int]
+
+	private fun next_free_color(color: Int, set: Collection[H]): Int do
+		loop
+			for h in set do
+				if used_colors[h].has(color) then
+					#print "\tin {h}, {color} is used"
+					color += 1
+					continue label
+				end
+			end
+			break
+		end label
+		return color
+	end
+
+	# Used for debugging only
+	fun pretty_print do
+		print "colors:"
+		for e, c in colors do print "  {e}: {c}"
+	end
+end
+
 # Colorize a collection of buckets
 # Two elements cannot have the same color if they both appear in the same bucket
 # No coloring order is garantied

--- a/src/compiler/coloring.nit
+++ b/src/compiler/coloring.nit
@@ -17,7 +17,7 @@ module coloring
 import poset
 
 # Build a conflict graph from a POSet
-class POSetConflictGraph[E: Object]
+class POSetConflictGraph[E]
 
 	# Core is composed by:
 	#  * elements that have mutiple direct parents
@@ -45,6 +45,7 @@ class POSetConflictGraph[E: Object]
 	# REQUIRE: is_colored
 	var conflicts = new HashMap[E, Set[E]]
 
+	# The associated poset
 	var poset: POSet[E]
 
 	# The linearisation order to visit elements in the poset
@@ -120,8 +121,12 @@ class POSetConflictGraph[E: Object]
 		#print "border: {border.join(" ")} ({border.length})"
 		#print "crown: {crown.join(" ")} ({crown.length})"
 		print "conflicts:"
-		for e, c in conflicts do print "  {e}: {c.join(" ")}"
+		for e, c in conflicts do print "  {e or else "NULL"}: {c.join(" ")}"
 	end
+end
+
+redef class POSet[E]
+	fun to_conflict_graph: POSetConflictGraph[E] do return new POSetConflictGraph[E](self)
 end
 
 # Colorize elements from a POSet

--- a/src/compiler/coloring.nit
+++ b/src/compiler/coloring.nit
@@ -47,11 +47,15 @@ class POSetConflictGraph[E: Object]
 
 	var poset: POSet[E]
 
+	# The linearisation order to visit elements in the poset
+	var order: Array[E] is noinit
+
 	init do
 		extract_core
 		extract_border
 		extract_crown
 		compute_conflicts
+		order = poset.linearize(poset)
 	end
 
 	# Compute the set of elements forming the core of the poset hierarchy.

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -386,7 +386,7 @@ class SeparateCompiler
 		method_tables = new HashMap[MClass, Array[nullable MPropDef]]
 		attr_tables = new HashMap[MClass, Array[nullable MProperty]]
 		for mclass in mclasses do
-			#if mclass.kind == abstract_kind or mclass.kind == interface_kind then continue
+			if not mclass.has_new_factory and (mclass.kind == abstract_kind or mclass.kind == interface_kind) then continue
 			if rta != null and not rta.live_classes.has(mclass) then continue
 
 			var mtype = mclass.intro.bound_mtype

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -199,8 +199,6 @@ class SeparateErasureCompiler
 		var mtype = mclass.intro.bound_mtype
 		var c_name = mclass.c_name
 
-		var vft = self.method_tables[mclass]
-		var attrs = self.attr_tables[mclass]
 		var class_table = self.class_tables[mclass]
 		var v = self.new_visitor
 
@@ -230,7 +228,8 @@ class SeparateErasureCompiler
 			end
 			v.add_decl("&type_table_{c_name},")
 			v.add_decl("\{")
-			for i in [0 .. vft.length[ do
+			var vft = self.method_tables.get_or_null(mclass)
+			if vft != null then for i in [0 .. vft.length[ do
 				var mpropdef = vft[i]
 				if mpropdef == null then
 					v.add_decl("NULL, /* empty */")
@@ -355,11 +354,18 @@ class SeparateErasureCompiler
 
 			var res = v.new_named_var(mtype, "self")
 			res.is_exact = true
-			v.add("{res} = nit_alloc(sizeof(struct instance) + {attrs.length}*sizeof(nitattribute_t));")
+			var attrs = self.attr_tables.get_or_null(mclass)
+			if attrs == null then
+				v.add("{res} = nit_alloc(sizeof(struct instance));")
+			else
+				v.add("{res} = nit_alloc(sizeof(struct instance) + {attrs.length}*sizeof(nitattribute_t));")
+			end
 			v.require_declaration("class_{c_name}")
 			v.add("{res}->class = &class_{c_name};")
-			self.generate_init_attr(v, res, mtype)
-			v.set_finalizer res
+			if attrs != null then
+				self.generate_init_attr(v, res, mtype)
+				v.set_finalizer res
+			end
 			v.add("return {res};")
 		end
 		v.add("\}")

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -468,6 +468,9 @@ class MClass
 	end
 
 	private var get_mtype_cache = new HashMap[Array[MType], MGenericType]
+
+	# Is there a `new` factory to allow the pseudo instantiation?
+	var has_new_factory = false is writable
 end
 
 

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -735,6 +735,7 @@ redef class AMethPropdef
 			end
 			mprop.is_init = is_init
 			mprop.is_new = n_kwnew != null
+			if mprop.is_new then mclassdef.mclass.has_new_factory = true
 			if parent isa ATopClassdef then mprop.is_toplevel = true
 			self.check_redef_keyword(modelbuilder, mclassdef, n_kwredef, false, mprop)
 		else


### PR DESCRIPTION
This introduce a new colorer, `POSetGroupColorer` that colors elements introduced by the classes in a class-hierarchy.
The advantage of this new colorer is that it uses conflict graphs of classes to colorize elements.
By comparison, the previously used colorers work with conflict graphs of elements; that are therefore much larger.

An other advantage is that only the introductions of elements are needed by the colorer, so filling the information from the model is far more easier.

The construction of the poset of types is also removed.
Instead, subtyping tables are computed with a more standard way:

* target cast types are grouped by classes: a map class->types is created
* the map is colored: a table layout by class is computed
* for each live type, the table layout of the associated class is used to build the type table

Results are so good that most of the time of the coloring is removed.

For nitc/nitc/nit

Before:

user: 0m6.044s
total: 15096 MIr
do_property_coloring: 1420 MIr
do_type_coloring: 2600 MIr

After:

user: 0m5.608s (-7%)
total: 12800 MIr (-15%)
do_property_coloring: 452 MIr (-68%)
do_type_coloring: 895 MIr (-65%)

note that in the previous numbers, most of the time is done in the model to inherit or resolve things.
Pure coloring algorithm is now negligible:

conflict_graph: 34 MIr (<1% of the total Ir)
coloring: 60 MIr (<1% of the total Ir)

Unfortunately, with types the coloring can degenerate and produce big tables. If this is an issue, the options `--type-poset` use the previous coloring method for types