### PR TITLE
nitdoc: start using DocComponent rendering

### DIFF
--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -73,7 +73,7 @@ redef class MModulePage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle(mentity, name, op)
+		return new GraphArticle(mentity, name, "Importation Graph", op)
 	end
 end
 
@@ -107,7 +107,7 @@ redef class MClassPage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle(mentity, name, op)
+		return new GraphArticle(mentity, name, "Inheritance Graph", op)
 	end
 end
 
@@ -120,6 +120,9 @@ class GraphArticle
 
 	# Graph ID (used for outputing file with names).
 	var id: String
+
+	# Graph title to display.
+	var graph_title: String
 
 	# Dot script of the graph.
 	var dot: Text

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -684,9 +684,10 @@ redef class DefinitionArticle
 				if lin.length > 1 then
 					var lin_article = new TplArticle("{mentity.nitdoc_id}.lin")
 					lin_article.title = "Inheritance"
-					var lst = new TplList.with_classes(["list-unstyled", "list-labeled"])
+					var lst = new UnorderedList
+					lst.css_classes.add("list-unstyled list-labeled")
 					for smpropdef in lin do
-						lst.add_li smpropdef.tpl_inheritance_item
+						lst.add_li tpl_inheritance_item(smpropdef)
 					end
 					lin_article.content = lst
 					article.add_child lin_article
@@ -717,6 +718,26 @@ redef class DefinitionArticle
 			end
 		end
 		return mpropdefs
+	end
+
+	private fun tpl_inheritance_item(mpropdef: MPropDef): ListItem do
+		var lnk = new Template
+		lnk.add new TplLabel.with_classes(css_classes)
+		lnk.add mpropdef.mclassdef.mmodule.html_namespace
+		lnk.add "::"
+		var atext = mpropdef.mclassdef.html_link.text
+		var ahref = "{mpropdef.mclassdef.mclass.nitdoc_url}#{mpropdef.mproperty.nitdoc_id}"
+		var atitle = mpropdef.mclassdef.html_link.title
+		var anchor = new Link.with_title(ahref, atext, atitle)
+		lnk.add anchor
+		var comment = mpropdef.html_short_comment
+		if comment != null then
+			lnk.add ": "
+			lnk.add comment
+		end
+		var li = new ListItem(lnk)
+		li.css_classes.add "signature"
+		return li
 	end
 end
 
@@ -798,59 +819,5 @@ redef class Location
 		var file_loc = getcwd.join_path(file.filename).simplify_path
 		var gith_loc = file_loc.substring(base_dir.length + 1, file_loc.length)
 		return "{gith_loc}:{line_start},{column_start}--{line_end},{column_end}"
-	end
-end
-
-redef class MEntity
-	# A li element that can go in a list
-	fun tpl_list_item: TplListItem do
-		var lnk = new Template
-		lnk.add new TplLabel.with_classes(css_classes)
-		lnk.add html_link
-		var comment = html_short_comment
-		if comment != null then
-			lnk.add ": "
-			lnk.add comment
-		end
-		return new TplListItem.with_content(lnk)
-	end
-end
-
-redef class MPropDef
-	redef fun tpl_list_item do
-		var lnk = new Template
-		lnk.add new TplLabel.with_classes(css_classes)
-		var atext = html_link.text
-		var ahref = "{mclassdef.mclass.nitdoc_url}#{mproperty.nitdoc_id}"
-		var atitle = html_link.title
-		var anchor = new Link.with_title(ahref, atext, atitle)
-		lnk.add anchor
-		var comment = html_short_comment
-		if comment != null then
-			lnk.add ": "
-			lnk.add comment
-		end
-		return new TplListItem.with_content(lnk)
-	end
-
-	#
-	fun tpl_inheritance_item: TplListItem do
-		var lnk = new Template
-		lnk.add new TplLabel.with_classes(css_classes)
-		lnk.add mclassdef.mmodule.html_namespace
-		lnk.add "::"
-		var atext = mclassdef.html_link.text
-		var ahref = "{mclassdef.mclass.nitdoc_url}#{mproperty.nitdoc_id}"
-		var atitle = mclassdef.html_link.title
-		var anchor = new Link.with_title(ahref, atext, atitle)
-		lnk.add anchor
-		var comment = html_short_comment
-		if comment != null then
-			lnk.add ": "
-			lnk.add comment
-		end
-		var li = new TplListItem.with_content(lnk)
-		li.css_classes.add "signature"
-		return li
 	end
 end

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -763,14 +763,8 @@ end
 redef class HierarchyListArticle
 	redef fun render(v, doc, page, parent) do
 		if mentities.is_empty then return
-		var title = list_title
-		var id = list_title.to_lower
-		var article = new TplArticle.with_title(id, title)
-		var list = new TplList.with_classes(["list-unstyled", "list-definition"])
-		for mentity in mentities do
-			list.elts.add mentity.tpl_list_item
-		end
-		article.content = list
+		var article = new TplArticle.with_title(list_title.to_lower, list_title)
+		article.content = write_to_string
 		parent.add_child article
 	end
 end

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -723,16 +723,8 @@ end
 redef class IntrosRedefsListArticle
 	redef fun render(v, doc, page, parent) do
 		if mentities.is_empty then return
-		var title = list_title
-		# FIXME diff hack
-		var id = "intros"
-		if title == "Redefines" then id = "redefs"
-		var article = new TplArticle.with_title("{mentity.nitdoc_id}.{id}", title)
-		var list = new TplList.with_classes(["list-unstyled", "list-labeled"])
-		for mentity in mentities do
-			list.add_li mentity.tpl_list_item
-		end
-		article.content = list
+		var article = new TplArticle.with_title(list_title.to_lower, list_title)
+		article.content = write_to_string
 		parent.add_child article
 	end
 end

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -606,24 +606,8 @@ redef class IntroArticle
 			article.source_link = v.tpl_showsource(mentity.location)
 		end
 		# article.subtitle = mentity.html_declaration
-		# FIXME diff hack
-		if mentity isa MProperty then
-			# intro title
-			var ns = mentity.intro.mclassdef.mmodule.html_namespace
-			var section = new TplSection("intro")
-			var title = new Template
-			title.add "Introduction in "
-			title.add ns
-			section.title = title
-			section.summary_title = "Introduction"
-			var intro = mentity.intro.tpl_article
-			intro.source_link = v.tpl_showsource(mentity.intro.location)
-			section.add_child intro
-			parent.add_child section
-		else
-			article.content = mentity.tpl_definition
-			parent.add_child article
-		end
+		article.content = write_to_string
+		parent.add_child article
 	end
 end
 

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -613,11 +613,8 @@ end
 
 redef class ConcernsArticle
 	redef fun render(v, doc, page, parent) do
-		# FIXME diff hack
-		var title = "concerns"
-		if page.mentity isa MProperty then title = "Concerns"
 		parent.add_child new TplArticle.
-			with_content(title, "Concerns", concerns.to_tpl)
+			with_content("concerns", "Concerns", write_to_string)
 	end
 end
 

--- a/src/doc/html_templates/html_components.nit
+++ b/src/doc/html_templates/html_components.nit
@@ -17,8 +17,24 @@
 module html_components
 
 import doc_base
-import template
+import html::bootstrap
 import json::static
+
+# A label with a text content.
+class DocHTMLLabel
+	super BSLabel
+
+	redef init do
+		css_classes.clear
+		css_classes.add "label"
+	end
+
+	# Init this label from css classes.
+	init with_classes(classes: Array[String]) do
+		init("label", "")
+		css_classes.add_all classes
+	end
+end
 
 #########################
 # general layout elements

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -129,6 +129,19 @@ redef class MEntity
 	#
 	# Mainly used for icons.
 	var css_classes = new Array[String]
+
+	# A li element that can go in a `HTMLList`.
+	fun html_list_item: ListItem do
+		var tpl = new Template
+		tpl.add new DocHTMLLabel.with_classes(css_classes)
+		tpl.add html_link
+		var comment = html_short_comment
+		if comment != null then
+			tpl.add ": "
+			tpl.add comment
+		end
+		return new ListItem(tpl)
+	end
 end
 
 redef class MProject

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -571,6 +571,56 @@ redef class MParameter
 	end
 end
 
+redef class ConcernsTree
+	# Render `self` as a hierarchical UnorderedList.
+	fun html_list: UnorderedList do
+		var lst = new UnorderedList
+		lst.css_classes.add "list-unstyled list-definition"
+		for r in roots do
+			var li = r.html_concern_item
+			lst.add_li li
+			build_html_list(r, li)
+		end
+		return lst
+	end
+
+	# Build the html list recursively.
+	private fun build_html_list(e: MConcern, li: ListItem) do
+		if not sub.has_key(e) then return
+		var subs = sub[e]
+		var lst = new UnorderedList
+		lst.css_classes.add "list-unstyled list-definition"
+		for e2 in subs do
+			if e2 isa MGroup and e2.is_root then
+				build_html_list(e2, li)
+			else
+				var sli = e2.html_concern_item
+				lst.add_li sli
+				build_html_list(e2, sli)
+			end
+		end
+		var text = new Template
+		text.add li.text
+		if not lst.is_empty then text.add lst
+		li.text = text
+	end
+end
+
+redef class MConcern
+	# Return a li element for `self` that can be displayed in a concern list
+	private fun html_concern_item: ListItem do
+		var lnk = html_link
+		var tpl = new Template
+		tpl.add new Link.with_title("#{nitdoc_id}", lnk.text, lnk.title)
+		var comment = html_short_comment
+		if comment != null then
+			tpl.add ": "
+			tpl.add comment
+		end
+		return new ListItem(tpl)
+	end
+end
+
 ################################################################################
 # Additions to `model_ext`.
 

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -117,6 +117,18 @@ redef class MEntity
 		if mdoc == null then return null
 		return mdoc.tpl_short_comment
 	end
+
+	# Icon that will be displayed before the title
+	fun html_icon: BSIcon do
+		var icon = new BSIcon("tag")
+		icon.css_classes.add_all(css_classes)
+		return icon
+	end
+
+	# CSS classes used to decorate `self`.
+	#
+	# Mainly used for icons.
+	var css_classes = new Array[String]
 end
 
 redef class MProject
@@ -124,6 +136,7 @@ redef class MProject
 	redef fun nitdoc_url do return root.nitdoc_url
 	redef var html_modifiers = ["project"]
 	redef fun html_namespace do return html_link
+	redef var css_classes = ["public"]
 end
 
 redef class MGroup
@@ -150,6 +163,8 @@ redef class MGroup
 		end
 		return tpl
 	end
+
+	redef var css_classes = ["public"]
 end
 
 redef class MModule
@@ -180,6 +195,8 @@ redef class MModule
 		tpl.add html_link
 		return tpl
 	end
+
+	redef var css_classes = ["public"]
 end
 
 redef class MClass
@@ -221,6 +238,9 @@ redef class MClass
 
 	# Returns `intro.html_signature`.
 	fun html_signature: Template do return intro.html_signature
+
+	redef fun html_icon do return intro.html_icon
+	redef fun css_classes do return intro.css_classes
 end
 
 redef class MClassDef
@@ -249,14 +269,17 @@ redef class MClassDef
 	#
 	# For intro: `private abstract class Foo[E: Object]`
 	# For redef: `redef class Foo[E]`
-	# TODO change the implementation to correspond to the comment.
 	redef fun html_declaration do
 		var tpl = new Template
 		tpl.add "<span>"
 		tpl.add html_modifiers.join(" ")
 		tpl.add " "
 		tpl.add html_link
-		tpl.add html_signature
+		if is_intro then
+			tpl.add html_signature
+		else
+			tpl.add html_short_signature
+		end
 		tpl.add "</span>"
 		return tpl
 	end
@@ -301,6 +324,14 @@ redef class MClassDef
 		end
 		return tpl
 	end
+
+	redef fun css_classes do
+		var set = new HashSet[String]
+		if is_intro then set.add "intro"
+		for m in mclass.intro.modifiers do set.add m.to_cmangle
+		for m in modifiers do set.add m.to_cmangle
+		return set.to_a
+	end
 end
 
 redef class MProperty
@@ -325,6 +356,8 @@ redef class MProperty
 
 	# Returns `intro.html_signature`.
 	fun html_signature: Template do return intro.html_signature
+
+	redef fun css_classes do return intro.css_classes
 end
 
 redef class MPropDef
@@ -352,14 +385,18 @@ redef class MPropDef
 	#
 	# For intro: `private fun foo(e: Object): Bar is abstract`
 	# For redef: `redef fun foo(e) is cached`
-	# TODO change the implementation to correspond to the comment.
 	redef fun html_declaration do
 		var tpl = new Template
 		tpl.add "<span>"
 		tpl.add html_modifiers.join(" ")
 		tpl.add " "
-		tpl.add html_link
-		tpl.add html_signature
+		if is_intro then
+			tpl.add html_link
+			tpl.add html_signature
+		else
+			tpl.add mproperty.intro.html_link
+			tpl.add html_short_signature
+		end
 		tpl.add "</span>"
 		return tpl
 	end
@@ -378,6 +415,14 @@ redef class MPropDef
 
 	# Returns the MPropDef signature with static types.
 	fun html_signature: Template is abstract
+
+	redef fun css_classes do
+		var set = new HashSet[String]
+		if is_intro then set.add "intro"
+		for m in mproperty.intro.modifiers do set.add m.to_cmangle
+		for m in modifiers do set.add m.to_cmangle
+		return set.to_a
+	end
 end
 
 redef class MAttributeDef

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -17,6 +17,7 @@ module html_templates
 
 import html_model
 import html::bootstrap
+import doc_phases::doc_structure
 
 # Renders the page as HTML.
 redef class DocPage
@@ -264,4 +265,16 @@ redef class DocArticle
 	# This is to maintain compatibility with old components, this may change
 	# without notice in further version.
 	redef fun render_title do end
+end
+
+redef class IntroArticle
+	redef var html_id is lazy do return "article_intro_{mentity.nitdoc_id}"
+	redef var html_title is lazy do return null
+	redef var is_hidden = false
+
+	redef fun render_body do
+		var comment = mentity.html_comment
+		if comment != null then	addn comment
+		super
+	end
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -18,6 +18,7 @@ module html_templates
 import html_model
 import html::bootstrap
 import doc_phases::doc_structure
+import doc_phases::doc_hierarchies
 
 # Renders the page as HTML.
 redef class DocPage
@@ -297,5 +298,20 @@ redef class DefinitionArticle
 		var comment = mentity.html_comment
 		if comment != null then	addn comment
 		super
+	end
+end
+
+redef class HierarchyListArticle
+	redef var html_id is lazy do return "article_hierarchy_{list_title}_{mentity.nitdoc_id}"
+	redef var html_title is lazy do return list_title
+	redef fun is_empty do return mentities.is_empty
+
+	redef fun render_body do
+		var lst = new UnorderedList
+		lst.css_classes.add "list-unstyled list-definition"
+		for mentity in mentities do
+			lst.add_li mentity.html_list_item
+		end
+		addn lst
 	end
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -286,3 +286,16 @@ redef class ConcernsArticle
 
 	redef fun render_body do add concerns.html_list
 end
+
+redef class DefinitionArticle
+	redef var html_id is lazy do return "article_definition_{mentity.nitdoc_id}"
+	redef var html_title is lazy do return mentity.html_name
+	redef var html_subtitle is lazy do return mentity.html_declaration
+	redef var is_hidden = false
+
+	redef fun render_body do
+		var comment = mentity.html_comment
+		if comment != null then	addn comment
+		super
+	end
+end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -19,6 +19,7 @@ import html_model
 import html::bootstrap
 import doc_phases::doc_structure
 import doc_phases::doc_hierarchies
+import doc_phases::doc_intros_redefs
 
 # Renders the page as HTML.
 redef class DocPage
@@ -313,5 +314,20 @@ redef class HierarchyListArticle
 			lst.add_li mentity.html_list_item
 		end
 		addn lst
+	end
+end
+
+redef class IntrosRedefsListArticle
+	redef var html_id is lazy do return "article_intros_redefs_{mentity.nitdoc_id}"
+	redef var html_title is lazy do return list_title
+	redef fun is_hidden do return mentities.is_empty
+
+	redef fun render_body do
+		var lst = new UnorderedList
+		lst.css_classes.add "list-unstyled list-labeled"
+		for mentity in mentities do
+			lst.add_li mentity.html_list_item
+		end
+		add lst
 	end
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -19,6 +19,7 @@ import html_model
 import html::bootstrap
 import doc_phases::doc_structure
 import doc_phases::doc_hierarchies
+import doc_phases::doc_graphs
 import doc_phases::doc_intros_redefs
 
 # Renders the page as HTML.
@@ -329,5 +330,23 @@ redef class IntrosRedefsListArticle
 			lst.add_li mentity.html_list_item
 		end
 		add lst
+	end
+end
+
+redef class GraphArticle
+	redef var html_id is lazy do return "article_graph_{mentity.nitdoc_id}"
+	redef var is_hidden = false
+
+	# HTML map used to display link.
+	#
+	# This attribute is set by the `doc_render` phase who knows the context.
+	var map: String is noinit, writable
+
+	redef fun render_body do
+		addn "<div class=\"text-center\">"
+		addn " <img src='{id}.png' usemap='#{id}' style='margin:auto'"
+		addn "  alt='{graph_title}'/>"
+		add map
+		addn "</div>"
 	end
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -278,3 +278,11 @@ redef class IntroArticle
 		super
 	end
 end
+
+redef class ConcernsArticle
+	redef var html_id is lazy do return "article_concerns_{mentity.nitdoc_id}"
+	redef var html_title = "Concerns"
+	redef fun is_hidden do return concerns.is_empty
+
+	redef fun render_body do add concerns.html_list
+end


### PR DESCRIPTION
This PR starts the migration of HTML rendering from old components to new DocComposite rendering.

Some minor differences can be seen in the output.

Démos: [stdli](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/index.html) and [nitc](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/nitc/index.html).