### PR TITLE
Test compilation of OS X and iOS programs, on OS X

### DIFF
--- a/tests/sav/hello_ios.res
+++ b/tests/sav/hello_ios.res
@@ -1,0 +1,4 @@
+out/hello_ios.bin
+out/hello_ios.bin/Info.plist
+out/hello_ios.bin/PkgInfo
+out/hello_ios.bin/hello_ios

--- a/tests/sav/test_platform_ios.res
+++ b/tests/sav/test_platform_ios.res
@@ -1,0 +1,4 @@
+out/test_platform_ios.bin
+out/test_platform_ios.bin/Info.plist
+out/test_platform_ios.bin/PkgInfo
+out/test_platform_ios.bin/test_platform_ios

--- a/tests/testosx.sh
+++ b/tests/testosx.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests to run on OS X for the host platform and iOS
+./tests.sh $@ \
+	test_ffi_objc_*.nit \
+	test_*ios.nit \
+	../lib/ios/examples/*.nit \
+	../lib/cocoa*/examples/*.nit

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -69,7 +69,9 @@ saferun()
 			*) stop=true
 		esac
 	done
-	if test -n "$TIME"; then
+	if test -d "$1"; then
+		find $1 | sort
+	elif test -n "$TIME"; then
 		$TIME -o "$o" $a $TIMEOUT "$@"
 	else
 		if test -n "$a"; then echo 0 >> "$o"; else echo 0 > "$o"; fi


### PR DESCRIPTION
The results of the compilation of iOS apps by XCode are directories. This PR fix tests.sh to detect those directory and report them cleanly.

Also intro a script for running OS X specific tests.