### PR TITLE
Improve loader

### DIFF
--- a/src/loader.nit
+++ b/src/loader.nit
@@ -389,12 +389,15 @@ redef class ModelBuilder
 			return mgroups[rdp]
 		end
 
-		# Hack, a group is determined by:
+		# Hack, a group is determined by one of the following:
 		# * the presence of a honomymous nit file
 		# * the fact that the directory is named `src`
+		# * the fact that there is a sub-directory named `src`
 		var pn = rdp.basename(".nit")
 		var mp = dirpath.join_path(pn + ".nit").simplify_path
 
+		# dirpath2 is the root directory
+		# dirpath is the src subdirectory directory, if any, else it is the same that dirpath2
 		var dirpath2 = dirpath
 		if not mp.file_exists then
 			if pn == "src" then
@@ -402,12 +405,17 @@ redef class ModelBuilder
 				dirpath2 = rdp.dirname
 				pn = dirpath2.basename("")
 			else
-				return null
+				# Check a `src` subdirectory
+				dirpath = dirpath2 / "src"
+				if not dirpath.file_exists then
+					# All rules failed, so return null
+					return null
+				end
 			end
 		end
 
 		# check parent directory
-		var parentpath = dirpath.join_path("..").simplify_path
+		var parentpath = dirpath2.join_path("..").simplify_path
 		var parent = get_mgroup(parentpath)
 
 		var mgroup
@@ -435,7 +443,8 @@ redef class ModelBuilder
 		end
 
 		mgroup.filepath = dirpath
-		mgroups[rdp] = mgroup
+		mgroups[module_absolute_path(dirpath)] = mgroup
+		mgroups[module_absolute_path(dirpath2)] = mgroup
 		return mgroup
 	end
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -421,13 +421,19 @@ redef class ModelBuilder
 			mgroup = new MGroup(pn, parent.mproject, parent)
 			toolcontext.info("found sub group `{mgroup.full_name}` at {dirpath}", 2)
 		end
-		var readme = dirpath2.join_path("README.md")
+
+		# search documentation
+		# in src first so the documentation of the project code can be distinct for the documentation of the project usage
+		var readme = dirpath.join_path("README.md")
+		if not readme.file_exists then readme = dirpath.join_path("README")
+		if not readme.file_exists then readme = dirpath2.join_path("README.md")
 		if not readme.file_exists then readme = dirpath2.join_path("README")
 		if readme.file_exists then
 			var mdoc = load_markdown(readme)
 			mgroup.mdoc = mdoc
 			mdoc.original_mentity = mgroup
 		end
+
 		mgroup.filepath = dirpath
 		mgroups[rdp] = mgroup
 		return mgroup

--- a/src/test_phase.nit
+++ b/src/test_phase.nit
@@ -62,6 +62,6 @@ var model = new Model
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
 # Here we load an process all modules passed on the command line
-var mmodules = modelbuilder.parse(arguments)
+var mmodules = modelbuilder.parse_full(arguments)
 modelbuilder.run_phases
 toolcontext.run_global_phases(mmodules)


### PR DESCRIPTION
This PR improves the loader that can now accepts

* directories of projects: to load all modules of all projects (eg `contrib`)
* root directories of groups: to load all modules of the groups (eg `contrib/benitlux`).
  Previously, this worked if there was no `src` subdirectory)

This works for tools that rely on full_parse (basically all tools except the engines).

~~~sh
$ ./test_test_phase ../lib -q
It works
I have 89 projects
I have 285 modules
I have 1038 classes
For 1366 definitions of classes
I have 7101 methods
For 9098 definitions of methods
~~~

Note that if any files has an error most tools will just stop.