### PR TITLE
Hint vararg

### DIFF
--- a/tests/sav/base_vararg3_alt1.res
+++ b/tests/sav/base_vararg3_alt1.res
@@ -1,1 +1,1 @@
-alt/base_vararg3_alt1.nit:41,7--13: Type Error: expected `Int`, got `Array[Int]`.
+alt/base_vararg3_alt1.nit:41,7--13: Type Error: expected `Int`, got `Array[Int]`. Is an ellipsis `...` missing on the argument?

--- a/tests/sav/base_vararg3_alt3.res
+++ b/tests/sav/base_vararg3_alt3.res
@@ -1,1 +1,1 @@
-alt/base_vararg3_alt3.nit:33,9: Type Error: expected `Int`, got `Array[Int]`.
+alt/base_vararg3_alt3.nit:33,9: Type Error: expected `Int`, got `Array[Int]`. Is an ellipsis `...` missing on the argument?


### PR DESCRIPTION
Improve the error message so that user that try to pass an array as is instead of elements is hinted about the `...` reverse-vararg operator.

~~~
fun foo(xs: Int...) do end
foo(1,2,3) # OK
var a = [1,2,3]
foo(a) # Error, expected `Int`; got `Array[Int]`. Is `...` missing?
foo(a...) # OK
~~~

![](http://i.imgur.com/zmyi8GR.jpg)

close #98 (quite old bug)