### PR TITLE
Fast benches

### DIFF
--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -77,7 +77,7 @@ function run_compiler()
 		bench_command "nitmd" "markdown" "./nitmd.$title.bin" markdown/benches/out/mixed.md 80
 	fi
 
-	rm -r *.bin .nit_compile out
+	rm -r *.bin .nit_compile out 2> /dev/null
 }
 
 ## HANDLE OPTIONS ##

--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -43,7 +43,10 @@ function run_compiler()
 {
 	local title=$1
 	shift
-	if test -n "$fast"; then
+	if test "$fast" = truetrue; then
+		run_command "$@" ../examples/hello_world.nit -o "hello.$title.bin"
+		bench_command "hello" "hello_world" "./hello.$title.bin"
+	elif test -n "$fast"; then
 		run_command "$@" ../src/nitc.nit -o "nitc.$title.bin"
 		bench_command "nitc-g" "nitc --global ../src/test_parser.nit" "./nitc.$title.bin" -v --global --no-cc ../src/test_parser.nit
 		run_command "$@" ../src/nit.nit -o "nit.$title.bin"
@@ -100,7 +103,7 @@ while [ "$stop" = false ]; do
 		-h) usage; exit;;
 		-n) count="$2"; shift; shift;;
 		--dry) dry_run=true; shift;;
-		--fast) fast=true; shift;;
+		--fast) fast=true$fast; shift;;
 		--html) html="index.html"; echo >"$html" "<html><head></head><body>"; shift;;
 		*) stop=true
 	esac

--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -186,10 +186,10 @@ function bench_nitc_options()
 	run_compiler "nitc-$name" ./nitc $common
 
 	if test "$1" = NOALL; then
+		withall=
 		shift
-	elif test -n "$2"; then
-		prepare_res "$name-all.dat" "all" "nitc-g with all options $@"
-		run_compiler "nitc-$name" ./nitc $common $@
+	else
+		withall=true
 	fi
 
 	for opt in "$@"; do
@@ -197,6 +197,11 @@ function bench_nitc_options()
 		prepare_res "$name$ot.dat" "$opt" "nitc-g with option $opt"
 		run_compiler "nitc-$name" ./nitc $common $opt
 	done
+
+	if test -n "$2" -a -n "$withall"; then
+		prepare_res "$name-all.dat" "all" "nitc-g with all options $@"
+		run_compiler "nitc-$name" ./nitc $common $@
+	fi
 
 	plot "$name.gnu"
 }


### PR DESCRIPTION
Last week benches shows some failures on some options due to recent commits.

This PR add a `--fast --fast` option that test only `hello_world` so it could be used in continuous integration to test the various meaningful combination of compiling options.

Moreover, the script is simplified to be more simple to use and extends with new options or combination of options,