### PR TITLE
Check contrib

### DIFF
--- a/contrib/header_keeper/Makefile
+++ b/contrib/header_keeper/Makefile
@@ -2,6 +2,7 @@ bin/header_keeper:
 	mkdir -p bin
 	../../bin/nitc --dir bin src/header_keeper.nit
 
+check: tests
 tests: bin/header_keeper
 	gcc -E /usr/include/SDL/SDL_image.h | bin/header_keeper SDL_image.h
 	gcc -E /usr/include/GLES2/gl2.h | bin/header_keeper gl2.h

--- a/contrib/inkscape_tools/Makefile
+++ b/contrib/inkscape_tools/Makefile
@@ -4,6 +4,7 @@ bins:
 	mkdir -p bin
 	../../bin/nitc --dir bin src/svg_to_png_and_nit.nit src/svg_to_icons.nit
 
+check: tests
 tests: test-dino test-app
 
 test-app: bin/svg_to_png_and_nit

--- a/contrib/nitcc/src/Makefile
+++ b/contrib/nitcc/src/Makefile
@@ -33,6 +33,7 @@ minilang: nitcc ../examples/minilang.sablecc ../examples/minilang.nit
 	${NITC} ../examples/minilang.nit -v
 	printf "10\n42\n" | ./minilang ../examples/minilang.minilang
 
+check: tests
 tests:
 	cd ../tests && ./run
 

--- a/contrib/nitiwiki/Makefile
+++ b/contrib/nitiwiki/Makefile
@@ -4,6 +4,7 @@ nitiwiki:
 	mkdir -p bin
 	../../bin/nitc src/nitiwiki.nit -o bin/nitiwiki
 
+check: tests
 tests: nitiwiki
 	cd tests; make
 

--- a/contrib/pep8analysis/Makefile
+++ b/contrib/pep8analysis/Makefile
@@ -5,6 +5,7 @@ bin/pep8analysis:
 doc/index.html:
 	../../bin/nitdoc src/pep8analysis.nit
 
+check: tests
 tests: bin/pep8analysis
 	bin/pep8analysis --cfg-long tests/privat/*.pep tests/micro/*.pep tests/terrasa/*.pep
 

--- a/misc/jenkins/check_contrib.sh
+++ b/misc/jenkins/check_contrib.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check the build and the execution of software in examples/ and contrib/
+# The script must be run from the root Nit directory.
+#
+# various .xml junit file will be generated in the root directory for jenkins.
+
+projects=`echo examples/*/Makefile contrib/*/Makefile`
+
+failed=
+for p in $projects; do
+	dir=`dirname "$p"`
+	name=`basename "$dir"`
+	echo "*** make $dir ***"
+	if misc/jenkins/unitrun.sh "run-$name-make" make -C "$dir"; then
+		# Make OK, is there a `check` rule?
+		make -C "$dir" check -n 2>/dev/null || continue
+		echo "*** makecheck $dir ***"
+		if misc/jenkins/unitrun.sh "run-$name-makecheck" make -C "$dir" check; then
+			:
+		else
+			failed="$failed $name-check"
+		fi
+
+	else
+		failed="$failed $name"
+	fi
+done
+grep '<error message' *-make.xml *-makecheck.xml
+if test -n "$failed"; then
+	echo "FAILED: $failed"
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
Add a script `misc/jenkins/check_contrib.sh` to automatically compile and tests things in contrib and examples.

New (and existing) programs in these directory should try to add some basic (or extensive) checking.

Note that I used the name `check` that is the standard name for Makefiles (`tests` seems to be an invention of myself) http://www.gnu.org/software/make/manual/make.html#Standard-Targets