### PR TITLE
parser: add a basic sabblecc3 parser in Java

### DIFF
--- a/src/parser/.gitignore
+++ b/src/parser/.gitignore
@@ -1,0 +1,5 @@
+*.class
+org/nitlanguage/gen/analysis/
+org/nitlanguage/gen/lexer/
+org/nitlanguage/gen/node/
+org/nitlanguage/gen/parser/

--- a/src/parser/Makefile
+++ b/src/parser/Makefile
@@ -38,3 +38,8 @@ maintainer-clean: clean
 	@echo "This command is intended for maintainers to use;"
 	@echo "it deletes files that may require special tools to rebuild."
 	rm -f -- parser.nit parser_abs.nit parser_prod.nit lexer.nit || true
+
+java: .nit.sablecc3
+	rm -r org/nitlanguage/gen/analysis/ org/nitlanguage/gen/lexer/ org/nitlanguage/gen/node/ org/nitlanguage/gen/parser/
+	${SABLECC3ALTGEN} .nit.sablecc3 -c .nit.sablecc3.dump
+	javac org/nitlanguage/gen/TestParser.java

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -27,7 +27,7 @@ In order to simplify the development of the Nit tools, files produced by the par
 * parser_nodes.nit: token and nodes classes hierarchy used by the parser and the lexer
 * tables.nit, tables_nit.h: Interfaces to access the tables needed by the parser and the lexer
 * xss/*.xss: alternate SableCC3 template files for the Nit language
-
+* org/nitlanguage/gen: A Nit parser in Java, used for tests. use the `make java` rule to build it.
 
 The following are generated but present to avoid the need of sablecc3:
 

--- a/src/parser/org/nitlanguage/gen/TestParser.java
+++ b/src/parser/org/nitlanguage/gen/TestParser.java
@@ -1,0 +1,56 @@
+/* This file is part of NIT ( http://www.nitlanguage.org ).
+ *
+ * This file is free software, which comes along with NIT.  This software is
+ * distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without  even  the implied warranty of  MERCHANTABILITY or  FITNESS FOR A
+ * PARTICULAR PURPOSE.  You can modify it is you want,  provided this header
+ * is kept unaltered, and a notification of the changes is added.
+ * You  are  allowed  to  redistribute it and sell it, alone or is a part of
+ * another product.
+ */
+
+package org.nitlanguage.gen;
+
+import java.io.*;
+import java.nio.file.*;
+
+import org.nitlanguage.gen.lexer.*;
+import org.nitlanguage.gen.parser.*;
+import org.nitlanguage.gen.analysis.*;
+import org.nitlanguage.gen.node.*;
+
+public class TestParser extends DepthFirstAdapter {
+	public static void main(String[] args) throws Exception {
+		if (args.length == 0) {
+			BufferedReader ir = new BufferedReader(new InputStreamReader(System.in));
+			work(ir);
+		} else {
+			for(int i=0; i<args.length; i++) {
+				//System.out.println(args[i]);
+
+				//Here we use "ISO-8859-1" because we want to opaquely treat Bytes as characters.
+				//Unfortunately "US-ASCII" does not seems to do the job for values>127.
+				BufferedReader ir = new BufferedReader(new InputStreamReader(new FileInputStream(args[i]), "ISO-8859-1"));
+
+				work(ir);
+			}
+		}
+	}
+
+	public static void work(BufferedReader ir) {
+		TestParser testParser = new TestParser();
+		try {
+			PushbackReader r = new PushbackReader(ir, 1024);
+			Parser parser = new Parser(new Lexer(r));
+			Node syntaxTree = parser.parse();
+			syntaxTree.apply(testParser);
+		} catch (LexerException e) {
+			System.out.println(e.getMessage() + ".");
+		} catch (ParserException e) {
+			System.out.println(e.getMessage() + ".");
+		} catch (IOException e) {
+			System.out.println(e.getMessage() + ".");
+			System.exit(1);
+		}
+	}
+}


### PR DESCRIPTION
So one can more easily play and compare parsers.

Sometime, when I have issues with the parser, it helps to understand if it is nit-related, sablecc-related or grammar-relater.