### PR TITLE
lib/standard/string: Added faster to_cstring method on FlatText.

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2204,6 +2204,9 @@ redef class AMethPropdef
 			else if pname == "atoi" then
 				v.ret(v.new_expr("atoi({arguments[0]});", ret.as(not null)))
 				return true
+			else if pname == "fast_cstring" then
+				v.ret(v.new_expr("{arguments[0]} + {arguments[1]}", ret.as(not null)))
+				return true
 			else if pname == "new" then
 				v.ret(v.new_expr("(char*)nit_alloc({arguments[1]})", ret.as(not null)))
 				return true

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -1016,6 +1016,9 @@ redef class AMethPropdef
 				return v.int_instance(res)
 			else if pname == "atof" then
 				return v.float_instance(recvval.to_f)
+			else if pname == "fast_cstring" then
+				var ns = recvval.to_cstring.to_s.substring_from(args[1].to_i)
+				return v.native_string_instance(ns)
 			end
 		else if cname == "String" then
 			var cs = v.send(v.force_get_primitive_method("to_cstring", args.first.mtype), [args.first])


### PR DESCRIPTION
Adds a service for quick cstring in `FlatTexts`, this is mainly to speedup some methods like `write_native`, which takes a cstring in input.

This just creates a new pointer to the same `char*` with an offset.

Since no copy is ever made, its use is highly discouraged in extern code or in cases other than ephemereal uses of the resulting `NativeString`.

Since it adds a new intern service, it cannot be used as is in the standard library as it will need a regeneration of c_src beforehand.