### PR TITLE
Autocast and literal arrays

### DIFF
--- a/lib/standard/string_search.nit
+++ b/lib/standard/string_search.nit
@@ -388,8 +388,14 @@ redef class Text
 	fun split_once_on(p: Pattern): Array[SELFTYPE]
 	do
 		var m = p.search_in(self, 0)
-		if m == null then return [self]
-		return new Array[SELFTYPE].with_items(substring(0, m.from), substring_from(m.after))
+		var res = new Array[SELFTYPE]
+		if m == null then
+			res.add self
+		else
+			res.add substring(0, m.from)
+			res.add substring_from(m.after)
+		end
+		return res
 	end
 
 	# Replace all occurences of a pattern with a string

--- a/src/metrics/detect_covariance.nit
+++ b/src/metrics/detect_covariance.nit
@@ -343,7 +343,7 @@ redef class TypeVisitor
 		return sub
 	end
 
-	redef fun check_subtype(node: ANode, sub, sup: MType): nullable MType
+	redef fun check_subtype(node: ANode, sub, sup: MType, autocast: Bool): nullable MType
 	do
 		var res = super
 
@@ -359,6 +359,9 @@ redef class TypeVisitor
 		# Case of autocast
 		if not self.is_subtype(sub, sup) then
 			if node isa AAsCastExpr then
+				return res
+			end
+			if not autocast then
 				return res
 			end
 			sup = supx.resolve_for(anchor.mclass.mclass_type, anchor, mmodule, true)

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -540,6 +540,8 @@ redef class AArrayExpr
 		mtype = v.cleanup_type(mtype).as(not null)
 		var prop = v.get_method(mtype, "with_native")
 		v.add_monomorphic_send(mtype, prop)
+		v.add_callsite(with_capacity_callsite)
+		v.add_callsite(push_callsite)
 	end
 end
 

--- a/src/transform.nit
+++ b/src/transform.nit
@@ -20,6 +20,7 @@ import astbuilder
 import astvalidation
 import semantize
 intrude import semantize::scope
+intrude import semantize::typing
 
 redef class ToolContext
 	var transform_phase: Phase = new TransformPhase(self, [typing_phase, auto_super_init_phase])
@@ -104,6 +105,14 @@ redef class AExpr
 			place.replace_with(nadd)
 		end
 		super
+	end
+
+	redef fun replace_with(other)
+	do
+		super
+		if other isa AExpr then
+			if other.implicit_cast_to == null then other.implicit_cast_to = implicit_cast_to
+		end
 	end
 end
 

--- a/tests/base_autocast_array.nit
+++ b/tests/base_autocast_array.nit
@@ -1,0 +1,45 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import standard::collection::array
+
+class A
+	type V: nullable Object
+	var v: V
+
+	fun test_array: Array[V]
+	do
+		#alt3#v = 10
+		return [v] #alt1-2#
+		#alt1#return [10:V]
+		#alt2#return [10]
+	end
+end
+
+class B
+	super A
+	redef type V: Bool
+end
+
+var a = new A(1)
+
+a.test_array.first.output
+
+var ab = new A(true)
+
+ab.test_array.first.output
+
+var b = new B(true)
+
+b.test_array.first.output

--- a/tests/sav/base_autocast_array.res
+++ b/tests/sav/base_autocast_array.res
@@ -1,0 +1,3 @@
+1
+true
+true

--- a/tests/sav/base_autocast_array_alt1.res
+++ b/tests/sav/base_autocast_array_alt1.res
@@ -1,0 +1,1 @@
+alt/base_autocast_array_alt1.nit:25,11--12: Type Error: expected `V`, got `Int`.

--- a/tests/sav/base_autocast_array_alt2.res
+++ b/tests/sav/base_autocast_array_alt2.res
@@ -1,0 +1,3 @@
+Runtime error: Cast failed. Expected `Array[V]`, got `Array[Int]` (alt/base_autocast_array_alt2.nit:26)
+10
+10

--- a/tests/sav/base_autocast_array_alt3.res
+++ b/tests/sav/base_autocast_array_alt3.res
@@ -1,0 +1,3 @@
+Runtime error: Cast failed. Expected `V`, got `Int` (alt/base_autocast_array_alt3.nit:23)
+10
+10

--- a/tests/sav/nitg-e/base_autocast_array_alt2.res
+++ b/tests/sav/nitg-e/base_autocast_array_alt2.res
@@ -1,0 +1,3 @@
+Runtime error: Cast failed (alt/base_autocast_array_alt2.nit:45)
+10
+10


### PR DESCRIPTION
Small bugfixes

* forbid autocasts in combined assignments and literal arrays
* keep autocast information in transform
* rta visits implicit methods of literal arrays

Only the first one was the original bug I wanted to fix, the two others where discovered and solved while writing the PR.