### PR TITLE
Unite app.nit metadata annotations common to Android and iOS

### DIFF
--- a/examples/calculator/src/calculator_android.nit
+++ b/examples/calculator/src/calculator_android.nit
@@ -18,7 +18,7 @@
 module calculator_android is
 	app_name "app.nit Calc."
 	app_version(0, 1, git_revision)
-	java_package "org.nitlanguage.calculator"
+	app_namespace "org.nitlanguage.calculator"
 
 	# Lock in portrait mode
 	android_manifest_activity """android:screenOrientation="portrait""""

--- a/examples/mnit_dino/src/dino_android.nit
+++ b/examples/mnit_dino/src/dino_android.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module dino_android is
-	java_package("org.nitlanguage.dino")
+	app_namespace "org.nitlanguage.dino"
 end
 
 import dino

--- a/examples/mnit_simple/src/complete_simple_android.nit
+++ b/examples/mnit_simple/src/complete_simple_android.nit
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 module complete_simple_android is
-	java_package("org.nitlanguage.test_all")
-	target_api_version(19)
+	app_namespace "org.nitlanguage.test_all"
+	target_api_version 19
 end
 
 import test_bundle

--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -32,7 +32,7 @@ as the launcher name.
 
     Example: `app_name "My App"`
 
-* `java_package` specifies the package used by the generated Java
+* `app_namespace` specifies the package used by the generated Java
 classes and the APK file. Once the application is published, this
 value should not be changed. By default, the compiler will use
 the package `org.nitlanguage.{module_name}`.

--- a/lib/android/aware.nit
+++ b/lib/android/aware.nit
@@ -20,7 +20,6 @@
 # used to tag `ldflags` annotations.
 module aware is
 	new_annotation android
-	new_annotation java_package
 	new_annotation min_api_version
 	new_annotation max_api_version
 	new_annotation target_api_version

--- a/lib/android/examples/src/ui_test.nit
+++ b/lib/android/examples/src/ui_test.nit
@@ -16,9 +16,9 @@
 
 # Test for app.nit's UI services
 module ui_test is
-	app_name("app.nit UI test")
+	app_name "app.nit UI test"
 	app_version(0, 1, git_revision)
-	java_package("org.nitlanguage.ui_test")
+	app_namespace "org.nitlanguage.ui_test"
 	android_manifest_activity """android:theme="@android:style/Theme.Light""""
 end
 

--- a/lib/app/app_base.nit
+++ b/lib/app/app_base.nit
@@ -16,6 +16,7 @@
 
 module app_base is
 	new_annotation app_name
+	new_annotation app_namespace
 	new_annotation app_version
 end
 

--- a/lib/ios/examples/hello_ios.nit
+++ b/lib/ios/examples/hello_ios.nit
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 # Simple iOS app with a single label
-module hello_ios
+module hello_ios is
+	app_name "Hello iOS"
+	app_namespace "nit.app.hello_ios"
+	app_version(0, 5, git_revision)
+end
 
 import ios
 

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -300,15 +300,8 @@ class MakefileToolchain
 	# Get the default name of the executable to produce
 	fun default_outname: String
 	do
-		var mainmodule = compiler.mainmodule
-
-		# Search a non fictive module
-		var res = mainmodule.name
-		while mainmodule.is_fictive do
-			mainmodule = mainmodule.in_importation.direct_greaters.first
-			res = mainmodule.name
-		end
-		return res
+		var mainmodule = compiler.mainmodule.first_real_mmodule
+		return mainmodule.name
 	end
 
 	# Combine options and platform informations to get the final path of the outfile

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -243,5 +243,15 @@ class MModule
 	# Is `self` a unit test module used by `nitunit`?
 	var is_test_suite: Bool = false is writable
 
+	# Get the first non `is_fictive` module greater than self
+	fun first_real_mmodule: MModule
+	do
+		var mmodule = self
+		while mmodule.is_fictive do
+			mmodule = mmodule.in_importation.direct_greaters.first
+		end
+		return mmodule
+	end
+
 	redef fun parent_concern do return mgroup
 end

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -63,19 +63,17 @@ class AndroidToolchain
 	do
 		var android_project_root = android_project_root.as(not null)
 		var project = new AndroidProject(toolcontext.modelbuilder, compiler.mainmodule)
-		var short_project_name = compiler.mainmodule.name.replace("-", "_")
 		var release = toolcontext.opt_release.value
 
 		var app_name = project.name
-		if app_name == null then app_name = compiler.mainmodule.name
 		if not release then app_name += " Debug"
 
+		var short_project_name = project.short_name
+
 		var app_package = project.namespace
-		if app_package == null then app_package = "org.nitlanguage.{short_project_name}"
 		if not release then app_package += "_debug"
 
 		var app_version = project.version
-		if app_version == null then app_version = "1.0"
 
 		var app_min_api = project.min_api
 		if app_min_api == null then app_min_api = 10

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -62,7 +62,7 @@ class AndroidToolchain
 	redef fun write_files(compile_dir, cfiles)
 	do
 		var android_project_root = android_project_root.as(not null)
-		var project = toolcontext.modelbuilder.android_project_for(compiler.mainmodule)
+		var project = new AndroidProject(toolcontext.modelbuilder, compiler.mainmodule)
 		var short_project_name = compiler.mainmodule.name.replace("-", "_")
 		var release = toolcontext.opt_release.value
 
@@ -70,7 +70,7 @@ class AndroidToolchain
 		if app_name == null then app_name = compiler.mainmodule.name
 		if not release then app_name += " Debug"
 
-		var app_package = project.java_package
+		var app_package = project.namespace
 		if app_package == null then app_package = "org.nitlanguage.{short_project_name}"
 		if not release then app_package += "_debug"
 

--- a/src/platform/android_annotations.nit
+++ b/src/platform/android_annotations.nit
@@ -14,29 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Annotations to gather metadata on Android projects. Get the metadata
-# by calling `ModelBuilder::android_project_for`.
+# Additionnal annotations to gather metadata on Android projects
 module android_annotations
 
-private import parser_util
-import modelize
-import literal
-import semantize
-private import annotation
+intrude import app_annotations
 
 # Metadata associated to an Android project
 class AndroidProject
-	# Name of the resulting application
-	var name: nullable String = null
-
-	# Java package used to identify the APK
-	var java_package: nullable String = null
-
-	# Version of the Android application and APK
-	var version: nullable String = null
-
-	# Numerical version code of the Android application and APK
-	var version_code: Int = 0
+	super AppProject
 
 	# Custom lines to add to the AndroidManifest.xml in the <manifest> node
 	var manifest_lines = new Array[String]
@@ -59,134 +44,48 @@ class AndroidProject
 	# Activities to declare in the manifest
 	var activities = new Array[String]
 
-	redef fun to_s do return """
-name: {{{name or else "null"}}}
-namespace: {{{java_package or else "null"}}}
-version: {{{version or else "null"}}}"""
-end
-
-redef class ModelBuilder
-	# Get the `AndroidProject` gathered from `mmodule` and its importations
-	fun android_project_for(mmodule: MModule): AndroidProject
+	init
 	do
-		var project = new AndroidProject
-
-		var annot = lookup_annotation_on_modules("app_name", mmodule)
-		if annot != null then project.name = annot.arg_as_string(self)
-
-		annot =  lookup_annotation_on_modules("app_version", mmodule)
-		if annot != null then project.version =  annot.as_version(self)
-
-		annot = lookup_annotation_on_modules("java_package", mmodule)
-		if annot != null then project.java_package = annot.arg_as_string(self)
-
-		var annots = collect_annotations_on_modules("min_api_version", mmodule)
+		var annots = modelbuilder.collect_annotations_on_modules("min_api_version", mainmodule)
 		if not annots.is_empty then
-			var i = annots.pop.arg_as_int(self)
+			var i = annots.pop.arg_as_int(modelbuilder)
 			if i == null then i = 0
-			project.min_api = i
+			min_api = i
 			for an in annots do
-				i = an.arg_as_int(self)
+				i = an.arg_as_int(modelbuilder)
 				if i == null then continue
-				project.min_api = project.min_api.max(i)
+				min_api = min_api.max(i)
 			end
 		end
 
-		annots = collect_annotations_on_modules("max_api_version", mmodule)
+		annots = modelbuilder.collect_annotations_on_modules("max_api_version", mainmodule)
 		if not annots.is_empty then
-			var i = annots.pop.arg_as_int(self)
+			var i = annots.pop.arg_as_int(modelbuilder)
 			if i == null then i = 0
-			project.max_api = i
+			max_api = i
 			for an in annots do
-				i = an.arg_as_int(self)
+				i = an.arg_as_int(modelbuilder)
 				if i == null then continue
-				project.max_api = project.max_api.min(i)
+				max_api = max_api.min(i)
 			end
 		end
 
-		annot = lookup_annotation_on_modules("target_api_version", mmodule)
-		if annot != null then project.target_api = annot.arg_as_int(self) or else 0
+		var annot = modelbuilder.lookup_annotation_on_modules("target_api_version", mainmodule)
+		if annot != null then target_api = annot.arg_as_int(modelbuilder) or else 0
 
-		annots = collect_annotations_on_modules("android_manifest", mmodule)
-		for an in annots do project.manifest_lines.add an.arg_as_string(self) or else ""
+		annots = modelbuilder.collect_annotations_on_modules("android_manifest", mainmodule)
+		for an in annots do manifest_lines.add an.arg_as_string(modelbuilder) or else ""
 
-		annots = collect_annotations_on_modules("android_manifest_application", mmodule)
-		for an in annots do project.manifest_application_lines.add an.arg_as_string(self) or else ""
+		annots = modelbuilder.collect_annotations_on_modules("android_manifest_application", mainmodule)
+		for an in annots do manifest_application_lines.add an.arg_as_string(modelbuilder) or else ""
 
-		annots = collect_annotations_on_modules("android_manifest_activity", mmodule)
-		for an in annots do project.manifest_activity_attributes.add an.arg_as_string(self) or else ""
+		annots = modelbuilder.collect_annotations_on_modules("android_manifest_activity", mainmodule)
+		for an in annots do manifest_activity_attributes.add an.arg_as_string(modelbuilder) or else ""
 
-		annots = collect_annotations_on_modules("android_activity", mmodule)
+		annots = modelbuilder.collect_annotations_on_modules("android_activity", mainmodule)
 		for an in annots do
-			var activity = an.arg_as_string(self)
-			if activity != null then project.activities.add activity
+			var activity = an.arg_as_string(modelbuilder)
+			if activity != null then activities.add activity
 		end
-
-		# Get the date and time (down to the minute) as string
-		var local_time = new Tm.localtime
-		var local_time_s = local_time.strftime("%y%m%d%H%M")
-		project.version_code = local_time_s.to_i
-
-		toolcontext.check_errors
-
-		return project
-	end
-end
-
-redef class AAnnotation
-	# Returns a version string (example: "1.5.6b42a7c") from an annotation `version(1, 5, git_revision)`.
-	#
-	# The user can enter as many fields as needed. The call to `git_revision` will be replaced by the short
-	# revision number. If the working tree is dirty, it will append another field with "d" for dirty.
-	private fun as_version(modelbuilder: ModelBuilder): String
-	do
-		var version_fields = new Array[Object]
-
-		var args = n_args
-		if args.length < 1 then
-			modelbuilder.error(self, "Annotation error: \"{name}\" expects at least a single argument.")
-			return ""
-		else
-			for arg in args do
-				var format_error = "Annotation error: \"{name}\" expects its arguments to be of type Int or a call to `git_revision`"
-
-				var value
-				value = arg.as_int
-				if value != null then
-					version_fields.add value
-					continue
-				end
-
-				value = arg.as_string
-				if value != null then
-					version_fields.add value
-				end
-
-				value = arg.as_id
-				if value == "git_revision" then
-					# Get Git short revision
-					var proc = new ProcessReader("git", "rev-parse", "--short", "HEAD")
-					proc.wait
-					assert proc.status == 0
-					var lines = proc.read_all
-					var revision = lines.split("\n").first
-
-					# Is it dirty?
-					# If not, the return of `git diff --shortstat` is an empty line
-					proc = new ProcessReader("git", "diff-index", "--quiet", "HEAD")
-					proc.wait
-					var dirty = proc.status != 0
-					if dirty then revision += ".d"
-
-					version_fields.add revision
-					continue
-				end
-
-				modelbuilder.error(self, format_error)
-				return ""
-			end
-		end
-
-		return version_fields.join(".")
 	end
 end

--- a/src/platform/app_annotations.nit
+++ b/src/platform/app_annotations.nit
@@ -1,0 +1,122 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Annotations to gather metadata on `app.nit` projects
+module app_annotations
+
+private import parser_util
+import modelize
+import literal
+import semantize
+private import annotation
+
+# Metadata associated to an Android project
+class AppProject
+	# Name of the resulting application
+	var name: nullable String = null
+
+	# Namespace/package used to identify the application
+	var namespace: nullable String = null
+
+	# Version of the application
+	var version: nullable String = null
+
+	# Numerical version code of the application
+	var version_code: Int = 0
+
+	private var modelbuilder: ModelBuilder
+	private var mainmodule: MModule
+
+	init
+	do
+		var annot = modelbuilder.lookup_annotation_on_modules("app_name", mainmodule)
+		if annot != null then name = annot.arg_as_string(modelbuilder)
+
+		annot = modelbuilder.lookup_annotation_on_modules("app_version", mainmodule)
+		if annot != null then version = annot.as_version(modelbuilder)
+
+		annot = modelbuilder.lookup_annotation_on_modules("app_namespace", mainmodule)
+		if annot != null then namespace = annot.arg_as_string(modelbuilder)
+
+		# Get the date and time (down to the minute) as string
+		var local_time = new Tm.localtime
+		var local_time_s = local_time.strftime("%y%m%d%H%M")
+		version_code = local_time_s.to_i
+
+		modelbuilder.toolcontext.check_errors
+	end
+
+	redef fun to_s do return """
+name: {{{name or else "null"}}}
+namespace: {{{namespace or else "null"}}}
+version: {{{version or else "null"}}}"""
+end
+
+redef class AAnnotation
+	# Returns a version string (example: "1.5.6b42a7c") from an annotation `version(1, 5, git_revision)`.
+	#
+	# The user can enter as many fields as needed. The call to `git_revision` will be replaced by the short
+	# revision number. If the working tree is dirty, it will append another field with "d" for dirty.
+	private fun as_version(modelbuilder: ModelBuilder): String
+	do
+		var version_fields = new Array[Object]
+
+		var args = n_args
+		if args.length < 1 then
+			modelbuilder.error(self, "Annotation error: \"{name}\" expects at least a single argument.")
+			return ""
+		else
+			for arg in args do
+				var format_error = "Annotation error: \"{name}\" expects its arguments to be of type Int or a call to `git_revision`"
+
+				var value
+				value = arg.as_int
+				if value != null then
+					version_fields.add value
+					continue
+				end
+
+				value = arg.as_string
+				if value != null then
+					version_fields.add value
+				end
+
+				value = arg.as_id
+				if value == "git_revision" then
+					# Get Git short revision
+					var proc = new ProcessReader("git", "rev-parse", "--short", "HEAD")
+					proc.wait
+					assert proc.status == 0
+					var lines = proc.read_all
+					var revision = lines.split("\n").first
+
+					# Is it dirty?
+					# If not, the return of `git diff --shortstat` is an empty line
+					proc = new ProcessReader("git", "diff-index", "--quiet", "HEAD")
+					proc.wait
+					var dirty = proc.status != 0
+					if dirty then revision += ".d"
+
+					version_fields.add revision
+					continue
+				end
+
+				modelbuilder.error(self, format_error)
+				return ""
+			end
+		end
+
+		return version_fields.join(".")
+	end
+end

--- a/src/platform/app_annotations.nit
+++ b/src/platform/app_annotations.nit
@@ -21,19 +21,28 @@ import literal
 import semantize
 private import annotation
 
-# Metadata associated to an Android project
+# Metadata associated to an `app.nit` project
 class AppProject
-	# Name of the resulting application
-	var name: nullable String = null
+	# Pretty name of the resulting application
+	var name: String = mainmodule.first_real_mmodule.name is lazy
+
+	# Short project name used in `namespace` and configuration files
+	var short_name: String = mainmodule.name.replace("-", "_") is lazy
 
 	# Namespace/package used to identify the application
-	var namespace: nullable String = null
+	var namespace = "org.nitlanguage.{short_name}" is lazy
 
 	# Version of the application
-	var version: nullable String = null
+	var version = "0.1"
 
 	# Numerical version code of the application
-	var version_code: Int = 0
+	var version_code: Int is lazy do
+
+		# Get the date and time (down to the minute) as string
+		var local_time = new Tm.localtime
+		var local_time_s = local_time.strftime("%y%m%d%H%M")
+		return local_time_s.to_i
+	end
 
 	private var modelbuilder: ModelBuilder
 	private var mainmodule: MModule
@@ -41,18 +50,19 @@ class AppProject
 	init
 	do
 		var annot = modelbuilder.lookup_annotation_on_modules("app_name", mainmodule)
-		if annot != null then name = annot.arg_as_string(modelbuilder)
+		if annot != null then
+			var val = annot.arg_as_string(modelbuilder)
+			if val != null then name = val
+		end
 
 		annot = modelbuilder.lookup_annotation_on_modules("app_version", mainmodule)
 		if annot != null then version = annot.as_version(modelbuilder)
 
 		annot = modelbuilder.lookup_annotation_on_modules("app_namespace", mainmodule)
-		if annot != null then namespace = annot.arg_as_string(modelbuilder)
-
-		# Get the date and time (down to the minute) as string
-		var local_time = new Tm.localtime
-		var local_time_s = local_time.strftime("%y%m%d%H%M")
-		version_code = local_time_s.to_i
+		if annot != null then
+			var val = annot.arg_as_string(modelbuilder)
+			if val != null then namespace = val
+		end
 
 		modelbuilder.toolcontext.check_errors
 	end

--- a/src/platform/xcode_templates.nit
+++ b/src/platform/xcode_templates.nit
@@ -627,8 +627,17 @@ end
 class PlistTemplate
 	super Template
 
-	# Package of the app
-	var package_name: String
+	# Value of CFBundleName, pretty name of the application
+	var product_name: String
+
+	# Value of CFBundleIdentifier, namespace of the app
+	var bundle_identifier: String
+
+	# Value of CFBundleShortVersionString, human readable version
+	var short_version: String
+
+	# Value of CFBundleVersion, often a revision number
+	var bundle_version: String
 
 	redef fun rendering
 	do
@@ -642,19 +651,19 @@ class PlistTemplate
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>{{{package_name}}}.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>{{{bundle_identifier}}}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>{{{product_name}}}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>{{{short_version}}}</string>
 	<key>CFBundleSignature</key>
 	<string>\\?\\?\\?\\?</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>{{{bundle_version}}}</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
* Rename the annotation `java_package` to `app_namespace`.
* Move up `app_name`, `app_version` and `app_namespace` and their default values from the Android platform.
* Apply these annotations in iOS too.
* Use the annotations in Hello iOS.