### PR TITLE
Improve checking of virtual types

### DIFF
--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -418,7 +418,7 @@ redef class ModelBuilder
 		var mtype = mproperty.mvirtualtype
 		var poset = new POSet[MType]
 
-		# The work-list of type to resolve
+		# The work-list of types to resolve
 		var todo = new List[MType]
 		todo.add mtype
 

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -621,26 +621,6 @@ redef class ASignature
 		self.is_visited = true
 		return true
 	end
-
-	# Build a visited signature
-	fun build_signature(modelbuilder: ModelBuilder): nullable MSignature
-	do
-		if param_names.length != param_types.length then
-			# Some parameters are typed, other parameters are not typed.
-			modelbuilder.error(self.n_params[param_types.length], "Error: Untyped parameter `{param_names[param_types.length]}'.")
-			return null
-		end
-
-		var mparameters = new Array[MParameter]
-		for i in [0..param_names.length[ do
-			var mparameter = new MParameter(param_names[i], param_types[i], i == vararg_rank)
-			self.n_params[i].mparameter = mparameter
-			mparameters.add(mparameter)
-		end
-
-		var msignature = new MSignature(mparameters, ret_type)
-		return msignature
-	end
 end
 
 redef class AParam

--- a/tests/error_virtual_type.nit
+++ b/tests/error_virtual_type.nit
@@ -1,0 +1,35 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import standard::kernel
+
+class G[E: Object]
+end
+
+class A
+	fun foo(t: T): Comparable do return t
+	type T: Comparable #alt1-5#
+	#alt1#type T: T
+	#alt2#type T: nullable T
+	#alt3#type T: G[T]
+	#alt4#type T: U
+	#alt4#type U: FAIL
+	#alt5#type T: U
+	#alt5#type U: T
+	fun bar(t: T): Comparable do return t
+end
+
+var a = new A
+a.foo(1)
+a.bar('1')

--- a/tests/error_virtual_type2.nit
+++ b/tests/error_virtual_type2.nit
@@ -1,0 +1,52 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import standard::kernel
+
+class G[E]
+end
+
+class A
+	fun foo(t: T): Comparable do return t
+	#fun foog: nullable G[T] do return barg
+	type T: Comparable #alt1-5#
+	type GT: G[T]
+	#alt1#type T: T
+	#alt2#type T: nullable T
+	#alt3#type T: G[T]
+	#alt4#type T: U
+	#alt4#type U: FAIL
+	#alt5#type T: U
+	#alt5#type U: T
+	fun bar(t: T): Comparable do return t
+	#fun barg: nullable G[T] do return foog
+end
+
+class B
+	super A
+	redef fun foo(t: T): T do return t
+	#redef fun foog: GT do return barg
+	redef type GT: G[Discrete]
+	#alt6#redef type GT: G[Bool]
+	redef fun bar(t: T): T do return t
+	#redef fun barg: GT do return foog
+end
+
+var a = new A
+a.foo(1)
+a.bar('1')
+
+var b = new B
+b.foo(2)
+b.bar('3')

--- a/tests/sav/base_virtual_type7.res
+++ b/tests/sav/base_virtual_type7.res
@@ -1,2 +1,1 @@
-base_virtual_type7.nit:20,2--10: Error: circularity of virtual type definition: E -> F -> E
-base_virtual_type7.nit:21,2--10: Error: circularity of virtual type definition: F -> E -> F
+base_virtual_type7.nit:20,2--10: Error: circularity of virtual type definition: E <-> F

--- a/tests/sav/error_virtual_type2.res
+++ b/tests/sav/error_virtual_type2.res
@@ -1,0 +1,1 @@
+error_virtual_type2.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of G[T], as in error_virtual_type2#A#GT.

--- a/tests/sav/error_virtual_type2_alt1.res
+++ b/tests/sav/error_virtual_type2_alt1.res
@@ -1,0 +1,5 @@
+alt/error_virtual_type2_alt1.nit:22,2--24,13: Error: circularity of virtual type definition: GT -> T <-> T
+alt/error_virtual_type2_alt1.nit:25,2--10: Error: circularity of virtual type definition: T <-> T
+alt/error_virtual_type2_alt1.nit:38,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt1#A#foo.
+alt/error_virtual_type2_alt1.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of null, as in error_virtual_type2_alt1#A#GT.
+alt/error_virtual_type2_alt1.nit:42,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt1#A#bar.

--- a/tests/sav/error_virtual_type2_alt2.res
+++ b/tests/sav/error_virtual_type2_alt2.res
@@ -1,0 +1,5 @@
+alt/error_virtual_type2_alt2.nit:22,2--24,13: Error: circularity of virtual type definition: GT -> T <-> nullable T
+alt/error_virtual_type2_alt2.nit:25,2--26,19: Error: circularity of virtual type definition: T <-> nullable T
+alt/error_virtual_type2_alt2.nit:38,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt2#A#foo.
+alt/error_virtual_type2_alt2.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of null, as in error_virtual_type2_alt2#A#GT.
+alt/error_virtual_type2_alt2.nit:42,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt2#A#bar.

--- a/tests/sav/error_virtual_type2_alt3.res
+++ b/tests/sav/error_virtual_type2_alt3.res
@@ -1,0 +1,5 @@
+alt/error_virtual_type2_alt3.nit:22,2--24,13: Error: circularity of virtual type definition: GT -> G[T] <-> T
+alt/error_virtual_type2_alt3.nit:25,2--27,12: Error: circularity of virtual type definition: T <-> G[T]
+alt/error_virtual_type2_alt3.nit:38,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt3#A#foo.
+alt/error_virtual_type2_alt3.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of null, as in error_virtual_type2_alt3#A#GT.
+alt/error_virtual_type2_alt3.nit:42,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt3#A#bar.

--- a/tests/sav/error_virtual_type2_alt4.res
+++ b/tests/sav/error_virtual_type2_alt4.res
@@ -1,0 +1,4 @@
+alt/error_virtual_type2_alt4.nit:29,10--13: Type error: class FAIL not found in module error_virtual_type2_alt4.
+alt/error_virtual_type2_alt4.nit:38,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt4#A#foo.
+alt/error_virtual_type2_alt4.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of null, as in error_virtual_type2_alt4#A#GT.
+alt/error_virtual_type2_alt4.nit:42,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt4#A#bar.

--- a/tests/sav/error_virtual_type2_alt5.res
+++ b/tests/sav/error_virtual_type2_alt5.res
@@ -1,0 +1,5 @@
+alt/error_virtual_type2_alt5.nit:22,2--24,13: Error: circularity of virtual type definition: GT -> T <-> U
+alt/error_virtual_type2_alt5.nit:25,2--30,10: Error: circularity of virtual type definition: T <-> U
+alt/error_virtual_type2_alt5.nit:38,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt5#A#foo.
+alt/error_virtual_type2_alt5.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of null, as in error_virtual_type2_alt5#A#GT.
+alt/error_virtual_type2_alt5.nit:42,23: Redef Error: Wrong return type. found T, expected Comparable as in error_virtual_type2_alt5#A#bar.

--- a/tests/sav/error_virtual_type2_alt6.res
+++ b/tests/sav/error_virtual_type2_alt6.res
@@ -1,0 +1,2 @@
+alt/error_virtual_type2_alt6.nit:40,17--26: Redef Error: Wrong bound type. Found G[Discrete], expected a subtype of G[T], as in error_virtual_type2_alt6#A#GT.
+alt/error_virtual_type2_alt6.nit:41,2--22: Error: A property GT is already defined in class B at line 39.

--- a/tests/sav/error_virtual_type_alt1.res
+++ b/tests/sav/error_virtual_type_alt1.res
@@ -1,0 +1,1 @@
+alt/error_virtual_type_alt1.nit:22,2--23,10: Error: circularity of virtual type definition: T <-> T

--- a/tests/sav/error_virtual_type_alt2.res
+++ b/tests/sav/error_virtual_type_alt2.res
@@ -1,0 +1,1 @@
+alt/error_virtual_type_alt2.nit:22,2--24,19: Error: circularity of virtual type definition: T <-> nullable T

--- a/tests/sav/error_virtual_type_alt3.res
+++ b/tests/sav/error_virtual_type_alt3.res
@@ -1,0 +1,2 @@
+alt/error_virtual_type_alt3.nit:25,12: Type error: expected Object, got T
+alt/error_virtual_type_alt3.nit:22,2--25,12: Error: circularity of virtual type definition: T <-> G[T]

--- a/tests/sav/error_virtual_type_alt4.res
+++ b/tests/sav/error_virtual_type_alt4.res
@@ -1,0 +1,1 @@
+alt/error_virtual_type_alt4.nit:27,10--13: Type error: class FAIL not found in module error_virtual_type_alt4.

--- a/tests/sav/error_virtual_type_alt5.res
+++ b/tests/sav/error_virtual_type_alt5.res
@@ -1,0 +1,1 @@
+alt/error_virtual_type_alt5.nit:22,2--28,10: Error: circularity of virtual type definition: T <-> U


### PR DESCRIPTION
This PR does 2 things to avoid runtime errors during nitc. Invalid programs that crashed the compiler now display errors messages.

* improve the static detection of loops in virtual types.
* consider types in the signatures of properties to be fragile since they contains potentially bad virtual types.

If merged with #1241 then nitpick can process the whole tests directory without crashing (impressive, since there is 1584 border-case files).
~~~
$ ./nitpick ../tests/*.nit ../tests/alt/*.nit -I ../lib/standard/ -I ../lib/standard/collection/
[... lots of errors ...]
Errors: 1766. Warnings: 195.
~~~