### PR TITLE
Bench markdown --semi-global

### DIFF
--- a/benchmarks/markdown/bench_markdown.sh
+++ b/benchmarks/markdown/bench_markdown.sh
@@ -74,7 +74,7 @@ engdir="./engines"
 bncdir="./benches/out"
 mkdir -p $outdir
 
-s=50
+s=200
 
 function bench_nitmd()
 {

--- a/benchmarks/markdown/bench_markdown.sh
+++ b/benchmarks/markdown/bench_markdown.sh
@@ -88,6 +88,18 @@ function bench_nitmd()
 }
 bench_nitmd
 
+function bench_nitmd-o()
+{
+	name="$FUNCNAME"
+	skip_test "$name" && return
+	prepare_res $outdir/nitmd-o.dat "nitmd-o" "nitmd-o"
+	for file in $bncdir/*.md; do
+		bench=`basename $file .md`
+		bench_command "$bench" "" "$engdir/nitmd/nitmd-o" "$file" "$s"
+	done
+}
+bench_nitmd-o
+
 function bench_txtmark()
 {
 	name="$FUNCNAME"

--- a/benchmarks/markdown/engines/nitmd/Makefile
+++ b/benchmarks/markdown/engines/nitmd/Makefile
@@ -14,11 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+all: nitmd nitmd-o
+
 nitmd:
 	nitc nitmd.nit
 
-test: nitmd
+nitmd-o:
+	nitc --semi-global nitmd.nit -o $@
+
+test: all
 	./nitmd ../../benches/hello.md 5
+	./nitmd-o ../../benches/hello.md 5
 
 clean:
-	rm -rf nitmd
+	rm -rf nitmd nitmd-o


### PR DESCRIPTION
Add a second nitmd engine compiled with --semi-global.

One can see that it helps to win against some java impl.

![](https://cloud.githubusercontent.com/assets/135828/6934753/ffe2f672-d863-11e4-8961-75b03e566da9.png)
