### PR TITLE
Prettier pretty printing

### DIFF
--- a/src/nitpretty.nit
+++ b/src/nitpretty.nit
@@ -87,7 +87,7 @@ var arguments = toolcontext.option_context.rest
 # build model
 var model = new Model
 var mbuilder = new ModelBuilder(model, toolcontext)
-var mmodules = mbuilder.parse(arguments)
+var mmodules = mbuilder.parse_full(arguments)
 mbuilder.run_phases
 
 if mmodules.is_empty then

--- a/src/nitpretty.nit
+++ b/src/nitpretty.nit
@@ -35,6 +35,9 @@ redef class ToolContext
 	# --line-width
 	var opt_line_width = new OptionInt("Maximum length of lines (use 0 to disable automatic line breaks)", 80, "--line-width")
 
+	# --no-inline
+	var opt_no_inline = new OptionBool("Disable automatic one-liners", "--no-inline")
+
 	# Break too long string literals.
 	var opt_break_str = new OptionBool("Break too long string literals", "--break-strings")
 
@@ -73,6 +76,7 @@ var opts = toolcontext.option_context
 opts.add_option(toolcontext.opt_dir, toolcontext.opt_output)
 opts.add_option(toolcontext.opt_diff, toolcontext.opt_meld, toolcontext.opt_check)
 opts.add_option(toolcontext.opt_line_width, toolcontext.opt_break_str, toolcontext.opt_inline_do)
+opts.add_option(toolcontext.opt_no_inline)
 opts.add_option(toolcontext.opt_skip_empty)
 
 toolcontext.tooldescription = "Usage: nitpretty [OPTION]... <file.nit>\n" +
@@ -109,6 +113,9 @@ if toolcontext.opt_inline_do.value then
 end
 if toolcontext.opt_skip_empty.value then
 	v.skip_empty = true
+end
+if toolcontext.opt_no_inline.value then
+	v.no_inline = true
 end
 
 for mmodule in mmodules do

--- a/src/nitpretty.nit
+++ b/src/nitpretty.nit
@@ -32,6 +32,9 @@ redef class ToolContext
 	var opt_meld = new OptionBool("Show diff between source and output using meld",
 	   "--meld")
 
+	# --line-width
+	var opt_line_width = new OptionInt("Maximum length of lines (use 0 to disable automatic line breaks)", 80, "--line-width")
+
 	# Break too long string literals.
 	var opt_break_str = new OptionBool("Break too long string literals", "--break-strings")
 
@@ -69,7 +72,7 @@ var toolcontext = new ToolContext
 var opts = toolcontext.option_context
 opts.add_option(toolcontext.opt_dir, toolcontext.opt_output)
 opts.add_option(toolcontext.opt_diff, toolcontext.opt_meld, toolcontext.opt_check)
-opts.add_option(toolcontext.opt_break_str, toolcontext.opt_inline_do)
+opts.add_option(toolcontext.opt_line_width, toolcontext.opt_break_str, toolcontext.opt_inline_do)
 opts.add_option(toolcontext.opt_skip_empty)
 
 toolcontext.tooldescription = "Usage: nitpretty [OPTION]... <file.nit>\n" +
@@ -97,6 +100,7 @@ var dir = toolcontext.opt_dir.value or else ".nitpretty"
 if not dir.file_exists then dir.mkdir
 var v = new PrettyPrinterVisitor
 
+v.max_size = toolcontext.opt_line_width.value
 if toolcontext.opt_break_str.value then
 	v.break_strings = true
 end

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -145,12 +145,16 @@ class PrettyPrinterVisitor
 	# Skip `current_token` until `target` is reached.
 	fun skip_to(target: nullable Token) do
 		if target == null then return
-		while current_token != target do skip
+		while current_token != null and current_token != target do skip
+		if current_token == null then
+			target.debug("Looked for, but not found :(")
+			abort
+		end
 	end
 
 	# Visit `current_token`.
 	fun consume(token: String) do
-		assert current_token.text == token
+		if current_token.text == token then else current_token.debug("Got `{current_token.text}`; expected `{token}`.")
 		visit current_token
 	end
 

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -124,7 +124,7 @@ class PrettyPrinterVisitor
 		if n.must_be_inline then return true
 		if n.must_be_block then return false
 		# check length
-		if n.collect_length + current_length > max_size then return false
+		if max_size > 0 and n.collect_length + current_length > max_size then return false
 		# check block is inlinable
 		return n.is_inlinable
 	end
@@ -219,7 +219,8 @@ class PrettyPrinterVisitor
 	var tab_size = 8
 
 	# Max line size.
-	var max_size = 80
+	# 0 (or negative) to disable.
+	var max_size = 80 is writable
 
 	# Length of the current line.
 	var current_length = 0
@@ -2118,7 +2119,7 @@ redef class AStringFormExpr
 			while i < text.length do
 				v.add text[i].to_s
 
-				if v.current_length >= v.max_size and i <= text.length - 3 then
+				if v.max_size > 0 and v.current_length >= v.max_size and i <= text.length - 3 then
 					v.add "\" +"
 					if was_inline then
 						v.forcen

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -292,6 +292,8 @@ redef class ANodes[E]
 		for e in self do
 			var e_can_inline = v.can_inline(e)
 
+			if v.current_token isa TComma then v.skip
+
 			if e != first then
 				if not e_can_inline then
 					v.add ","

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -121,6 +121,7 @@ class PrettyPrinterVisitor
 	# Is the node inlinable and can fit on the line.
 	fun can_inline(n: nullable ANode): Bool do
 		if n == null then return true
+		if no_inline and n.location.line_start != n.location.line_end then return false
 		if n.must_be_inline then return true
 		if n.must_be_block then return false
 		# check length
@@ -284,6 +285,9 @@ class PrettyPrinterVisitor
 
 	# Do we force the deletion of empty lines?
 	var skip_empty = false is public writable
+
+	# Disable automatic inlining.
+	var no_inline = false is writable
 end
 
 # Base framework redefs

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -2067,6 +2067,11 @@ redef class AArrayExpr
 	redef fun accept_pretty_printer(v) do
 		v.consume "["
 		v.visit_list n_exprs
+		if n_type != null then
+			v.consume ":"
+			v.adds
+			v.visit n_type
+		end
 		v.consume "]"
 	end
 end

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -165,8 +165,14 @@ class PrettyPrinterVisitor
 		end
 	end
 
+	# Consume comments and end of lines if any
+	fun consume_comments do
+		while current_token isa TEol or current_token isa TComment do visit current_token
+	end
+
 	# Visit `current_token`.
 	fun consume(token: String) do
+		consume_comments
 		if current_token.text == token then else current_token.debug("Got `{current_token.text}`; expected `{token}`.")
 		visit current_token
 	end
@@ -1278,10 +1284,8 @@ redef class AIfExpr
 				end
 			end
 
+			v.consume_comments
 			if has_else(v) then
-				while not v.current_token isa TKwelse do
-					v.consume v.current_token.text
-				end
 
 				v.indent -= 1
 				v.addt

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -1287,7 +1287,10 @@ redef class AIfExpr
 			end
 
 			v.consume_comments
-			if has_else(v) then
+
+			# FIXME: for some unknown reasons, has_else can be true even if
+			# there is no `else` keyword but a `end` instead.
+			if has_else(v) and v.current_token isa TKwelse then
 
 				v.indent -= 1
 				v.addt

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -1063,7 +1063,7 @@ redef class AExternCalls
 			v.adds
 			v.visit_list n_extern_calls
 		else
-			v.addn
+			v.forcen
 			v.indent += 1
 			v.addt
 			v.indent -= 1
@@ -1163,7 +1163,7 @@ redef class TExternCodeSegment
 				v.add "`\{"
 
 				if not lines.first.trim.is_empty then
-					v.addn
+					v.forcen
 					lines.first.l_trim
 					v.indent += 1
 					v.addt
@@ -1240,7 +1240,7 @@ redef class AIfExpr
 			v.adds
 		else
 			v.visit n_expr
-			v.addn
+			v.forcen
 			v.addt
 		end
 
@@ -1582,7 +1582,7 @@ redef class ACallExpr
 		v.visit_recv n_expr
 
 		if not n_expr isa AImplicitSelfExpr and not can_inline then
-			v.addn
+			v.forcen
 			v.addt
 		end
 
@@ -1731,7 +1731,7 @@ redef class ANewExpr
 			v.consume "."
 
 			if not can_inline then
-				v.addn
+				v.forcen
 				v.indent += 1
 				v.addt
 				v.indent -= 1
@@ -1849,7 +1849,7 @@ redef class AAssertExpr
 				else
 					v.addt
 					v.visit n_else
-					v.addn
+					v.forcen
 					v.indent -= 1
 					v.addt
 					v.add "end"
@@ -1977,7 +1977,7 @@ private class ABinOpHelper
 			v.adds
 			v.visit bin_expr2
 		else
-			v.addn
+			v.forcen
 			v.indent += 1
 			v.addt
 			v.indent -= 1

--- a/src/pretty.nit
+++ b/src/pretty.nit
@@ -99,7 +99,20 @@ class PrettyPrinterVisitor
 		n.accept_pretty_printer self
 	end
 
-	# Visit a list of `Anode`.
+	# Visit a list of arguments `ANode` with optional parentheses
+	fun visit_args(n: nullable ANodes[ANode]) do
+		if n == null or n.is_empty then return
+		if current_token isa TOpar then
+			consume "("
+		else
+			adds
+		end
+
+		visit_list n
+		if current_token isa TCpar then consume ")"
+	end
+
+	# Visit a list of `ANode`.
 	fun visit_list(n: nullable ANodes[ANode]) do
 		if n == null then return
 		n.accept_pretty_printer self
@@ -513,15 +526,7 @@ redef class AAnnotation
 			v.adds
 		end
 		v.visit n_atid
-		if not n_args.is_empty then
-			if n_opar == null then
-				v.adds
-			else
-				v.visit n_opar
-			end
-			v.visit_list n_args
-			v.visit n_cpar
-		end
+		v.visit_args n_args
 	end
 end
 
@@ -1576,14 +1581,7 @@ redef class ACallExpr
 				v.visit n_args.n_exprs.first
 				if v.current_token isa TCpar then v.skip
 			else
-				if v.current_token isa TOpar then
-					v.consume "("
-				else
-					v.adds
-				end
-
-				v.visit_list n_args.n_exprs
-				if v.current_token isa TCpar then v.consume ")"
+				v.visit_args n_args.n_exprs
 			end
 		end
 	end
@@ -1704,12 +1702,7 @@ redef class AInitExpr
 		end
 
 		v.visit n_kwinit
-
-		if not n_args.n_exprs.is_empty then
-			v.consume "("
-			v.visit_list n_args.n_exprs
-			v.consume ")"
-		end
+		v.visit_args n_args.n_exprs
 	end
 end
 
@@ -1733,11 +1726,7 @@ redef class ANewExpr
 			v.visit n_id
 		end
 
-		if not n_args.n_exprs.is_empty then
-			v.consume "("
-			v.visit_list n_args.n_exprs
-			v.consume ")"
-		end
+		v.visit_args n_args.n_exprs
 	end
 
 	redef fun is_inlinable do return true
@@ -1884,14 +1873,7 @@ redef class ASuperExpr
 				v.visit n_args.n_exprs.first
 				if v.current_token isa TCpar then v.skip
 			else
-				if v.current_token isa TOpar then
-					v.consume "("
-				else
-					v.adds
-				end
-
-				v.visit_list n_args.n_exprs
-				if v.current_token isa TCpar then v.consume ")"
+				v.visit_args n_args.n_exprs
 			end
 		end
 	end


### PR DESCRIPTION
Some bugfixes, improvements and workaround for nitprettty.

The two options `--no-inline` and `--line-width` allow to control some rules about line-breaks.
This can be useful especially for people that want more relaxed rules.

~~~sh
$ ./nitpretty --check ../lib | wc -l
224
$ ./nitpretty --check ../lib --line-width 0 --no-inline | wc -l
188
~~~

So 36 more files are identical to their pretty printing with those relaxed rules.

For information, the tool crashed on some files in lib with the version before the PR.

Note that a lot of more work is still needed, one can see very strange and inconsistent results if the line width is forced to 1.