### PR TITLE
lib/std/file: do not flush on each write

### DIFF
--- a/lib/standard/exec.nit
+++ b/lib/standard/exec.nit
@@ -129,7 +129,9 @@ class ProcessWriter
 	redef fun execute
 	do
 		super
-		stream_out = new FileWriter.from_fd(data.in_fd)
+		var out = new FileWriter.from_fd(data.in_fd)
+		out.set_buffering_mode(0, sys.buffer_mode_none)
+		stream_out = out
 	end
 end
 

--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -150,7 +150,6 @@ class FileWriter
 		else
 			for i in s.substrings do write_native(i.to_cstring, i.length)
 		end
-		_file.flush
 	end
 
 	redef fun close


### PR DESCRIPTION
Flushing for each small element of an output made things too slow.

real (not user) time for nitc/nitc/nitc:
before: 0m7.373s
after: 0m5.901s (-20%)