### PR TITLE
Parallelization phase improvement

### DIFF
--- a/lib/pthreads/README.md
+++ b/lib/pthreads/README.md
@@ -12,7 +12,12 @@ This group also provides two optional modules with thread-safe collections:
 Theses services are implemented using the POSIX threads.
 
 You can also use the `is threaded` annotation on methods, which makes them run on their own thread.
-Methods with return value or self calls are not supported.
+Methods with self calls are not supported.
+
+A method or function annotated with `is threaded` has its return value changed during compilation.
+You will get a subclass of `Thread`, even if there wasn't a return value before. You can know if the threaded method is done with the `is_done` boolean from `Thread`.
+A call to the `join` method will block the execution until the threaded method is done, or immediatly return if it's already done.
+`join` will return an object typed with the orginial return type, or `null` if there wasn't.
 
 ## Known limitations:
 
@@ -24,3 +29,4 @@ Methods with return value or self calls are not supported.
 
 * See: `man pthreads`
 * See: `examples/concurrent_array_and_barrier.nit`
+* See: ̀ examples/threaded_example.nit`

--- a/lib/pthreads/examples/threaded_example.nit
+++ b/lib/pthreads/examples/threaded_example.nit
@@ -32,7 +32,17 @@ fun bar(i : Int, s : String) is threaded do
 	print s
 end
 
+# Parameterized `threaded` method with a return type
+fun baz(i : Int, j : Int): Int is threaded do
+	sys.nanosleep(10, 0)
+	return i + j
+end
+
+print "main"
 foo
 bar(10, "parameterized and threaded")
-print "main"
 sys.nanosleep(5,0)
+var x  = baz(2, 3)
+print "main, waiting for baz"
+var y = x.join
+print("baz result : " + y.to_s)

--- a/lib/pthreads/pthreads.nit
+++ b/lib/pthreads/pthreads.nit
@@ -236,19 +236,26 @@ end
 abstract class Thread
 	super Finalizable
 
+	# Type returned by `main`
+	type E : nullable Object
+
 	private var native: nullable NativePthread = null
+
+	# Is this thread finished ? True when main returned
+	var is_done = false
 
 	# Main method of this thread
 	#
 	# The returned valued is passed to the caller of `join`.
-	fun main: nullable Object do return null
+	fun main: E do return null
 
-	private fun main_intern: nullable Object
+	private fun main_intern: E
 	do
 		# Register thread local data
 		sys.self_thread_key.set self
-
-		return main
+		var r = main
+		self.is_done = true
+		return r
 	end
 
 	# Start executing this thread
@@ -266,12 +273,12 @@ abstract class Thread
 	# `Sys::thread_exit`. Returns the object returned from the other thread.
 	#
 	# Stats the thread if now already done by a call to `start`.
-	fun join: nullable Object
+	fun join: E
 	do
 		if native == null then start
 		var r = native.join
 		native = null
-		return r
+		return r.as(E)
 	end
 
 	redef fun finalize

--- a/tests/sav/threaded_example.res
+++ b/tests/sav/threaded_example.res
@@ -2,3 +2,5 @@ main
 threaded
 10
 parameterized and threaded
+main, waiting for baz
+baz result : 5


### PR DESCRIPTION
Adds the support of methods with return value

If you use `is threaded` on a method with a return, it will instead return you a custom instance of `Thread` class on which you can use the method `join` to retrieve the return of the annotated method. `join` waits for the method to end before returning.If you want to make sure that the method has done his work before trying to retrieve it's return value, you can check it with the boolean `is_done`