### PR TITLE
GTK clean up and a few new features

### DIFF
--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -1,8 +1,7 @@
 all:
 	mkdir -p bin/
 
-	# Compile in global mode to silence warnings on unused GTK deprecated
-	../../bin/nitc --global --dir bin/ src/calculator_gtk.nit src/calculator_test.nit
+	../../bin/nitc --dir bin/ src/calculator_gtk.nit src/calculator_test.nit
 
 android:
 	mkdir -p bin/ res/

--- a/examples/calculator/src/calculator_gtk.nit
+++ b/examples/calculator/src/calculator_gtk.nit
@@ -55,10 +55,11 @@ class CalculatorGui
 	do
 		init_gtk
 
-		win = new GtkWindow(0)
+		win = new GtkWindow(new GtkWindowType.toplevel)
+		win.connect_destroy_signal_to_quit
 
-		container = new GtkGrid(5, 5, true)
-		win.add(container)
+		container = new GtkGrid
+		win.add container
 
 		lbl_disp = new GtkLabel("_")
 		container.attach(lbl_disp, 0, 0, 5, 1)

--- a/lib/gtk/v3_4/gdk_enums.nit
+++ b/lib/gtk/v3_4/gdk_enums.nit
@@ -15,73 +15,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module gdk_enums is pkgconfig("gtk+-3.0")
+module gdk_enums is pkgconfig "gtk+-3.0"
 
 in "C Header" `{
 	#include <gtk/gtk.h>
 `}
 
-#enum GdkGravity
-#Defines the reference point of a window and the meaning of coordinates passed to gtk_window_move().
-#@https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkGravity
+# enum GdkGravity
+# Defines the reference point of a window and the meaning of coordinates passed to gtk_window_move().
+# See: https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkGravity
 extern class GdkGravity `{GdkGravity`}
-	#The reference point is at the top left corner.
-	new north_west `{ return GDK_GRAVITY_NORTH_WEST; `} 
+	# The reference point is at the top left corner.
+	new north_west `{ return GDK_GRAVITY_NORTH_WEST; `}
 
-	#The reference point is in the middle of the top edge.	
-	new north `{ return GDK_GRAVITY_NORTH; `} 	
+	# The reference point is in the middle of the top edge.
+	new north `{ return GDK_GRAVITY_NORTH; `}
 
-	#The reference point is at the top right corner.	
-	new north_east `{ return GDK_GRAVITY_NORTH_EAST; `} 
+	# The reference point is at the top right corner.
+	new north_east `{ return GDK_GRAVITY_NORTH_EAST; `}
 
-	#The reference point is at the middle of the left edge.
-	new west `{ return GDK_GRAVITY_WEST; `} 	
+	# The reference point is at the middle of the left edge.
+	new west `{ return GDK_GRAVITY_WEST; `}
 
-	#The reference point is at the center of the window
-	new center `{ return GDK_GRAVITY_CENTER; `} 	
+	# The reference point is at the center of the window
+	new center `{ return GDK_GRAVITY_CENTER; `}
 
-	#The reference point is at the middle of the right edge.
-	new east `{ return GDK_GRAVITY_EAST; `} 	
+	# The reference point is at the middle of the right edge.
+	new east `{ return GDK_GRAVITY_EAST; `}
 
-	#The reference point is at the lower left corner.
-	new south_west `{ return GDK_GRAVITY_SOUTH_WEST; `} 
+	# The reference point is at the lower left corner.
+	new south_west `{ return GDK_GRAVITY_SOUTH_WEST; `}
 
-	#The reference point is at the middle of the lower edge.
-	new south `{ return GDK_GRAVITY_SOUTH; `} 
+	# The reference point is at the middle of the lower edge.
+	new south `{ return GDK_GRAVITY_SOUTH; `}
 
-	#The reference point is at the lower right corner.
-	new south_east `{ return GDK_GRAVITY_SOUTH_EAST; `} 
+	# The reference point is at the lower right corner.
+	new south_east `{ return GDK_GRAVITY_SOUTH_EAST; `}
 
-	#The reference point is at the top left corner of the window itself, ignoring window manager decorations.	
-	new static `{ return GDK_GRAVITY_STATIC; `} 
+	# The reference point is at the top left corner of the window itself, ignoring window manager decorations.
+	new static `{ return GDK_GRAVITY_STATIC; `}
 end
 
-#enum GdkGWindowEdge
-#Determines a window edge or corner.
-#@https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkWindowEdge
+# enum GdkGWindowEdge
+# Determines a window edge or corner.
+# See: https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#GdkWindowEdge
 extern class GdkWindowEdge `{GdkWindowEdge`}
-	#The top left corner.
-	new north_west `{ return GDK_WINDOW_EDGE_NORTH_WEST; `} 
+	# The top left corner.
+	new north_west `{ return GDK_WINDOW_EDGE_NORTH_WEST; `}
 
-	#The top edge.	
-	new north `{ return GDK_WINDOW_EDGE_NORTH; `} 	
+	# The top edge.
+	new north `{ return GDK_WINDOW_EDGE_NORTH; `}
 
-	#The top right corner.	
-	new north_east `{ return GDK_WINDOW_EDGE_NORTH_EAST; `} 
+	# The top right corner.
+	new north_east `{ return GDK_WINDOW_EDGE_NORTH_EAST; `}
 
-	#The left edge.
-	new west `{ return GDK_WINDOW_EDGE_WEST; `} 	 	
+	# The left edge.
+	new west `{ return GDK_WINDOW_EDGE_WEST; `}
 
-	#The right edge.
-	new east `{ return GDK_WINDOW_EDGE_EAST; `} 	
+	# The right edge.
+	new east `{ return GDK_WINDOW_EDGE_EAST; `}
 
-	#The lower left corner.
-	new south_west `{ return GDK_WINDOW_EDGE_SOUTH_WEST; `} 
+	# The lower left corner.
+	new south_west `{ return GDK_WINDOW_EDGE_SOUTH_WEST; `}
 
-	#The lower edge.
-	new south `{ return GDK_WINDOW_EDGE_SOUTH; `} 
+	# The lower edge.
+	new south `{ return GDK_WINDOW_EDGE_SOUTH; `}
 
-	#The lower right corner.
-	new south_east `{ return GDK_WINDOW_EDGE_SOUTH_EAST; `} 
+	# The lower right corner.
+	new south_east `{ return GDK_WINDOW_EDGE_SOUTH_EAST; `}
 end
 

--- a/lib/gtk/v3_4/gtk_assistant.nit
+++ b/lib/gtk/v3_4/gtk_assistant.nit
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module gtk_assistant is pkgconfig("gtk+-3.0")
+module gtk_assistant is pkgconfig "gtk+-3.0"
 
 import gtk_core
 
@@ -23,115 +23,115 @@ in "C Header" `{
 	#include <gtk/gtk.h>
 `}
 
-#A widget used to guide users through multi-step operations
-#@https://developer.gnome.org/gtk3/stable/GtkAssistant.html
+# A widget used to guide users through multi-step operations
+# See: https://developer.gnome.org/gtk3/stable/GtkAssistant.html
 extern class GtkAssistant `{GtkAssistant *`}
 	super GtkWindow
 
-	new is extern `{
-		return (GtkAssistant *)gtk_assistant_new( );
+	new `{
+		return (GtkAssistant *)gtk_assistant_new();
 	`}
 
-	fun current_page : Int is extern `{
-		return gtk_assistant_get_current_page ( recv );
+	fun current_page: Int `{
+		return gtk_assistant_get_current_page (recv);
 	`}
 
-	fun current_page=( page_num : Int ) is extern `{
-		gtk_assistant_set_current_page( recv, page_num);
+	fun current_page=(page_num: Int) `{
+		gtk_assistant_set_current_page(recv, page_num);
 	`}
 
-	fun number_pages : Int is extern `{
-		return gtk_assistant_get_n_pages( recv );
+	fun number_pages: Int `{
+		return gtk_assistant_get_n_pages(recv);
 	`}
 
-	fun get_page( page_num : Int ) : GtkWidget is extern `{
-		return gtk_assistant_get_nth_page( recv, page_num );
+	fun get_page(page_num: Int): GtkWidget `{
+		return gtk_assistant_get_nth_page(recv, page_num);
 	`}
 
-	fun prepend( page : GtkWidget ) : Int is extern `{
-		return gtk_assistant_prepend_page( recv, page );
+	fun prepend(page: GtkWidget): Int `{
+		return gtk_assistant_prepend_page(recv, page);
 	`}
 
-	fun append( page : GtkWidget ) : Int is extern `{
-		return gtk_assistant_append_page( recv, page );
+	fun append(page: GtkWidget): Int `{
+		return gtk_assistant_append_page(recv, page);
 	`}
 
-	fun insert( page : GtkWidget, position : Int ) : Int is extern `{
-		return gtk_assistant_insert_page( recv, page, position );
+	fun insert(page: GtkWidget, position: Int): Int `{
+		return gtk_assistant_insert_page(recv, page, position);
 	`}
 
-	fun remove( page_num : Int ) is extern `{
-		gtk_assistant_remove_page( recv, page_num );
+	fun remove(page_num: Int) `{
+		gtk_assistant_remove_page(recv, page_num);
 	`}
 
-	fun get_page_type( page : GtkWidget ) : GtkAssistantPageType is extern `{
-		return gtk_assistant_get_page_type( recv, page );
+	fun get_page_type(page: GtkWidget): GtkAssistantPageType `{
+		return gtk_assistant_get_page_type(recv, page);
 	`}
 
-	fun set_page_type( page : GtkWidget, t : GtkAssistantPageType) is extern `{
-		gtk_assistant_set_page_type( recv, page, t );
+	fun set_page_type(page: GtkWidget, t: GtkAssistantPageType) `{
+		gtk_assistant_set_page_type(recv, page, t);
 	`}
 
-	fun get_page_title( page : GtkWidget ) : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_assistant_get_page_title( recv, page ) );
+	fun get_page_title(page: GtkWidget): String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_assistant_get_page_title(recv, page));
 	`}
 
-	fun set_page_title( page : GtkWidget, title : String) is extern import String.to_cstring `{
-		gtk_assistant_set_page_title( recv, page, String_to_cstring( title ) );
+	fun set_page_title(page: GtkWidget, title: String) import String.to_cstring `{
+		gtk_assistant_set_page_title(recv, page, String_to_cstring(title));
 	`}
 
-	fun set_page_complete( page : GtkWidget, is_complete : Bool ) is extern `{
-		gtk_assistant_set_page_complete( recv, page, is_complete );
+	fun set_page_complete(page: GtkWidget, is_complete: Bool) `{
+		gtk_assistant_set_page_complete(recv, page, is_complete);
 	`}
 
-	fun get_page_complete( page : GtkWidget ) : Bool is extern `{
-		return gtk_assistant_get_page_complete( recv, page );
+	fun get_page_complete(page: GtkWidget): Bool `{
+		return gtk_assistant_get_page_complete(recv, page);
 	`}
 
-	fun remove_action_widget( child : GtkWidget ) is extern `{
-		gtk_assistant_remove_action_widget( recv, child );
+	fun remove_action_widget(child: GtkWidget) `{
+		gtk_assistant_remove_action_widget(recv, child);
 	`}
 
-	fun add_action_widget( child : GtkWidget ) is extern `{
-		gtk_assistant_add_action_widget( recv, child );
+	fun add_action_widget(child: GtkWidget) `{
+		gtk_assistant_add_action_widget(recv, child);
 	`}
 
-	fun update_buttons_state is extern `{
-		gtk_assistant_update_buttons_state( recv );
+	fun update_buttons_state `{
+		gtk_assistant_update_buttons_state(recv);
 	`}
 
-	fun commit is extern `{
-		gtk_assistant_commit( recv );
+	fun commit `{
+		gtk_assistant_commit(recv);
 	`}
 
-	fun next_page is extern `{
-		gtk_assistant_next_page( recv );
+	fun next_page `{
+		gtk_assistant_next_page(recv);
 	`}
 
-	fun previous_page is extern `{
-		gtk_assistant_previous_page( recv );
+	fun previous_page `{
+		gtk_assistant_previous_page(recv);
 	`}
 end
 
-#enum GtkAssistantPageType
-#An enum for determining the page role inside the GtkAssistant. It's used to handle buttons sensitivity and visibility.
-#@https://developer.gnome.org/gtk3/stable/GtkAssistant.html#GtkAssistantPageType
+# enum GtkAssistantPageType
+# An enum for determining the page role inside the GtkAssistant. It's used to handle buttons sensitivity and visibility.
+# See: https://developer.gnome.org/gtk3/stable/GtkAssistant.html#GtkAssistantPageType
 extern class GtkAssistantPageType `{GtkAssistantPageType`}
-	#The page has regular contents. Both the Back and forward buttons will be shown.
+	# The page has regular contents. Both the Back and forward buttons will be shown.
 	new content `{ return GTK_ASSISTANT_PAGE_CONTENT; `}
 
-	#The page contains an introduction to the assistant task. Only the Forward button will be shown if there is a next page.
+	# The page contains an introduction to the assistant task. Only the Forward button will be shown if there is a next page.
 	new intro `{ return GTK_ASSISTANT_PAGE_INTRO; `}
 
-	#The page lets the user confirm or deny the changes. The Back and Apply buttons will be shown.
+	# The page lets the user confirm or deny the changes. The Back and Apply buttons will be shown.
 	new confirm `{ return GTK_ASSISTANT_PAGE_CONFIRM; `}
 
-	#The page informs the user of the changes done. Only the Close button will be shown.
+	# The page informs the user of the changes done. Only the Close button will be shown.
 	new summary `{ return GTK_ASSISTANT_PAGE_SUMMARY; `}
 
-	#Used for tasks that take a long time to complete, blocks the assistant until the page is marked as complete. Only the back button will be shown.
+	# Used for tasks that take a long time to complete, blocks the assistant until the page is marked as complete. Only the back button will be shown.
 	new progress `{ return GTK_ASSISTANT_PAGE_PROGRESS; `}
 
-	#Used for when other page types are not appropriate. No buttons will be shown, and the application must add its own buttons through gtk_assistant_add_action_widget().
+	# Used for when other page types are not appropriate. No buttons will be shown, and the application must add its own buttons through gtk_assistant_add_action_widget().
 	new custom `{ return GTK_ASSISTANT_PAGE_CUSTOM; `}
 end

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -336,9 +336,9 @@ end
 extern class GtkGrid `{GtkGrid *`}
 	super GtkContainer
 
-	# Create a grid with a fixed number of rows and columns
-	new ( rows : Int, columns : Int, homogeneous : Bool ) `{
-		return (GtkGrid*)gtk_grid_new(); // rows, columns, homogeneous );
+	# Create a new grid
+	new `{
+		return (GtkGrid*)gtk_grid_new();
 	`}
 
 	# Set a widget child inside the grid at a given position

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -16,7 +16,10 @@
 # limitations under the License.
 
 # Classes and services to use libGTK widgets
-module gtk_core is pkgconfig("gtk+-3.0")
+module gtk_core is
+	pkgconfig "gtk+-3.0"
+	cflags "-Wno-deprecated-declarations"
+end
 
 import gtk_enums
 import gdk_enums

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -1015,11 +1015,10 @@ extern class GtkAdjustment `{GtkAdjustment *`}
 end
 
 extern class GdkColor `{GdkColor*`}
-	new is extern `{
-		GdkColor * col = malloc(sizeof(GdkColor));
-		/*gdk_color_parse( "red", recv );*/
-		gdk_color_parse( "red", col);
-		return col;
+	new (color_name: String) import String.to_cstring `{
+		GdkColor *color = malloc(sizeof(GdkColor));
+		gdk_color_parse(String_to_cstring(color_name), color);
+		return color;
 	`}
 end
 

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -360,6 +360,21 @@ extern class GtkGrid `{GtkGrid *`}
 	`}
 end
 
+# A widget that can switch orientation
+extern class GtkOrientable `{GtkOrientable *`}
+	super GtkWidget
+
+	# Get the orientation of this widget
+	fun orientation: GtkOrientation `{
+		return gtk_orientable_get_orientation(recv);
+	`}
+
+	# Set the orientation of this widget
+	fun orientation=(orientation: GtkOrientation) `{
+		gtk_orientable_set_orientation(recv, orientation);
+	`}
+end
+
 # A container box
 #
 # See: https://developer.gnome.org/gtk3/3.4/GtkBox.html

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -386,6 +386,29 @@ extern class GtkBox `{ GtkBox * `}
 	new (orientation: GtkOrientation, spacing: Int) `{
 		return (GtkBox *)gtk_box_new(orientation, spacing);
 	`}
+
+	# Give the children of `self` equal space in the box?
+	fun omogeneous: Bool `{ return gtk_box_get_homogeneous(recv); `}
+
+	# Give the children of `self` equal space in the box?
+	fun omogeneous=(omogeneous: Bool) `{
+		gtk_box_set_homogeneous(recv, omogeneous);
+	`}
+
+	# Add `child` and pack it at the start of the box
+	fun pack_start(child: GtkWidget, expand, fill: Bool, padding: Int) `{
+		gtk_box_pack_start(recv, child, expand, fill, padding);
+	`}
+
+	# Add `child` and pack it at the end of the box
+	fun pack_end(child: GtkWidget, expand, fill: Bool, padding: Int) `{
+		gtk_box_pack_end(recv, child, expand, fill, padding);
+	`}
+
+	# Set the way `child` is packed in `self`
+	fun set_child_packing(child: GtkWidget, expand, fill: Bool, padding: Int, packing: GtkPackType) `{
+		gtk_box_set_child_packing(recv, child, expand, fill, padding, packing);
+	`}
 end
 
 # The tree interface used by GtkTreeView

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -1024,7 +1024,5 @@ extern class GdkColor `{GdkColor*`}
 end
 
 extern class GdkRGBA `{GdkRGBA*`}
-	new is extern `{
-	`}
 end
 

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -174,12 +174,13 @@ end
 extern class GtkWindow `{GtkWindow *`}
 	super GtkBin
 
-	new (flag: Int) `{
-		GtkWindow *win;
+	new (typ: GtkWindowType) `{
+		return (GtkWindow *)gtk_window_new(typ);
+	`}
 
-		win = GTK_WINDOW(gtk_window_new(flag));
-		g_signal_connect(win, "destroy", G_CALLBACK(gtk_main_quit), NULL);
-		return win;
+	# Connect the "destroy" signal to `quit_gtk`
+	fun connect_destroy_signal_to_quit `{
+		g_signal_connect(recv, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 	`}
 
 	fun title=(title: String) import String.to_cstring `{

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -29,94 +29,95 @@ in "C Header" `{
 `}
 
 `{
-		/* callback user data */
-		typedef struct {
-			GtkCallable to_call;
-			nullable_Object user_data;
-		} NitGtkSignal;
+	/* callback user data */
+	typedef struct {
+		GtkCallable to_call;
+		nullable_Object user_data;
+	} NitGtkSignal;
 
-		void nit_gtk_callback_func( GtkWidget *widget,
-							gpointer   callback_data ) {
-			NitGtkSignal *data;
-			data = (NitGtkSignal*)callback_data;
-			GtkCallable_signal( data->to_call, widget, data->user_data );
-		}
+	void nit_gtk_callback_func(GtkWidget *widget, gpointer callback_data) {
+		NitGtkSignal *data;
+		data = (NitGtkSignal*)callback_data;
+		GtkCallable_signal(data->to_call, widget, data->user_data);
+	}
 `}
 
-redef interface Object
-	protected fun init_gtk `{ gtk_init( 0, NULL ); `}
-	protected fun run_gtk `{ gtk_main(); `}
-	protected fun quit_gtk `{ gtk_main_quit(); `}
-end
+# Initialize the GTK system
+fun init_gtk `{ gtk_init(0, NULL); `}
+
+# Hand over control to the GTK event loop
+fun run_gtk `{ gtk_main(); `}
+
+# Quit the GTK event loop and clean up the system
+fun quit_gtk `{ gtk_main_quit(); `}
 
 interface GtkCallable
 	# return true to stop event processing, false to let it propagate
-	fun signal( sender : GtkWidget, user_data : nullable Object ) is abstract
+	fun signal(sender: GtkWidget, user_data: nullable Object) is abstract
 end
 
 extern class GdkEvent `{GdkEvent *`}
 end
 
-
-#Base class for all widgets
-#@https://developer.gnome.org/gtk3/stable/GtkWidget.html
+# Base class for all widgets
+# See: https://developer.gnome.org/gtk3/stable/GtkWidget.html
 extern class GtkWidget `{GtkWidget *`}
-	fun show_all is extern `{ gtk_widget_show_all( recv ); `}
+	fun show_all `{ gtk_widget_show_all(recv); `}
 
-	fun signal_connect( signal_name : String, to_call : GtkCallable, user_data : nullable Object ) is extern import String.to_cstring, GtkCallable.signal, Object.as not nullable `{
-		NitGtkSignal *data = malloc( sizeof(NitGtkSignal) );
+	fun signal_connect(signal_name: String, to_call: GtkCallable, user_data: nullable Object) import String.to_cstring, GtkCallable.signal, Object.as not nullable `{
+		NitGtkSignal *data = malloc(sizeof(NitGtkSignal));
 
-		GtkCallable_incr_ref( to_call );
-		Object_incr_ref( user_data );
+		GtkCallable_incr_ref(to_call);
+		Object_incr_ref(user_data);
 
 		data->to_call = to_call;
 		data->user_data = user_data;
 
 		/*Use G_CALLBACK() to cast the callback function to a GCallback*/
-		g_signal_connect( recv,
-							String_to_cstring( signal_name ),
-							G_CALLBACK(nit_gtk_callback_func),
-							data );
+		g_signal_connect(recv,
+		                 String_to_cstring(signal_name),
+		                 G_CALLBACK(nit_gtk_callback_func),
+		                 data);
 	`}
 
-	redef fun == ( o ) do return o isa GtkWidget and equal_to_gtk_widget( o )
+	redef fun ==(o) do return o isa GtkWidget and equal_to_gtk_widget(o)
 
-	private fun equal_to_gtk_widget( o : GtkWidget ) : Bool `{
+	private fun equal_to_gtk_widget(o: GtkWidget): Bool `{
 		return recv == o;
 	`}
 
-	fun request_size( width, height : Int ) `{
-		gtk_widget_set_size_request( recv, width, height );
+	fun request_size(width, height: Int) `{
+		gtk_widget_set_size_request(recv, width, height);
 	`}
 
-	fun bg_color=( state : GtkStateType, color : GdkRGBA ) is extern `{
-		gtk_widget_override_background_color( recv, state, color);
+	fun bg_color=(state: GtkStateType, color: GdkRGBA) `{
+		gtk_widget_override_background_color(recv, state, color);
 	`}
 
-	#with gtk it's possible to set fg_color to all widget : is it correct? is fg color inherited?
-	#GdkColor color;
-	fun fg_color=( state : GtkStateType, color : GdkRGBA ) is extern `{
-		gtk_widget_override_color( recv, state, color);
+	# with gtk it's possible to set fg_color to all widget: is it correct? is fg color inherited?
+	# GdkColor color;
+	fun fg_color=(state: GtkStateType, color: GdkRGBA) `{
+		gtk_widget_override_color(recv, state, color);
 	`}
-	
+
 	# Sets the sensitivity of a widget. sensitive -> the user can interact with it.
 	# Insensitive -> widget "grayed out" and the user can"t interact with them
-	fun sensitive=(sensitive : Bool) is extern `{
+	fun sensitive=(sensitive: Bool) `{
 		gtk_widget_set_sensitive(recv, sensitive);
 	`}
-	
+
 	# return the sensitivity of the widget
-	fun sensitive: Bool is extern `{
+	fun sensitive: Bool `{
 		return gtk_widget_get_sensitive(recv);
 	`}
-	
+
 	# Set the visibility of the widget
-	fun visible=(visible: Bool) is extern `{
+	fun visible=(visible: Bool) `{
 		gtk_widget_set_visible(recv, visible);
 	`}
 
 	# Get the visibility of the widget only
-	fun visible_self: Bool is extern `{
+	fun visible_self: Bool `{
 		return gtk_widget_get_visible(recv);
 	`}
 
@@ -132,207 +133,204 @@ extern class GtkWidget `{GtkWidget *`}
 	fun hide `{ gtk_widget_hide(recv); `}
 end
 
-#Base class for widgets which contain other widgets
-#@https://developer.gnome.org/gtk3/stable/GtkContainer.html
+# Base class for widgets which contain other widgets
+# See: https://developer.gnome.org/gtk3/stable/GtkContainer.html
 extern class GtkContainer `{GtkContainer *`}
 	super GtkWidget
 
 	# Add a widget to the container
-	fun add( widget : GtkWidget ) is extern `{
-		gtk_container_add( recv, widget );
+	fun add(widget: GtkWidget) `{
+		gtk_container_add(recv, widget);
 	`}
 	# Remove the widget from the container
-	fun remove_widget( widget : GtkWidget ) is extern `{
-		gtk_container_remove( recv, widget );
+	fun remove_widget(widget: GtkWidget) `{
+		gtk_container_remove(recv, widget);
 	`}
 
 	# Get the resize mode of the container
-	fun resize_mode : GtkResizeMode is extern `{
-		return gtk_container_get_resize_mode( recv );
+	fun resize_mode: GtkResizeMode `{
+		return gtk_container_get_resize_mode(recv);
 	`}
 
 	# Set the resize mode of the container
-	fun resize_mode=( resize_mode: GtkResizeMode ) is extern `{
-		gtk_container_set_resize_mode( recv, resize_mode );
+	fun resize_mode=(resize_mode: GtkResizeMode) `{
+		gtk_container_set_resize_mode(recv, resize_mode);
 	`}
 
 end
 
-#A container with just one child
-#@https://developer.gnome.org/gtk3/stable/GtkBin.html
+# A container with just one child
+# See: https://developer.gnome.org/gtk3/stable/GtkBin.html
 extern class GtkBin `{GtkBin *`}
 	super GtkContainer
 
-	fun child : GtkWidget is extern `{
-		return gtk_bin_get_child( recv );
+	fun child: GtkWidget `{
+		return gtk_bin_get_child(recv);
 	`}
 end
 
-#Toplevel which can contain other widgets
-#@https://developer.gnome.org/gtk3/stable/GtkWindow.html
+# Toplevel which can contain other widgets
+# See: https://developer.gnome.org/gtk3/stable/GtkWindow.html
 extern class GtkWindow `{GtkWindow *`}
 	super GtkBin
 
-	new ( flag : Int ) is extern `{
+	new (flag: Int) `{
 		GtkWindow *win;
 
-		win = GTK_WINDOW(gtk_window_new( flag ));
+		win = GTK_WINDOW(gtk_window_new(flag));
 		g_signal_connect(win, "destroy", G_CALLBACK(gtk_main_quit), NULL);
 		return win;
 	`}
 
-	fun title=( title : String ) is extern import String.to_cstring `{
-		gtk_window_set_title( recv, String_to_cstring( title ) );
+	fun title=(title: String) import String.to_cstring `{
+		gtk_window_set_title(recv, String_to_cstring(title));
 	`}
 
-	#The "destroy" signal is emitted when a widget is destroyed, either by explicitly calling gtk_widget_destroy() or when the widget is unparented. Top-level GtkWindows are also destroyed when the Close window control button is clicked.
-	fun on_close( to_call : GtkCallable, user_data : nullable Object )
+	# The "destroy" signal is emitted when a widget is destroyed, either by explicitly calling gtk_widget_destroy() or when the widget is unparented. Top-level GtkWindows are also destroyed when the Close window control button is clicked.
+	fun on_close(to_call: GtkCallable, user_data: nullable Object)
 	do
-		signal_connect( "destroy", to_call, user_data )
+		signal_connect("destroy", to_call, user_data)
 	end
 
-	fun resizable : Bool is extern `{
-		return gtk_window_get_resizable( recv );
+	fun resizable: Bool `{
+		return gtk_window_get_resizable(recv);
 	`}
 
-	fun resizable=( is_resizable : Bool) is extern `{
-		return gtk_window_set_resizable( recv, is_resizable );
+	fun resizable=(is_resizable: Bool) `{
+		return gtk_window_set_resizable(recv, is_resizable);
 	`}
 
-	#Activates the current focused widget within the window.
-	#returns TRUE if a widget got activated.
-	fun activate_focus : Bool is extern `{
-		return gtk_window_activate_focus( recv );
+	# Activates the current focused widget within the window.
+	# returns TRUE if a widget got activated.
+	fun activate_focus: Bool `{
+		return gtk_window_activate_focus(recv);
 	`}
 
-	#Sets a window modal or non-modal. Modal windows prevent interaction with other windows in the same application.
-	fun modal=( is_modal : Bool ) is extern `{
-		gtk_window_set_modal( recv, is_modal );
+	# Sets a window modal or non-modal. Modal windows prevent interaction with other windows in the same application.
+	fun modal=(is_modal: Bool) `{
+		gtk_window_set_modal(recv, is_modal);
 	`}
 
-	#Windows can't actually be 0x0 in size, they must be at least 1x1
-	#but passing 0 for width and height is OK, resulting in a 1x1 default size.
-	#params width in pixels, or -1 to unset the default width
-	#params height in pixels, or -1 to unset the default height
-	fun default_size( width : Int, height : Int ) is extern `{
-		gtk_window_set_default_size( recv, width, height );
+	# Windows can't actually be 0x0 in size, they must be at least 1x1
+	# but passing 0 for width and height is OK, resulting in a 1x1 default size.
+	# params width in pixels, or -1 to unset the default width
+	# params height in pixels, or -1 to unset the default height
+	fun default_size(width: Int, height: Int) `{
+		gtk_window_set_default_size(recv, width, height);
 	`}
 
-	#Activates the default widget for the window
-	#unless the current focused widget has been configured to receive the default action (see gtk_widget_set_receives_default()), in which case the focused widget is activated.
-	fun activate_default : Bool is extern `{
-		return gtk_window_activate_default( recv );
+	# Activates the default widget for the window
+	# unless the current focused widget has been configured to receive the default action (see gtk_widget_set_receives_default()), in which case the focused widget is activated.
+	fun activate_default: Bool `{
+		return gtk_window_activate_default(recv);
 	`}
 
-	fun gravity : GdkGravity is extern `{
-		return gtk_window_get_gravity( recv );
+	fun gravity: GdkGravity `{
+		return gtk_window_get_gravity(recv);
 	`}
 
-	fun gravity=( window_grav : GdkGravity ) is extern `{
-		gtk_window_set_gravity( recv, window_grav );
+	fun gravity=(window_grav: GdkGravity) `{
+		gtk_window_set_gravity(recv, window_grav);
 	`}
 
-#	fun position : GtkWindowPosition is extern `{
-#		return gtk_window_get_position( recv );
+#	fun position: GtkWindowPosition `{
+#		return gtk_window_get_position(recv);
 #	`}
 #
-#	fun position=( window_pos : GtkWindowPosition ) is extern `{
-#		gtk_window_set_position( recv, window_pos );
+#	fun position=(window_pos: GtkWindowPosition) `{
+#		gtk_window_set_position(recv, window_pos);
 #	`}
 
-	fun active : Bool is extern `{
-		return gtk_window_is_active( recv );
+	fun active: Bool `{
+		return gtk_window_is_active(recv);
 	`}
 
-	#Returns whether the input focus is within this GtkWindow. For real toplevel windows, this is identical to gtk_window_is_active(), but for embedded windows, like GtkPlug, the results will differ.
-	fun has_toplevel_focus : Bool is extern `{
-		return gtk_window_has_toplevel_focus( recv );
+	# Returns whether the input focus is within this GtkWindow. For real toplevel windows, this is identical to gtk_window_is_active(), but for embedded windows, like GtkPlug, the results will differ.
+	fun has_toplevel_focus: Bool `{
+		return gtk_window_has_toplevel_focus(recv);
 	`}
 
-	fun get_focus : GtkWidget is extern `{
-		return gtk_window_get_focus( recv );
+	fun get_focus: GtkWidget `{
+		return gtk_window_get_focus(recv);
 	`}
 
-	fun set_focus( widget : GtkWidget ) is extern `{
-		return gtk_window_set_focus( recv, widget );
+	fun set_focus(widget: GtkWidget) `{
+		return gtk_window_set_focus(recv, widget);
 	`}
 
-	fun get_default_widget : GtkWidget is extern `{
-		return gtk_window_get_default_widget( recv );
+	fun get_default_widget: GtkWidget `{
+		return gtk_window_get_default_widget(recv);
 	`}
 
-	fun set_default_widget( widget : GtkWidget ) is extern `{
-		return gtk_window_set_default( recv, widget );
+	fun set_default_widget(widget: GtkWidget) `{
+		return gtk_window_set_default(recv, widget);
 	`}
 
-	fun maximize is extern `{
-		return gtk_window_maximize( recv );
+	fun maximize `{
+		return gtk_window_maximize(recv);
 	`}
 
-	fun unmaximize is extern `{
-		return gtk_window_unmaximize( recv );
+	fun unmaximize `{
+		return gtk_window_unmaximize(recv);
 	`}
 
-	fun fullscreen is extern `{
-		return gtk_window_fullscreen( recv );
+	fun fullscreen `{
+		return gtk_window_fullscreen(recv);
 	`}
 
-	fun unfullscreen is extern `{
-		return gtk_window_unfullscreen( recv );
+	fun unfullscreen `{
+		return gtk_window_unfullscreen(recv);
 	`}
 
-	fun keep_above=( setting : Bool ) is extern `{
-		gtk_window_set_keep_above( recv, setting );
+	fun keep_above=(setting: Bool) `{
+		gtk_window_set_keep_above(recv, setting);
 	`}
 
-	fun keep_below=( setting : Bool ) is extern `{
-		gtk_window_set_keep_below( recv, setting );
+	fun keep_below=(setting: Bool) `{
+		gtk_window_set_keep_below(recv, setting);
 	`}
 end
 
-#A bin with a decorative frame and optional label
-#https://developer.gnome.org/gtk3/stable/GtkFrame.html
+# A bin with a decorative frame and optional label
+# https://developer.gnome.org/gtk3/stable/GtkFrame.html
 extern class GtkFrame `{GtkFrame *`}
 	super GtkBin
 
-	new ( lbl : String ) is extern import String.to_cstring`{
-		return (GtkFrame *)gtk_frame_new( String_to_cstring( lbl ) );
+	new (lbl: String) import String.to_cstring `{
+		return (GtkFrame *)gtk_frame_new(String_to_cstring(lbl));
 	`}
 
-	fun frame_label : String is extern`{
-		return NativeString_to_s( (char *)gtk_frame_get_label( recv ) );
+	fun frame_label: String `{
+		return NativeString_to_s((char *)gtk_frame_get_label(recv));
 	`}
 
-	fun frame_label=( lbl : String ) is extern import String.to_cstring`{
-		gtk_frame_set_label( recv, String_to_cstring( lbl ) );
+	fun frame_label=(lbl: String) import String.to_cstring `{
+		gtk_frame_set_label(recv, String_to_cstring(lbl));
 	`}
 
-	fun label_widget : GtkWidget is extern `{
-		return gtk_frame_get_label_widget( recv );
+	fun label_widget: GtkWidget `{
+		return gtk_frame_get_label_widget(recv);
 	`}
 
-	fun label_widget=( widget : GtkWidget ) is extern `{
-		gtk_frame_set_label_widget( recv, widget );
+	fun label_widget=(widget: GtkWidget) `{
+		gtk_frame_set_label_widget(recv, widget);
 	`}
 
-	fun shadow_type : GtkShadowType is extern `{
-		return gtk_frame_get_shadow_type( recv );
+	fun shadow_type: GtkShadowType `{
+		return gtk_frame_get_shadow_type(recv);
 	`}
 
-	fun shadow_type=( stype : GtkShadowType ) is extern `{
-		gtk_frame_set_shadow_type( recv, stype );
+	fun shadow_type=(stype: GtkShadowType) `{
+		gtk_frame_set_shadow_type(recv, stype);
 	`}
 
-	#fun label_align : GtkShadowType is extern `{
-	#`}
-
-	fun label_align=( xalign : Float, yalign : Float ) is extern `{
-		gtk_frame_set_label_align( recv, xalign, yalign );
+	fun label_align=(xalign: Float, yalign: Float) `{
+		gtk_frame_set_label_align(recv, xalign, yalign);
 	`}
 end
 
-#Pack widgets in a rows and columns
-#@https://developer.gnome.org/gtk3/3.3/GtkGrid.html
+# Pack widgets in a rows and columns
+# See: https://developer.gnome.org/gtk3/3.3/GtkGrid.html
 extern class GtkGrid `{GtkGrid *`}
 	super GtkContainer
 
@@ -342,329 +340,326 @@ extern class GtkGrid `{GtkGrid *`}
 	`}
 
 	# Set a widget child inside the grid at a given position
-	fun attach( child : GtkWidget, left, top, width, height : Int ) `{
-		gtk_grid_attach( recv, child, left, top, width, height );
+	fun attach(child: GtkWidget, left, top, width, height: Int) `{
+		gtk_grid_attach(recv, child, left, top, width, height);
 	`}
 
 	# Get the child of the Grid at the given position
-	fun get_child_at( left : Int, top : Int ): GtkWidget is extern `{
-		return gtk_grid_get_child_at( recv, left, top );
+	fun get_child_at(left: Int, top: Int): GtkWidget `{
+		return gtk_grid_get_child_at(recv, left, top);
 	`}
 
 	# Insert a row at the specified position
-	fun insert_row( position :Int ) is extern `{
-		gtk_grid_insert_row( recv, position );
+	fun insert_row(position:Int) `{
+		gtk_grid_insert_row(recv, position);
 	`}
 
 	# Insert a column at the specified position
-	fun insert_column( position : Int ) is extern `{
-		gtk_grid_insert_column( recv, position );
+	fun insert_column(position: Int) `{
+		gtk_grid_insert_column(recv, position);
 	`}
 end
 
 # A container box
 #
-# @https://developer.gnome.org/gtk3/3.4/GtkBox.html
+# See: https://developer.gnome.org/gtk3/3.4/GtkBox.html
 extern class GtkBox `{ GtkBox * `}
 	super GtkContainer
 end
 
-#The tree interface used by GtkTreeView
-#@https://developer.gnome.org/gtk3/stable/GtkTreeModel.html
+# The tree interface used by GtkTreeView
+# See: https://developer.gnome.org/gtk3/stable/GtkTreeModel.html
 extern class GtkTreeModel `{GtkTreeModel *`}
 end
 
-#An abstract class for laying out GtkCellRenderers
-#@https://developer.gnome.org/gtk3/stable/GtkCellArea.html
+# An abstract class for laying out GtkCellRenderers
+# See: https://developer.gnome.org/gtk3/stable/GtkCellArea.html
 extern class GtkCellArea `{GtkCellArea *`}
 end
 
-#Base class for widgets with alignments and padding
-#@https://developer.gnome.org/gtk3/3.2/GtkMisc.html
+# Base class for widgets with alignments and padding
+# See: https://developer.gnome.org/gtk3/3.2/GtkMisc.html
 extern class GtkMisc `{GtkMisc *`}
 	super GtkWidget
 
-	fun alignment : GtkAlignment is abstract
+	fun alignment: GtkAlignment is abstract
 
-	fun alignment=( x : Float, y : Float ) is extern `{
-		gtk_misc_set_alignment( recv, x, y );
+	fun alignment=(x: Float, y: Float) `{
+		gtk_misc_set_alignment(recv, x, y);
 	`}
 
-	fun padding : GtkAlignment is abstract
+	fun padding: GtkAlignment is abstract
 
-	fun padding=( x : Float, y : Float ) is extern `{
-		gtk_misc_set_padding( recv, x, y );
+	fun padding=(x: Float, y: Float) `{
+		gtk_misc_set_padding(recv, x, y);
 	`}
 
 end
 
-#A single line text entry field
-#@https://developer.gnome.org/gtk3/3.2/GtkEntry.html
+# A single line text entry field
+# See: https://developer.gnome.org/gtk3/3.2/GtkEntry.html
 extern class GtkEntry `{GtkEntry *`}
 	super GtkWidget
 
-	new is extern `{
+	new `{
 		 return (GtkEntry *)gtk_entry_new();
 	`}
 
-	fun text : String is extern import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy( (char *)gtk_entry_get_text( recv ) );
+	fun text: String import NativeString.to_s_with_copy `{
+		return NativeString_to_s_with_copy((char *)gtk_entry_get_text(recv));
 	`}
 
-	fun text=( value : String) is extern import String.to_cstring`{
-		gtk_entry_set_text( recv, String_to_cstring( value ) );
+	fun text=(value: String) import String.to_cstring `{
+		gtk_entry_set_text(recv, String_to_cstring(value));
 	`}
 
 	# Is the text visible or is it the invisible char (such as '*')?
-	fun visiblility: Bool is extern `{
-		return gtk_entry_get_visibility( recv );
+	fun visiblility: Bool `{
+		return gtk_entry_get_visibility(recv);
 	`}
 
 	# Set the text visiblility
 	# If false, will use the invisible char (such as '*')
-	fun visibility=( is_visible : Bool) is extern `{
-		gtk_entry_set_visibility( recv, is_visible );
+	fun visibility=(is_visible: Bool) `{
+		gtk_entry_set_visibility(recv, is_visible);
 	`}
 
-	fun max_length : Int is extern `{
-		return gtk_entry_get_max_length( recv );
+	fun max_length: Int `{
+		return gtk_entry_get_max_length(recv);
 	`}
 
-	fun max_length=( max : Int) is extern `{
-		gtk_entry_set_max_length( recv, max );
+	fun max_length=(max: Int) `{
+		gtk_entry_set_max_length(recv, max);
 	`}
 end
 
-#Base class for widgets which visualize an adjustment
-#@https://developer.gnome.org/gtk3/3.2/GtkRange.html
+# Base class for widgets which visualize an adjustment
+# See: https://developer.gnome.org/gtk3/3.2/GtkRange.html
 extern class GtkRange `{GtkRange *`}
 	super GtkWidget
 
-	#Gets the current position of the fill level indicator.
-	fun fill_level : Float is extern `{
-		return gtk_range_get_fill_level( recv );
+	# Gets the current position of the fill level indicator.
+	fun fill_level: Float `{
+		return gtk_range_get_fill_level(recv);
 	`}
 
-	fun fill_level=( level : Float ) is extern `{
-		gtk_range_set_fill_level( recv, level );
+	fun fill_level=(level: Float) `{
+		gtk_range_set_fill_level(recv, level);
 	`}
 
-	#Gets whether the range is restricted to the fill level.
-	fun restricted_to_fill_level : Bool is extern `{
-		return gtk_range_get_restrict_to_fill_level( recv );
+	# Gets whether the range is restricted to the fill level.
+	fun restricted_to_fill_level: Bool `{
+		return gtk_range_get_restrict_to_fill_level(recv);
 	`}
 
-	fun restricted_to_fill_level=( restricted : Bool ) is extern `{
-		gtk_range_set_restrict_to_fill_level( recv, restricted );
+	fun restricted_to_fill_level=(restricted: Bool) `{
+		gtk_range_set_restrict_to_fill_level(recv, restricted);
 	`}
 
-	#Gets whether the range displays the fill level graphically.
-	fun show_fill_level : Bool is extern `{
-		return gtk_range_get_show_fill_level( recv );
+	# Gets whether the range displays the fill level graphically.
+	fun show_fill_level: Bool `{
+		return gtk_range_get_show_fill_level(recv);
 	`}
 
- 	fun show_fill_level=( is_displayed : Bool ) is extern `{
-		gtk_range_set_show_fill_level( recv, is_displayed );
+	fun show_fill_level=(is_displayed: Bool) `{
+		gtk_range_set_show_fill_level(recv, is_displayed);
 	`}
 
-	fun adjustment : GtkAdjustment is extern `{
-		return gtk_range_get_adjustment( recv );
+	fun adjustment: GtkAdjustment `{
+		return gtk_range_get_adjustment(recv);
 	`}
 
- 	fun adjustment=( value : GtkAdjustment ) is extern `{
-		gtk_range_set_adjustment( recv, value );
+	fun adjustment=(value: GtkAdjustment) `{
+		gtk_range_set_adjustment(recv, value);
 	`}
 
-	fun inverted : Bool is extern `{
-		return gtk_range_get_inverted( recv );
+	fun inverted: Bool `{
+		return gtk_range_get_inverted(recv);
 	`}
 
- 	fun inverted=( setting : Bool ) is extern `{
-		gtk_range_set_inverted( recv, setting );
+	fun inverted=(setting: Bool) `{
+		gtk_range_set_inverted(recv, setting);
 	`}
 
-	fun value : Float is extern `{
-		return gtk_range_get_value( recv );
+	fun value: Float `{
+		return gtk_range_get_value(recv);
 	`}
 
- 	fun value=( val : Float ) is extern `{
-		gtk_range_set_value( recv, val );
+	fun value=(val: Float) `{
+		gtk_range_set_value(recv, val);
 	`}
 
-	fun set_increments( step : Float, page : Float ) is extern `{
-		gtk_range_set_increments( recv, step, page );
+	fun set_increments(step: Float, page: Float) `{
+		gtk_range_set_increments(recv, step, page);
 	`}
 
-	fun set_range( min : Float, max : Float ) is extern `{
-		gtk_range_set_range( recv, min, max );
+	fun set_range(min: Float, max: Float) `{
+		gtk_range_set_range(recv, min, max);
 	`}
 
-	fun round_digits : Int is extern `{
-		return gtk_range_get_round_digits( recv );
+	fun round_digits: Int `{
+		return gtk_range_get_round_digits(recv);
 	`}
 
- 	fun round_digits=( nb : Int ) is extern `{
-		gtk_range_set_round_digits( recv, nb );
+	fun round_digits=(nb: Int) `{
+		gtk_range_set_round_digits(recv, nb);
 	`}
 
-	fun size_fixed : Bool is extern `{
-		return gtk_range_get_slider_size_fixed( recv );
+	fun size_fixed: Bool `{
+		return gtk_range_get_slider_size_fixed(recv);
 	`}
 
-	fun size_fixed=( is_fixed : Bool ) is extern `{
-		return gtk_range_set_slider_size_fixed( recv, is_fixed );
+	fun size_fixed=(is_fixed: Bool) `{
+		return gtk_range_set_slider_size_fixed(recv, is_fixed);
 	`}
 
-	fun flippable : Bool is extern `{
-		return gtk_range_get_flippable( recv );
+	fun flippable: Bool `{
+		return gtk_range_get_flippable(recv);
 	`}
 
-	fun min_size=( is_flippable : Bool ) is extern `{
-		return gtk_range_set_flippable( recv, is_flippable );
+	fun min_size=(is_flippable: Bool) `{
+		return gtk_range_set_flippable(recv, is_flippable);
 	`}
 
-	fun min_slider_size : Int is extern `{
-		return gtk_range_get_min_slider_size( recv );
+	fun min_slider_size: Int `{
+		return gtk_range_get_min_slider_size(recv);
 	`}
 
-	fun min_slider_size=( size : Int ) is extern `{
-		return gtk_range_set_min_slider_size( recv, size );
+	fun min_slider_size=(size: Int) `{
+		return gtk_range_set_min_slider_size(recv, size);
 	`}
 end
 
-#A slider widget for selecting a value from a range
-#@https://developer.gnome.org/gtk3/3.2/GtkScale.html
+# A slider widget for selecting a value from a range
+# See: https://developer.gnome.org/gtk3/3.2/GtkScale.html
 extern class GtkScale `{GtkScale *`}
 	super GtkRange
 
-	new ( orientation : GtkOrientation, adjustment : GtkAdjustment ) is extern `{
-		return (GtkScale *)gtk_scale_new( orientation, adjustment );
+	new (orientation: GtkOrientation, adjustment: GtkAdjustment) `{
+		return (GtkScale *)gtk_scale_new(orientation, adjustment);
 	`}
 
-	new with_range ( orientation : GtkOrientation, min : Float, max : Float, step : Float ) is extern `{
-		return (GtkScale *)gtk_scale_new_with_range( orientation, min, max, step );
+	new with_range (orientation: GtkOrientation, min: Float, max: Float, step: Float) `{
+		return (GtkScale *)gtk_scale_new_with_range(orientation, min, max, step);
 	`}
 
-	fun digits : Int is extern `{
-		return gtk_scale_get_digits( recv );
+	fun digits: Int `{
+		return gtk_scale_get_digits(recv);
 	`}
 
-	fun digits=( nb_digits : Int ) is extern `{
-		gtk_scale_set_digits( recv, nb_digits );
+	fun digits=(nb_digits: Int) `{
+		gtk_scale_set_digits(recv, nb_digits);
 	`}
 
-	fun draw_value : Bool is extern `{
-		return gtk_scale_get_draw_value( recv );
+	fun draw_value: Bool `{
+		return gtk_scale_get_draw_value(recv);
 	`}
 
-	fun draw_value=( is_displayed : Bool ) is extern `{
-		gtk_scale_set_draw_value( recv, is_displayed );
+	fun draw_value=(is_displayed: Bool) `{
+		gtk_scale_set_draw_value(recv, is_displayed);
 	`}
 
-	fun value_position : GtkPositionType is extern `{
-		return gtk_scale_get_value_pos( recv );
+	fun value_position: GtkPositionType `{
+		return gtk_scale_get_value_pos(recv);
 	`}
 
-	fun value_position=( pos : GtkPositionType ) is extern `{
-		gtk_scale_set_value_pos( recv, pos );
+	fun value_position=(pos: GtkPositionType) `{
+		gtk_scale_set_value_pos(recv, pos);
 	`}
 
-	fun has_origin : Bool is extern `{
-		return gtk_scale_get_has_origin( recv );
+	fun has_origin: Bool `{
+		return gtk_scale_get_has_origin(recv);
 	`}
 
-	fun has_origin=( orig : Bool ) is extern `{
-		gtk_scale_set_has_origin( recv, orig );
+	fun has_origin=(orig: Bool) `{
+		gtk_scale_set_has_origin(recv, orig);
 	`}
 
-	fun add_mark( value : Float, position : GtkPositionType, markup : String ) is extern import String.to_cstring`{
-		gtk_scale_add_mark( recv, value, position, String_to_cstring( markup ) );
+	fun add_mark(value: Float, position: GtkPositionType, markup: String)
+	import String.to_cstring `{
+		gtk_scale_add_mark(recv, value, position, String_to_cstring(markup));
 	`}
 
-	#Removes any marks that have been added with gtk_scale_add_mark().
-	fun clear_marks is extern `{
-		gtk_scale_clear_marks( recv );
+	# Removes any marks that have been added with gtk_scale_add_mark().
+	fun clear_marks `{
+		gtk_scale_clear_marks(recv);
 	`}
-
-	#get layout
-	#get layout offsets
-
 end
 
-#A scrollbar
-#@https://developer.gnome.org/gtk3/3.2/GtkScrollbar.html
+# A scrollbar
+# See: https://developer.gnome.org/gtk3/3.2/GtkScrollbar.html
 extern class GtkScrollbar `{GtkScrollbar *`}
 	super GtkRange
 
-		new ( orientation : GtkOrientation, adjustment : GtkAdjustment ) is extern `{
-		return (GtkScrollbar *)gtk_scrollbar_new( orientation, adjustment );
+		new (orientation: GtkOrientation, adjustment: GtkAdjustment) `{
+		return (GtkScrollbar *)gtk_scrollbar_new(orientation, adjustment);
 	`}
 end
 
-#A widget that displays a small to medium amount of text
-#@https://developer.gnome.org/gtk3/3.2/GtkLabel.html
+# A widget that displays a small to medium amount of text
+# See: https://developer.gnome.org/gtk3/3.2/GtkLabel.html
 extern class GtkLabel `{GtkLabel *`}
 	super GtkMisc
 
 	# Create a GtkLabel with text
-	new ( text : String ) is extern import String.to_cstring `{
-		return (GtkLabel*)gtk_label_new( String_to_cstring( text ) );
+	new (text: String) import String.to_cstring `{
+		return (GtkLabel*)gtk_label_new(String_to_cstring(text));
 	`}
 
 	# Set the text of the label
-	fun text=( text : String ) import String.to_cstring `{
-		gtk_label_set_text( recv, String_to_cstring( text ) );
+	fun text=(text: String) import String.to_cstring `{
+		gtk_label_set_text(recv, String_to_cstring(text));
 	`}
 
 	# Returns the text of the label
-	fun text : String import NativeString.to_s `{
-		return NativeString_to_s( (char*)gtk_label_get_text( recv ) );
+	fun text: String import NativeString.to_s `{
+		return NativeString_to_s((char*)gtk_label_get_text(recv));
 	`}
 
 	# Sets the angle of rotation for the label.
 	# An angle of 90 reads from from bottom to top, an angle of 270, from top to bottom.
-	fun angle=( degre : Float ) `{
-		gtk_label_set_angle( recv, degre );
+	fun angle=(degre: Float) `{
+		gtk_label_set_angle(recv, degre);
 	`}
 
 	# Returns the angle of rotation for the label.
-	fun angle : Float `{
-		return gtk_label_get_angle( recv );
+	fun angle: Float `{
+		return gtk_label_get_angle(recv);
 	`}
 
 end
 
-#A widget displaying an image
-#@https://developer.gnome.org/gtk3/3.2/GtkImage.html
+# A widget displaying an image
+# See: https://developer.gnome.org/gtk3/3.2/GtkImage.html
 extern class GtkImage `{GtkImage *`}
 	super GtkMisc
 
 	# Create a GtkImage
-	new is extern `{
-		return (GtkImage*)gtk_image_new( );
+	new `{
+		return (GtkImage*)gtk_image_new();
 	`}
 
 	# Create a GtkImage with text
-	new file( filename : String ) is extern import String.to_cstring `{
-		return (GtkImage*)gtk_image_new_from_file( String_to_cstring( filename ) );
+	new file(filename: String) import String.to_cstring `{
+		return (GtkImage*)gtk_image_new_from_file(String_to_cstring(filename));
 	`}
 
-	fun pixel_size : Int is extern `{
-		return gtk_image_get_pixel_size( recv );
+	fun pixel_size: Int `{
+		return gtk_image_get_pixel_size(recv);
 	`}
 
-	fun pixel_size=( size : Int) is extern `{
-		gtk_image_set_pixel_size( recv, size );
+	fun pixel_size=(size: Int) `{
+		gtk_image_set_pixel_size(recv, size);
 	`}
 
-	fun clear is extern `{
-		gtk_image_clear( recv );
+	fun clear `{
+		gtk_image_clear(recv);
 	`}
 end
 
-#enum GtkImageType
-#Describes the image data representation used by a GtkImage.
-#@https://developer.gnome.org/gtk3/3.2/GtkImage.html#GtkImageType
+# enum GtkImageType
+# Describes the image data representation used by a GtkImage.
+# See: https://developer.gnome.org/gtk3/3.2/GtkImage.html#GtkImageType
 extern class GtkImageType `{GtkImageType`}
 	# There is no image displayed by the widget.
 	new empty `{ return GTK_IMAGE_EMPTY; `}
@@ -688,330 +683,320 @@ extern class GtkImageType `{GtkImageType`}
 	new gicon `{ return GTK_IMAGE_GICON; `}
 end
 
-#Displays an arrow
-#@https://developer.gnome.org/gtk3/3.2/GtkArrow.html
+# Displays an arrow
+# See: https://developer.gnome.org/gtk3/3.2/GtkArrow.html
 extern class GtkArrow `{GtkArrow *`}
 	super GtkMisc
 
-	new ( arrow_type : GtkArrowType, shadow_type : GtkShadowType ) is extern `{
-		return (GtkArrow *)gtk_arrow_new( arrow_type, shadow_type );
+	new (arrow_type: GtkArrowType, shadow_type: GtkShadowType) `{
+		return (GtkArrow *)gtk_arrow_new(arrow_type, shadow_type);
 	`}
 
-	fun set( arrow_type : GtkArrowType, shadow_type : GtkShadowType ) is extern `{
-		gtk_arrow_set( recv, arrow_type, shadow_type );
+	fun set(arrow_type: GtkArrowType, shadow_type: GtkShadowType) `{
+		gtk_arrow_set(recv, arrow_type, shadow_type);
 	`}
 end
 
-#A widget that emits a signal when clicked on
-#@https://developer.gnome.org/gtk3/stable/GtkButton.html
+# A widget that emits a signal when clicked on
+# See: https://developer.gnome.org/gtk3/stable/GtkButton.html
 extern class GtkButton `{GtkButton *`}
 	super GtkBin
 
-	new is extern `{
-		return (GtkButton *)gtk_button_new(  );
+	new `{
+		return (GtkButton *)gtk_button_new();
 	`}
 
-	#Create a GtkButton with text
-	new with_label( text : String ) is extern import String.to_cstring `{
-		return (GtkButton *)gtk_button_new_with_label( String_to_cstring( text ) );
+	# Create a GtkButton with text
+	new with_label(text: String) import String.to_cstring `{
+		return (GtkButton *)gtk_button_new_with_label(String_to_cstring(text));
 	`}
 
-	new from_stock( stock_id : String ) is extern import String.to_cstring `{
-		return (GtkButton *)gtk_button_new_from_stock( String_to_cstring( stock_id ) );
+	new from_stock(stock_id: String) import String.to_cstring `{
+		return (GtkButton *)gtk_button_new_from_stock(String_to_cstring(stock_id));
 	`}
 
-	fun text : String is extern `{
-		return NativeString_to_s( (char *)gtk_button_get_label( recv ) );
+	fun text: String `{
+		return NativeString_to_s((char *)gtk_button_get_label(recv));
 	`}
 
-	fun text=( value : String ) is extern import String.to_cstring`{
-		gtk_button_set_label( recv, String_to_cstring( value ) );
+	fun text=(value: String) import String.to_cstring `{
+		gtk_button_set_label(recv, String_to_cstring(value));
 	`}
 
-	fun on_click( to_call : GtkCallable, user_data : nullable Object ) do
-			signal_connect( "clicked", to_call, user_data )
+	fun on_click(to_call: GtkCallable, user_data: nullable Object) do
+			signal_connect("clicked", to_call, user_data)
 	end
 
 end
 
-#A button which pops up a scale
-#@https://developer.gnome.org/gtk3/stable/GtkScaleButton.html
+# A button which pops up a scale
+# See: https://developer.gnome.org/gtk3/stable/GtkScaleButton.html
 extern class GtkScaleButton `{GtkScaleButton *`}
 	super GtkButton
 
-	#const gchar **icons
-	new( size: GtkIconSize, min: Float, max: Float, step: Float ) is extern `{
-		return (GtkScaleButton *)gtk_scale_button_new( size, min, max, step, (const char **)0 );
+	# const gchar **icons
+	new(size: GtkIconSize, min: Float, max: Float, step: Float) `{
+		return (GtkScaleButton *)gtk_scale_button_new(size, min, max, step, (const char **)0);
 	`}
 end
 
-#Create buttons bound to a URL
-#@https://developer.gnome.org/gtk3/stable/GtkLinkButton.html
+# Create buttons bound to a URL
+# See: https://developer.gnome.org/gtk3/stable/GtkLinkButton.html
 extern class GtkLinkButton `{GtkLinkButton *`}
 	super GtkButton
 
-	new( uri: String ) is extern import String.to_cstring `{
-		return (GtkLinkButton *)gtk_link_button_new( String_to_cstring(uri) );
+	new(uri: String) import String.to_cstring `{
+		return (GtkLinkButton *)gtk_link_button_new(String_to_cstring(uri));
 	`}
 end
 
-#A container which can hide its child
-#https://developer.gnome.org/gtk3/stable/GtkExpander.html
+# A container which can hide its child
+# https://developer.gnome.org/gtk3/stable/GtkExpander.html
 extern class GtkExpander `{GtkExpander *`}
 	super GtkBin
 
-	new( lbl : String) is extern import String.to_cstring`{
-		return (GtkExpander *)gtk_expander_new( String_to_cstring( lbl ) );
+	new(lbl: String) import String.to_cstring `{
+		return (GtkExpander *)gtk_expander_new(String_to_cstring(lbl));
 	`}
 
-	new with_mnemonic( lbl : String) is extern import String.to_cstring`{
-		return (GtkExpander *)gtk_expander_new_with_mnemonic(String_to_cstring( lbl ));
+	new with_mnemonic(lbl: String) import String.to_cstring `{
+		return (GtkExpander *)gtk_expander_new_with_mnemonic(String_to_cstring(lbl));
 	`}
 
-	fun expanded : Bool is extern `{
-		return gtk_expander_get_expanded( recv );
+	fun expanded: Bool `{
+		return gtk_expander_get_expanded(recv);
 	`}
 
-	fun expanded=( is_expanded : Bool ) is extern `{
-		gtk_expander_set_expanded( recv, is_expanded );
+	fun expanded=(is_expanded: Bool) `{
+		gtk_expander_set_expanded(recv, is_expanded);
 	`}
 
-	fun spacing : Int is extern `{
-		return gtk_expander_get_spacing( recv );
+	fun spacing: Int `{
+		return gtk_expander_get_spacing(recv);
 	`}
 
-	fun spacing=( pixels : Int ) is extern `{
-		gtk_expander_set_spacing( recv, pixels );
+	fun spacing=(pixels: Int) `{
+		gtk_expander_set_spacing(recv, pixels);
 	`}
 
-	fun label_text : String is extern `{
-		return NativeString_to_s( (char *)gtk_expander_get_label( recv ) );
+	fun label_text: String `{
+		return NativeString_to_s((char *)gtk_expander_get_label(recv));
 	`}
 
-	fun label_text=( lbl : String ) is extern import String.to_cstring`{
-		gtk_expander_set_label( recv, String_to_cstring( lbl ) );
+	fun label_text=(lbl: String) import String.to_cstring `{
+		gtk_expander_set_label(recv, String_to_cstring(lbl));
 	`}
 
-	fun use_underline : Bool is extern `{
-		return gtk_expander_get_use_underline( recv );
+	fun use_underline: Bool `{
+		return gtk_expander_get_use_underline(recv);
 	`}
 
-	fun use_underline=( used : Bool) is extern `{
-		gtk_expander_set_use_underline( recv, used );
+	fun use_underline=(used: Bool) `{
+		gtk_expander_set_use_underline(recv, used);
 	`}
 
-	fun use_markup : Bool is extern `{
-		return gtk_expander_get_use_markup( recv );
+	fun use_markup: Bool `{
+		return gtk_expander_get_use_markup(recv);
 	`}
 
-	fun use_markup=( used : Bool) is extern `{
-		 gtk_expander_set_use_markup( recv, used );
+	fun use_markup=(used: Bool) `{
+		 gtk_expander_set_use_markup(recv, used);
 	`}
 
-	fun label_widget : GtkWidget is extern `{
-		return gtk_expander_get_label_widget( recv );
+	fun label_widget: GtkWidget `{
+		return gtk_expander_get_label_widget(recv);
 	`}
 
-	fun label_widget=( widget : GtkWidget ) is extern `{
-		gtk_expander_set_label_widget( recv, widget );
+	fun label_widget=(widget: GtkWidget) `{
+		gtk_expander_set_label_widget(recv, widget);
 	`}
 
-	fun label_fill : Bool is extern `{
-		return gtk_expander_get_label_fill( recv );
+	fun label_fill: Bool `{
+		return gtk_expander_get_label_fill(recv);
 	`}
 
-	fun label_fill=( fill : Bool ) is extern `{
-		gtk_expander_set_label_fill( recv, fill );
+	fun label_fill=(fill: Bool) `{
+		gtk_expander_set_label_fill(recv, fill);
 	`}
 
-	fun resize_toplevel : Bool is extern `{
-		return gtk_expander_get_resize_toplevel( recv );
+	fun resize_toplevel: Bool `{
+		return gtk_expander_get_resize_toplevel(recv);
 	`}
 
-	fun resize_toplevel=( resize : Bool ) is extern `{
-		gtk_expander_set_resize_toplevel( recv, resize );
+	fun resize_toplevel=(resize: Bool) `{
+		gtk_expander_set_resize_toplevel(recv, resize);
 	`}
 
 end
 
-#An abstract class for laying out GtkCellRenderers
-#@https://developer.gnome.org/gtk3/stable/GtkCellArea.html
+# An abstract class for laying out GtkCellRenderers
+# See: https://developer.gnome.org/gtk3/stable/GtkCellArea.html
 extern class GtkComboBox `{GtkComboBox *`}
 	super GtkBin
 
-	new is extern `{
-		return (GtkComboBox *)gtk_combo_box_new( );
+	new `{
+		return (GtkComboBox *)gtk_combo_box_new();
 	`}
 
-	new with_entry is extern `{
-		return (GtkComboBox *)gtk_combo_box_new_with_entry( );
+	new with_entry `{
+		return (GtkComboBox *)gtk_combo_box_new_with_entry();
 	`}
 
-	new with_model( model : GtkTreeModel ) is extern `{
-		return (GtkComboBox *)gtk_combo_box_new_with_model( model );
+	new with_model(model: GtkTreeModel) `{
+		return (GtkComboBox *)gtk_combo_box_new_with_model(model);
 	`}
 
-	new with_model_and_entry( model : GtkTreeModel ) is extern `{
-		return (GtkComboBox *)gtk_combo_box_new_with_model_and_entry( model );
+	new with_model_and_entry(model: GtkTreeModel) `{
+		return (GtkComboBox *)gtk_combo_box_new_with_model_and_entry(model);
 	`}
 
-	new with_area( area : GtkCellArea ) is extern `{
-		return (GtkComboBox *)gtk_combo_box_new_with_area( area );
+	new with_area(area: GtkCellArea) `{
+		return (GtkComboBox *)gtk_combo_box_new_with_area(area);
 	`}
 
-	new with_area_and_entry( area : GtkCellArea ) is extern `{
-		return (GtkComboBox *)gtk_combo_box_new_with_area_and_entry( area );
+	new with_area_and_entry(area: GtkCellArea) `{
+		return (GtkComboBox *)gtk_combo_box_new_with_area_and_entry(area);
 	`}
 
-	fun wrap_width : Int is extern `{
-		return gtk_combo_box_get_wrap_width( recv );
+	fun wrap_width: Int `{
+		return gtk_combo_box_get_wrap_width(recv);
 	`}
 
-	fun wrap_width=( width : Int ) is extern `{
-		gtk_combo_box_set_wrap_width( recv, width );
+	fun wrap_width=(width: Int) `{
+		gtk_combo_box_set_wrap_width(recv, width);
 	`}
 
-	fun row_span_col : Int is extern `{
-		return gtk_combo_box_get_row_span_column( recv );
+	fun row_span_col: Int `{
+		return gtk_combo_box_get_row_span_column(recv);
 	`}
 
-	fun row_span_col=( row_span : Int ) is extern `{
-		gtk_combo_box_set_row_span_column( recv, row_span );
+	fun row_span_col=(row_span: Int) `{
+		gtk_combo_box_set_row_span_column(recv, row_span);
 	`}
 
-	fun col_span_col : Int is extern `{
-		return gtk_combo_box_get_column_span_column( recv );
+	fun col_span_col: Int `{
+		return gtk_combo_box_get_column_span_column(recv);
 	`}
 
-	fun col_span_col=( col_span : Int ) is extern `{
-		gtk_combo_box_set_column_span_column( recv, col_span );
+	fun col_span_col=(col_span: Int) `{
+		gtk_combo_box_set_column_span_column(recv, col_span);
 	`}
 
-	fun active_item : Int is extern `{
-		return gtk_combo_box_get_active( recv );
+	fun active_item: Int `{
+		return gtk_combo_box_get_active(recv);
 	`}
 
-	fun active_item=( active : Int ) is extern `{
-		gtk_combo_box_set_active( recv, active );
+	fun active_item=(active: Int) `{
+		gtk_combo_box_set_active(recv, active);
 	`}
 
-	#fun active_iter : GtkTreeIter is extern `{
-	#`}
-	#
-	#fun active_iter=( active : Bool ) is extern `{
-	#`}
-
-	fun column_id : Int is extern `{
-		return gtk_combo_box_get_id_column( recv );
+	fun column_id: Int `{
+		return gtk_combo_box_get_id_column(recv);
 	`}
 
-	fun column_id=( id_column : Int ) is extern `{
-		gtk_combo_box_set_id_column( recv, id_column );
+	fun column_id=(id_column: Int) `{
+		gtk_combo_box_set_id_column(recv, id_column);
 	`}
 
-	fun active_id : String is extern `{
-		return NativeString_to_s( (char *)gtk_combo_box_get_active_id( recv ) );
+	fun active_id: String `{
+		return NativeString_to_s((char *)gtk_combo_box_get_active_id(recv));
 	`}
 
-	fun active_id=( id_active : String ) is extern import String.to_cstring`{
-		gtk_combo_box_set_active_id( recv, String_to_cstring( id_active ) );
+	fun active_id=(id_active: String) import String.to_cstring `{
+		gtk_combo_box_set_active_id(recv, String_to_cstring(id_active));
 	`}
 
-	fun model : GtkTreeModel is extern `{
-		return gtk_combo_box_get_model( recv );
+	fun model: GtkTreeModel `{
+		return gtk_combo_box_get_model(recv);
 	`}
 
-	fun model=( model : GtkTreeModel ) is extern `{
-		gtk_combo_box_set_model( recv, model );
+	fun model=(model: GtkTreeModel) `{
+		gtk_combo_box_set_model(recv, model);
 	`}
 
-	fun popup is extern `{
-		gtk_combo_box_popup( recv );
+	fun popup `{
+		gtk_combo_box_popup(recv);
 	`}
 
-	fun popdown is extern `{
-		gtk_combo_box_popdown( recv );
+	fun popdown `{
+		gtk_combo_box_popdown(recv);
 	`}
 
-	fun title : String is extern`{
-		return NativeString_to_s( (char *)gtk_combo_box_get_title( recv ) );
+	fun title: String `{
+		return NativeString_to_s((char *)gtk_combo_box_get_title(recv));
 	`}
 
-	fun title=( t : String ) is extern import String.to_cstring `{
-		gtk_combo_box_set_title( recv, String_to_cstring( t ) );
+	fun title=(t: String) import String.to_cstring `{
+		gtk_combo_box_set_title(recv, String_to_cstring(t));
 	`}
 
-	fun has_entry : Bool is extern `{
-		return gtk_combo_box_get_has_entry( recv );
+	fun has_entry: Bool `{
+		return gtk_combo_box_get_has_entry(recv);
 	`}
 
-	fun with_fixed : Bool is extern `{
-		return gtk_combo_box_get_popup_fixed_width( recv );
+	fun with_fixed: Bool `{
+		return gtk_combo_box_get_popup_fixed_width(recv);
 	`}
 
-	fun with_fixed=( fixed : Bool ) is extern `{
-		gtk_combo_box_set_popup_fixed_width( recv, fixed );
+	fun with_fixed=(fixed: Bool) `{
+		gtk_combo_box_set_popup_fixed_width(recv, fixed);
 	`}
 end
 
-#Show a spinner animation
-#@https://developer.gnome.org/gtk3/3.2/GtkSpinner.html
+# Show a spinner animation
+# See: https://developer.gnome.org/gtk3/3.2/GtkSpinner.html
 extern class GtkSpinner `{GtkSpinner *`}
 	super GtkWidget
 
-	new is extern `{
+	new `{
 		 return (GtkSpinner *)gtk_spinner_new();
 	`}
 
-	fun start is extern `{
-		return gtk_spinner_start( recv );
+	fun start `{
+		return gtk_spinner_start(recv);
 	`}
 
-	fun stop is extern `{
-		return gtk_spinner_stop( recv );
+	fun stop `{
+		return gtk_spinner_stop(recv);
 	`}
 end
 
-#A "light switch" style toggle
-#@https://developer.gnome.org/gtk3/3.2/GtkSwitch.html
+# A "light switch" style toggle
+# See: https://developer.gnome.org/gtk3/3.2/GtkSwitch.html
 extern class GtkSwitch `{GtkSwitch *`}
 	super GtkWidget
 
-	new is extern `{
+	new `{
 		 return (GtkSwitch *)gtk_switch_new();
 	`}
 
-	fun active : Bool is extern `{
-		return gtk_switch_get_active( recv );
+	fun active: Bool `{
+		return gtk_switch_get_active(recv);
 	`}
 
-	fun active=( is_active : Bool ) is extern `{
-		return gtk_switch_set_active( recv, is_active );
+	fun active=(is_active: Bool) `{
+		return gtk_switch_set_active(recv, is_active);
 	`}
 end
 
-
-#A widget which controls the alignment and size of its child
-#https://developer.gnome.org/gtk3/stable/GtkAlignment.html
+# A widget which controls the alignment and size of its child
+# https://developer.gnome.org/gtk3/stable/GtkAlignment.html
 extern class GtkAlignment `{GtkAlignment *`}
 	super GtkBin
 
-	new ( xalign : Float, yalign : Float, xscale : Float, yscale : Float ) is extern `{
-		return (GtkAlignment *)gtk_alignment_new( xalign, yalign, xscale, yscale );
+	new (xalign: Float, yalign: Float, xscale: Float, yscale: Float) `{
+		return (GtkAlignment *)gtk_alignment_new(xalign, yalign, xscale, yscale);
 	`}
 
-	fun set ( xalign : Float, yalign : Float, xscale : Float, yscale : Float ) is extern `{
-		gtk_alignment_set( recv, xalign, yalign, xscale, yscale );
+	fun set (xalign: Float, yalign: Float, xscale: Float, yscale: Float) `{
+		gtk_alignment_set(recv, xalign, yalign, xscale, yscale);
 	`}
 
-	#get_padding
-	#set_padding
 end
 
-#A representation of an adjustable bounded value
-#@https://developer.gnome.org/gtk3/stable/GtkAdjustment.html#GtkAdjustment.description
+# A representation of an adjustable bounded value
+# See: https://developer.gnome.org/gtk3/stable/GtkAdjustment.html#GtkAdjustment.description
 extern class GtkAdjustment `{GtkAdjustment *`}
-
 end
 
 extern class GdkColor `{GdkColor*`}

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -380,6 +380,12 @@ end
 # See: https://developer.gnome.org/gtk3/3.4/GtkBox.html
 extern class GtkBox `{ GtkBox * `}
 	super GtkContainer
+	super GtkOrientable
+
+	# Create a new `GtkBox` with the given `orientation` and `spacing` between its children
+	new (orientation: GtkOrientation, spacing: Int) `{
+		return (GtkBox *)gtk_box_new(orientation, spacing);
+	`}
 end
 
 # The tree interface used by GtkTreeView

--- a/lib/gtk/v3_4/gtk_dialogs.nit
+++ b/lib/gtk/v3_4/gtk_dialogs.nit
@@ -23,299 +23,315 @@ in "C Header" `{
 	#include <gtk/gtk.h>
 `}
 
-#Create popup windows
-#@https://developer.gnome.org/gtk3/stable/GtkDialog.html
+# Create popup windows
+# See: https://developer.gnome.org/gtk3/stable/GtkDialog.html
 extern class GtkDialog `{GtkDialog *`}
 	super GtkWindow
 
-	new is extern `{
-		return (GtkDialog *)gtk_dialog_new( );
+	new `{
+		return (GtkDialog *)gtk_dialog_new();
 	`}
 
-	new with_buttons( title : String, parent : GtkWindow, flags : GtkDialogFlags) is extern import String.to_cstring`{
-		return (GtkDialog *)gtk_dialog_new_with_buttons( String_to_cstring( title ), parent, flags, "", NULL );
+	new with_buttons(title: String, parent: GtkWindow, flags: GtkDialogFlags)
+	import String.to_cstring `{
+		return (GtkDialog *)gtk_dialog_new_with_buttons(
+			String_to_cstring(title), parent, flags, "", NULL);
 	`}
 
-	fun run is extern `{
-		gtk_dialog_run( recv );
+	fun run `{
+		gtk_dialog_run(recv);
 	`}
-
 end
 
-#Display information about an application
-#@https://developer.gnome.org/gtk3/stable/GtkAboutDialog.html
+# Display information about an application
+# See: https://developer.gnome.org/gtk3/stable/GtkAboutDialog.html
 extern class GtkAboutDialog `{GtkAboutDialog *`}
 	super GtkDialog
 
-	new is extern `{
-		return (GtkAboutDialog *)gtk_about_dialog_new( );
+	new `{
+		return (GtkAboutDialog *)gtk_about_dialog_new();
 	`}
 
-	fun program_name : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_program_name( recv ) );
+	fun program_name: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_program_name(recv));
 	`}
 
-	fun program_name=( name : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_program_name( recv, String_to_cstring( name ) );
+	fun program_name=(name: String) import String.to_cstring `{
+		gtk_about_dialog_set_program_name(recv, String_to_cstring(name));
 	`}
 
-	fun version : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_version( recv ) );
+	fun version: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_version(recv));
 	`}
 
-	fun version=( v : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_version( recv, String_to_cstring( v ) );
+	fun version=(v: String) import String.to_cstring `{
+		gtk_about_dialog_set_version(recv, String_to_cstring(v));
 	`}
 
-	fun copyright : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_copyright( recv ) );
+	fun copyright: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_copyright(recv));
 	`}
 
-	fun copyright=( c : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_copyright( recv, String_to_cstring( c ) );
+	fun copyright=(c: String) import String.to_cstring `{
+		gtk_about_dialog_set_copyright(recv, String_to_cstring(c));
 	`}
 
-	fun comments : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_comments( recv ) );
+	fun comments: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_comments(recv));
 	`}
 
-	fun comments=( com : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_comments( recv, String_to_cstring( com ) );
+	fun comments=(com: String) import String.to_cstring `{
+		gtk_about_dialog_set_comments(recv, String_to_cstring(com));
 	`}
 
-	fun license : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_license( recv ) );
+	fun license: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_license(recv));
 	`}
 
-	fun license=( li : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_license( recv, String_to_cstring( li ) );
+	fun license=(li: String) import String.to_cstring `{
+		gtk_about_dialog_set_license(recv, String_to_cstring(li));
 	`}
 
-	#license_type
+	# license_type
 
-	fun website : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_about_dialog_get_website( recv ) );
+	fun website: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_about_dialog_get_website(recv));
 	`}
 
-	fun website=( link : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_website( recv, String_to_cstring( link ) );
+	fun website=(link: String) import String.to_cstring `{
+		gtk_about_dialog_set_website(recv, String_to_cstring(link));
 	`}
 
-	fun website_label : String import NativeString.to_s `{
-		return NativeString_to_s( (char *) gtk_about_dialog_get_website_label( recv ) );
+	fun website_label: String import NativeString.to_s `{
+		return NativeString_to_s((char *) gtk_about_dialog_get_website_label(recv));
 	`}
 
-	fun website_label=( link_label : String ) is extern import String.to_cstring`{
-		gtk_about_dialog_set_website_label( recv, String_to_cstring( link_label ) );
+	fun website_label=(link_label: String) import String.to_cstring `{
+		gtk_about_dialog_set_website_label(recv, String_to_cstring(link_label));
 	`}
 
-	#TODO
-	#fun authors : String is extern`{
-	#		return NativeString_to_s( gtk_about_dialog_get_authors( recv ) );
-	#`}
+	# TODO
+	# fun authors: String`{
+	#		return NativeString_to_s(gtk_about_dialog_get_authors(recv));
+	# `}
 
-	#TODO
-	#fun authors=( authors_list : String ) is extern import String.to_cstring`{
-	#	gtk_about_dialog_set_authors( recv, String_to_cstring( authors_list ) );
-	#`}
+	# TODO
+	# fun authors=(authors_list: String) import String.to_cstring`{
+	#	gtk_about_dialog_set_authors(recv, String_to_cstring(authors_list));
+	# `}
 
-	fun show_about_dialog(parent: GtkWindow, params: String) import String.to_cstring `{
+	fun show_about_dialog(parent: GtkWindow, params: String)
+	import String.to_cstring `{
 		gtk_show_about_dialog(parent, String_to_cstring(params), NULL);
 	`}
 end
 
-#An application chooser dialog
-#@https://developer.gnome.org/gtk3/stable/GtkAppChooserDialog.html
+# An application chooser dialog
+# See: https://developer.gnome.org/gtk3/stable/GtkAppChooserDialog.html
 extern class GtkAppChooserDialog `{GtkAppChooserDialog *`}
 	super GtkDialog
 
-	#TODO - GFile
-	#new ( parent : GtkWindow, flags : GtkDialogFlags, file : GFile ) is extern `{
-	#	return (GtkAppChooserDialog *)gtk_app_chooser_dialog_new( parent, flags, file );
-	#`}
+	# TODO - GFile
+	# new (parent: GtkWindow, flags: GtkDialogFlags, file: GFile) `{
+	#	return (GtkAppChooserDialog *)gtk_app_chooser_dialog_new(parent, flags, file);
+	# `}
 
-	new for_content_type ( parent : GtkWindow, flags : GtkDialogFlags, content_type : String ) is extern  import String.to_cstring `{
-		return (GtkAppChooserDialog *)gtk_app_chooser_dialog_new_for_content_type( parent, flags, 																							String_to_cstring( content_type ) );
+	new for_content_type (parent: GtkWindow, flags: GtkDialogFlags, content_type: String)
+	import String.to_cstring `{
+		return (GtkAppChooserDialog *)gtk_app_chooser_dialog_new_for_content_type(
+			parent, flags, String_to_cstring(content_type));
 	`}
 
-	fun widget : GtkWidget is extern `{ return gtk_app_chooser_dialog_get_widget( recv ); `}
+	fun widget: GtkWidget `{ return gtk_app_chooser_dialog_get_widget(recv); `}
 
-	fun heading : String import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_app_chooser_dialog_get_heading( recv ) );
+	fun heading: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_app_chooser_dialog_get_heading(recv));
 	`}
 
-	fun heading=( text : String ) is extern import String.to_cstring `{
-		gtk_app_chooser_dialog_set_heading( recv, String_to_cstring( text ) );
+	fun heading=(text: String) import String.to_cstring `{
+		gtk_app_chooser_dialog_set_heading(recv, String_to_cstring(text));
 	`}
 
 end
 
-#A dialog for choosing colors
-#@https://developer.gnome.org/gtk3/stable/GtkColorChooserDialog.html
+# A dialog for choosing colors
+# See: https://developer.gnome.org/gtk3/stable/GtkColorChooserDialog.html
 extern class GtkColorChooserDialog `{GtkColorChooserDialog *`}
 	super GtkDialog
 
-	new ( title : String, parent : GtkWindow ) is extern import String.to_cstring `{
-		return (GtkColorChooserDialog *)gtk_color_chooser_dialog_new( String_to_cstring( title ), parent );
+	new (title: String, parent: GtkWindow) import String.to_cstring `{
+		return (GtkColorChooserDialog *)gtk_color_chooser_dialog_new(
+			String_to_cstring(title), parent);
 	`}
 end
 
-#A file chooser dialog, suitable for "File/Open" or "File/Save" commands
-#@https://developer.gnome.org/gtk3/stable/GtkFileChooserDialog.html
+# A file chooser dialog, suitable for "File/Open" or "File/Save" commands
+# See: https://developer.gnome.org/gtk3/stable/GtkFileChooserDialog.html
 extern class GtkFileChooserDialog `{GtkFileChooserDialog *`}
 	super GtkDialog
 
-	new ( title : String, parent : GtkWindow, action : GtkFileChooserAction ) is extern import String.to_cstring `{
-		return (GtkFileChooserDialog *)gtk_file_chooser_dialog_new( String_to_cstring( title ), parent, action, "", NULL );
+	new (title: String, parent: GtkWindow, action: GtkFileChooserAction)
+	import String.to_cstring `{
+		return (GtkFileChooserDialog *)gtk_file_chooser_dialog_new(
+			String_to_cstring(title), parent, action, "", NULL);
 	`}
 end
 
-#enum GtkFileChooserAction
-#Describes whether a GtkFileChooser is being used to open existing files or to save to a possibly new file.
-#@https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#GtkFileChooserAction
+# enum GtkFileChooserAction
+#
+# Describes whether a GtkFileChooser is being used to open existing files or to save to a possibly new file.
+# See: https://developer.gnome.org/gtk3/stable/GtkFileChooser.html#GtkFileChooserAction
 extern class GtkFileChooserAction `{GtkFileChooserAction`}
-	#Indicates open mode. The file chooser will only let the user pick an existing file.
+	# Open file mode
+	#
+	# The file chooser will only let the user pick an existing file.
 	new open `{ return GTK_FILE_CHOOSER_ACTION_OPEN; `}
 
-	#Indicates save mode. The file chooser will let the user pick an existing file, or type in a new filename.
+	# Save file mode
+	#
+	# The file chooser will let the user pick an existing file, or type in a new filename.
 	new save `{ return GTK_FILE_CHOOSER_ACTION_SAVE; `}
 
-	#Indicates an Open mode for selecting folders. The file chooser will let the user pick an existing folder.
+	# Select folder mode
+	#
+	# The file chooser will let the user pick an existing folder.
 	new select_folder `{ return GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER; `}
 
-	#Indicates a mode for creating a new folder. The file chooser will let the user name an existing or new folder.
+	# Create a new folder mode
+	#
+	# The file chooser will let the user name an existing or new folder.
 	new create_folder `{ return GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER; `}
 end
 
-#A dialog for selecting fonts
-#@https://developer.gnome.org/gtk3/stable/GtkFontChooserDialog.html
+# A dialog for selecting fonts
+# See: https://developer.gnome.org/gtk3/stable/GtkFontChooserDialog.html
 extern class GtkFontChooserDialog `{GtkFontChooserDialog *`}
 	super GtkDialog
 
-	new ( title : String, parent : GtkWindow ) is extern `{
-		return (GtkFontChooserDialog *)gtk_font_chooser_dialog_new( String_to_cstring( title ), parent );
+	new (title: String, parent: GtkWindow) `{
+		return (GtkFontChooserDialog *)gtk_font_chooser_dialog_new(String_to_cstring(title), parent);
 	`}
 end
 
-#A convenient message window
-#@https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html
+# A convenient message window
+# See: https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html
 extern class GtkMessageDialog `{GtkMessageDialog *`}
 	super GtkDialog
 
-	new ( parent : GtkWindow, flags : GtkDialogFlags, msg_type : GtkMessageType, btn_type : GtkButtonsType, format : String ) is extern import String.to_cstring `{
-		return (GtkMessageDialog *)gtk_message_dialog_new( parent, flags, msg_type, btn_type, String_to_cstring( format ), NULL );
+	new (parent: GtkWindow, flags: GtkDialogFlags, msg_type: GtkMessageType, btn_type: GtkButtonsType, format: String) import String.to_cstring `{
+		return (GtkMessageDialog *)gtk_message_dialog_new(parent, flags, msg_type, btn_type, String_to_cstring(format), NULL);
 	`}
 end
 
-#enum GtkButtonsType
-#Prebuilt sets of buttons for the dialog. If none of these choices are appropriate, simply use GTK_BUTTONS_NONE then call gtk_dialog_add_buttons().
-#@https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html#GtkButtonsType
+# enum GtkButtonsType
+# Prebuilt sets of buttons for the dialog. If none of these choices are appropriate, simply use GTK_BUTTONS_NONE then call gtk_dialog_add_buttons().
+# See: https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html#GtkButtonsType
 extern class GtkButtonsType `{GtkButtonsType`}
-	#No buttons at all
+	# No buttons at all
 	new none `{ return GTK_BUTTONS_NONE; `}
 
-	#An OK button.
+	# An OK button.
 	new ok `{ return GTK_BUTTONS_OK; `}
 
-	#A Close button.
+	# A Close button.
 	new close `{ return GTK_BUTTONS_CLOSE; `}
 
-	#A Cancel button.
+	# A Cancel button.
 	new cancel `{ return GTK_BUTTONS_CANCEL; `}
 
-	#Yes and No buttons.
+	# Yes and No buttons.
 	new yes_no `{ return GTK_BUTTONS_YES_NO; `}
 
-	#OK and Cancel buttons.
+	# OK and Cancel buttons.
 	new ok_cancel `{ return GTK_BUTTONS_OK_CANCEL; `}
 end
 
-#enum GtkMessageType
-#The type of message being displayed in the dialog.
-#@https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html#GtkMessageType
+# enum GtkMessageType
+# The type of message being displayed in the dialog.
+# See: https://developer.gnome.org/gtk3/stable/GtkMessageDialog.html#GtkMessageType
 extern class GtkMessageType `{GtkMessageType`}
-	#Informational message
+	# Informational message
 	new info `{ return GTK_MESSAGE_INFO; `}
 
-	#Non-fatal warning message.
+	# Non-fatal warning message.
 	new warning `{ return GTK_MESSAGE_WARNING; `}
 
-	#Question requiring a choice.
+	# Question requiring a choice.
 	new question `{ return GTK_MESSAGE_QUESTION; `}
 
-	#Fatal error message.
+	# Fatal error message.
 	new error `{ return GTK_MESSAGE_ERROR; `}
 
-	#None of the above, doesn't get an icon.
+	# None of the above, doesn't get an icon.
 	new other `{ return GTK_MESSAGE_OTHER; `}
 end
 
-#A page setup dialog
-#@https://developer.gnome.org/gtk3/stable/GtkPageSetupUnixDialog.html
-#extern class GtkPageSetupUnixDialog `{GtkPageSetupUnixDialog *`}
+# A page setup dialog
+# See: https://developer.gnome.org/gtk3/stable/GtkPageSetupUnixDialog.html
+# extern class GtkPageSetupUnixDialog `{GtkPageSetupUnixDialog *`}
 #	super GtkDialog
 #
-#end
+# end
 
-#A print dialog
-#@https://developer.gnome.org/gtk3/stable/GtkPrintUnixDialog.html
-#extern class GtkPrintUnixDialog `{GtkPrintUnixDialog *`}
+# A print dialog
+# See: https://developer.gnome.org/gtk3/stable/GtkPrintUnixDialog.html
+# extern class GtkPrintUnixDialog `{GtkPrintUnixDialog *`}
 #	super GtkDialog
 #
-#end
+# end
 
-#Displays recently used files in a dialog
-#@https://developer.gnome.org/gtk3/stable/GtkRecentChooserDialog.html
+# Displays recently used files in a dialog
+# See: https://developer.gnome.org/gtk3/stable/GtkRecentChooserDialog.html
 extern class GtkRecentChooserDialog `{GtkRecentChooserDialog *`}
 	super GtkDialog
 
 end
 
 
-#enum GtkDialogFlags
-#Flags used to influence dialog construction.
-#@https://developer.gnome.org/gtk3/stable/GtkDialog.html#GtkDialogFlags
+# enum GtkDialogFlags
+# Flags used to influence dialog construction.
+# See: https://developer.gnome.org/gtk3/stable/GtkDialog.html#GtkDialogFlags
 extern class GtkDialogFlags `{GtkDialogFlags`}
-	#Make the constructed dialog modal.
+	# Make the constructed dialog modal.
 	new modal `{ return GTK_DIALOG_MODAL; `}
 
-	#Destroy the dialog when its parent is destroyed.
+	# Destroy the dialog when its parent is destroyed.
 	new destroy_with_parent `{ return GTK_DIALOG_DESTROY_WITH_PARENT; `}
 end
 
-#enum GtkResponseType
-#Predefined values for use as response ids in gtk_dialog_add_button().
-#@https://developer.gnome.org/gtk3/stable/GtkDialog.html#GtkResponseType
+# enum GtkResponseType
+# Predefined values for use as response ids in gtk_dialog_add_button().
+# See: https://developer.gnome.org/gtk3/stable/GtkDialog.html#GtkResponseType
 extern class GtkResponseType `{GtkResponseType`}
-	#Returned if an action widget has no response id, or if the dialog gets programmatically hidden or destroyed.
+	# Returned if an action widget has no response id, or if the dialog gets programmatically hidden or destroyed.
 	new none `{ return GTK_RESPONSE_NONE; `}
 
-	#Generic response id, not used by GTK+ dialogs.
+	# Generic response id, not used by GTK+ dialogs.
 	new reject `{ return GTK_RESPONSE_REJECT; `}
 
-	#Generic response id, not used by GTK+ dialogs
+	# Generic response id, not used by GTK+ dialogs
 	new accept `{ return GTK_RESPONSE_ACCEPT; `}
 
-	#Returned if the dialog is deleted
+	# Returned if the dialog is deleted
 	new delete_event `{ return GTK_RESPONSE_DELETE_EVENT; `}
-	#Returned by OK buttons in GTK+ dialogs.
+	# Returned by OK buttons in GTK+ dialogs.
 	new ok `{ return GTK_RESPONSE_OK; `}
 
-	#Returned by Cancel buttons in GTK+ dialogs.
+	# Returned by Cancel buttons in GTK+ dialogs.
 	new cancel `{ return GTK_RESPONSE_CANCEL; `}
 
-	#Returned by OK Close in GTK+ dialogs.
+	# Returned by OK Close in GTK+ dialogs.
 	new close `{ return GTK_RESPONSE_CLOSE; `}
 
-	#Returned by OK Yes in GTK+ dialogs.
+	# Returned by OK Yes in GTK+ dialogs.
 	new yes `{ return GTK_RESPONSE_YES; `}
 
-	#Returned by OK No in GTK+ dialogs.
+	# Returned by OK No in GTK+ dialogs.
 	new no `{ return GTK_RESPONSE_NO; `}
 
-	#Returned by OK Apply in GTK+ dialogs.
+	# Returned by OK Apply in GTK+ dialogs.
 	new apply `{ return GTK_RESPONSE_APPLY; `}
 
-	#Returned by OK Help in GTK+ dialogs.
+	# Returned by OK Help in GTK+ dialogs.
 	new help `{ return GTK_RESPONSE_HELP; `}
 end

--- a/lib/gtk/v3_4/gtk_widgets_ext.nit
+++ b/lib/gtk/v3_4/gtk_widgets_ext.nit
@@ -15,58 +15,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module gtk_widgets_ext is pkgconfig("gtk+-3.0")
+module gtk_widgets_ext is pkgconfig "gtk+-3.0"
 
 import gtk_core
 
-#Displays a calendar and allows the user to select a date
-#@https://developer.gnome.org/gtk3/3.2/GtkCalendar.html
+# Displays a calendar and allows the user to select a date
+# See: https://developer.gnome.org/gtk3/3.2/GtkCalendar.html
 extern class GtkCalendar `{GtkCalendar *`}
 	super GtkWidget
 
-	new is extern `{
+	new `{
 		 return (GtkCalendar *)gtk_calendar_new();
 	`}
 
-	fun month=( month : Int, year : Int ) is extern `{
-		gtk_calendar_select_month( recv, month, year );
+	fun month=(month: Int, year: Int) `{
+		gtk_calendar_select_month(recv, month, year);
 	`}
 
-	fun day=( day : Int ) is extern `{
-		gtk_calendar_select_day( recv, day );
+	fun day=(day: Int) `{
+		gtk_calendar_select_day(recv, day);
 	`}
 
-	fun mark_day( day : Int ) is extern `{
-		gtk_calendar_mark_day( recv, day );
+	fun mark_day(day: Int) `{
+		gtk_calendar_mark_day(recv, day);
 	`}
 
-	fun unmark_day( day : Int ) is extern `{
-		gtk_calendar_unmark_day( recv, day );
+	fun unmark_day(day: Int) `{
+		gtk_calendar_unmark_day(recv, day);
 	`}
 
-	fun is_marked( day : Int ): Bool is extern `{
-		return gtk_calendar_get_day_is_marked( recv, day );
+	fun is_marked(day: Int): Bool `{
+		return gtk_calendar_get_day_is_marked(recv, day);
 	`}
 
-   fun clear_marks is extern `{
-		gtk_calendar_clear_marks( recv );
+   fun clear_marks `{
+		gtk_calendar_clear_marks(recv);
 	`}
 
-	fun display_options : GtkCalendarDisplayOptions is extern `{
-		return gtk_calendar_get_display_options( recv );
+	fun display_options: GtkCalendarDisplayOptions `{
+		return gtk_calendar_get_display_options(recv);
 	`}
 
 
-	fun display_options=( options : GtkCalendarDisplayOptions) is extern `{
-		gtk_calendar_set_display_options( recv, options );
+	fun display_options=(options: GtkCalendarDisplayOptions) `{
+		gtk_calendar_set_display_options(recv, options);
 	`}
 
-	#date en nit...
+	# date en nit...
 	fun date: String is abstract
 end
 
-#enum GtkCalendarDisplayOptions
-#@https://developer.gnome.org/gtk3/3.2/GtkCalendar.html#GtkCalendarDisplayOptions
+# enum GtkCalendarDisplayOptions
+# See: https://developer.gnome.org/gtk3/3.2/GtkCalendar.html#GtkCalendarDisplayOptions
 extern class GtkCalendarDisplayOptions `{GtkCalendarDisplayOptions`}
 	new show_heading `{ return GTK_CALENDAR_SHOW_HEADING; `}
 	new show_day_names `{ return GTK_CALENDAR_SHOW_DAY_NAMES; `}
@@ -75,68 +75,68 @@ extern class GtkCalendarDisplayOptions `{GtkCalendarDisplayOptions`}
 	new show_details `{ return GTK_CALENDAR_SHOW_DETAILS; `}
 end
 
-#A separator widget
-#@https://developer.gnome.org/gtk3/stable/GtkSeparator.html
+# A separator widget
+# See: https://developer.gnome.org/gtk3/stable/GtkSeparator.html
 extern class GtkSeparator `{GtkSeparator *`}
 	super GtkWidget
 
-	new ( orientation : GtkOrientation ) is extern `{
-		 return (GtkSeparator *)gtk_separator_new( orientation );
+	new (orientation: GtkOrientation) `{
+		 return (GtkSeparator *)gtk_separator_new(orientation);
 	`}
 
 end
 
-#A widget which indicates progress visually
-#@https://developer.gnome.org/gtk3/3.2/GtkProgressBar.html
+# A widget which indicates progress visually
+# See: https://developer.gnome.org/gtk3/3.2/GtkProgressBar.html
 extern class GtkProgressBar `{GtkProgressBar *`}
 	super GtkWidget
 
-	new is extern `{
+	new `{
 		 return (GtkProgressBar *)gtk_progress_bar_new();
 	`}
 
-	fun pulse is extern `{
-		gtk_progress_bar_pulse( recv );
+	fun pulse `{
+		gtk_progress_bar_pulse(recv);
 	`}
 
-	fun pulse_step : Float is extern `{
-		return gtk_progress_bar_get_pulse_step( recv );
+	fun pulse_step: Float `{
+		return gtk_progress_bar_get_pulse_step(recv);
 	`}
 
-	fun pulse_step=( step : Float ) is extern `{
-		gtk_progress_bar_set_pulse_step( recv, step);
+	fun pulse_step=(step: Float) `{
+		gtk_progress_bar_set_pulse_step(recv, step);
 	`}
 
-	fun fraction : Float is extern `{
-		return gtk_progress_bar_get_fraction( recv );
+	fun fraction: Float `{
+		return gtk_progress_bar_get_fraction(recv);
 	`}
 
-	fun fraction=( fraction : Float) is extern `{
-		gtk_progress_bar_set_fraction( recv, fraction );
+	fun fraction=(fraction: Float) `{
+		gtk_progress_bar_set_fraction(recv, fraction);
 	`}
 
-	fun inverted : Bool is extern `{
-		return gtk_progress_bar_get_inverted( recv );
+	fun inverted: Bool `{
+		return gtk_progress_bar_get_inverted(recv);
 	`}
 
-	fun inverted=( is_inverted : Bool) is extern `{
-		gtk_progress_bar_set_inverted( recv, is_inverted );
+	fun inverted=(is_inverted: Bool) `{
+		gtk_progress_bar_set_inverted(recv, is_inverted);
 	`}
 
-	fun show_text : Bool is extern `{
-		return gtk_progress_bar_get_show_text( recv );
+	fun show_text: Bool `{
+		return gtk_progress_bar_get_show_text(recv);
 	`}
 
-	fun show_text=( show : Bool) is extern `{
-		gtk_progress_bar_set_show_text( recv, show );
+	fun show_text=(show: Bool) `{
+		gtk_progress_bar_set_show_text(recv, show);
 	`}
 
-	fun text : String is extern import NativeString.to_s `{
-		return NativeString_to_s( (char *)gtk_progress_bar_get_text( recv ) );
+	fun text: String import NativeString.to_s `{
+		return NativeString_to_s((char *)gtk_progress_bar_get_text(recv));
 	`}
 
-	fun text=( value : String) is extern import String.to_cstring`{
-		gtk_progress_bar_set_text( recv, String_to_cstring( value ) );
+	fun text=(value: String) import String.to_cstring `{
+		gtk_progress_bar_set_text(recv, String_to_cstring(value));
 	`}
 
 	fun ellipsize is abstract
@@ -145,116 +145,104 @@ end
 
 extern class GtkColorSelectionDialog
 	super GtkWidget
-	new ( title : String, parent : GtkWindow ) is extern  import String.to_cstring `{
-		 return gtk_color_chooser_dialog_new( String_to_cstring( title ), parent );
+	new (title: String, parent: GtkWindow)  import String.to_cstring `{
+		 return gtk_color_chooser_dialog_new(String_to_cstring(title), parent);
 	`}
 
-	#fun color_selection :  is extern `{
-	#	return gtk_color_selection_dialog_get_color_selection( GTK_COLOR_SELECTION_DIALOG( recv ) );
-	#`}
+	# fun color_selection:  `{
+	#	return gtk_color_selection_dialog_get_color_selection(GTK_COLOR_SELECTION_DIALOG(recv));
+	# `}
 
-	#fun color : Float is extern `{
-	#	return gtk_color_selection_dialog_get_color_selection( GTK_COLOR_SELECTION_DIALOG( recv ) );
-	#`}
+	# fun color: Float `{
+	#	return gtk_color_selection_dialog_get_color_selection(GTK_COLOR_SELECTION_DIALOG(recv));
+	# `}
 end
 
-#Retrieve an integer or floating-point number from the user
-#@https://developer.gnome.org/gtk3/3.2/GtkSpinButton.html
+# Retrieve an integer or floating-point number from the user
+# See: https://developer.gnome.org/gtk3/3.2/GtkSpinButton.html
 extern class GtkSpinButton `{GtkSpinButton *`}
 	super GtkEntry
 
-	new ( adjustment : GtkAdjustment, climb_rate : Float, digits : Int )is extern `{
-		return (GtkSpinButton *)gtk_spin_button_new( adjustment, climb_rate, digits );
+	new (adjustment: GtkAdjustment, climb_rate: Float, digits: Int)is extern `{
+		return (GtkSpinButton *)gtk_spin_button_new(adjustment, climb_rate, digits);
 	`}
 
-	new with_range( min : Float, max : Float, step : Float )is extern `{
-		return (GtkSpinButton *)gtk_spin_button_new_with_range( min, max, step );
+	new with_range(min: Float, max: Float, step: Float)is extern `{
+		return (GtkSpinButton *)gtk_spin_button_new_with_range(min, max, step);
 	`}
 
-	fun configure ( adjustment : GtkAdjustment, climb_rate : Float, digits : Int ) is extern `{
-		gtk_spin_button_configure( recv, adjustment, climb_rate, digits );
+	fun configure (adjustment: GtkAdjustment, climb_rate: Float, digits: Int) `{
+		gtk_spin_button_configure(recv, adjustment, climb_rate, digits);
 	`}
 
-	fun adjustment : GtkAdjustment is extern `{
-		return gtk_spin_button_get_adjustment( recv );
+	fun adjustment: GtkAdjustment `{
+		return gtk_spin_button_get_adjustment(recv);
 	`}
 
-	fun adjustment=( value : GtkAdjustment ) is extern `{
-		gtk_spin_button_set_adjustment( recv, value );
+	fun adjustment=(value: GtkAdjustment) `{
+		gtk_spin_button_set_adjustment(recv, value);
 	`}
 
-	fun digits : Int is extern `{
-		return gtk_spin_button_get_digits( recv );
+	fun digits: Int `{
+		return gtk_spin_button_get_digits(recv);
 	`}
 
-	fun digits=( nb_digits : Int ) is extern `{
-		gtk_spin_button_set_digits( recv, nb_digits );
+	fun digits=(nb_digits: Int) `{
+		gtk_spin_button_set_digits(recv, nb_digits);
 	`}
 
-	fun value : Float is extern `{
-		return gtk_spin_button_get_value( recv );
+	fun value: Float `{
+		return gtk_spin_button_get_value(recv);
 	`}
 
-	fun val=( val : Float ) is extern `{
-		gtk_spin_button_set_value( recv, val );
+	fun val=(val: Float) `{
+		gtk_spin_button_set_value(recv, val);
 	`}
 
-	fun spin( direction : GtkSpinType, increment : Float ) is extern`{
-		gtk_spin_button_spin( recv, direction, increment );
+	fun spin(direction: GtkSpinType, increment: Float)`{
+		gtk_spin_button_spin(recv, direction, increment);
 	`}
 end
 
-#enum GtkSpinType
-#The values of the GtkSpinType enumeration are used to specify the change to make in gtk_spin_button_spin().
-#@https://developer.gnome.org/gtk3/stable/GtkSpinButton.html#GtkSpinType
+# enum GtkSpinType
+# The values of the GtkSpinType enumeration are used to specify the change to make in gtk_spin_button_spin().
+# See: https://developer.gnome.org/gtk3/stable/GtkSpinButton.html#GtkSpinType
 extern class GtkSpinType `{GtkSpinType`}
-	#Increment by the adjustments step increment.
+	# Increment by the adjustments step increment.
 	new step_forward `{ return GTK_SPIN_STEP_FORWARD; `}
 
-	#Decrement by the adjustments step increment.
+	# Decrement by the adjustments step increment.
 	new step_backward `{ return GTK_SPIN_STEP_BACKWARD; `}
 
-	#Increment by the adjustments page increment.
+	# Increment by the adjustments page increment.
 	new page_forward `{ return GTK_SPIN_PAGE_FORWARD; `}
 
-	#Decrement by the adjustments page increment.
+	# Decrement by the adjustments page increment.
 	new page_backward `{ return GTK_SPIN_PAGE_BACKWARD; `}
 
-	#Go to the adjustments lower bound.
+	# Go to the adjustments lower bound.
 	new lower_bound `{ return GTK_SPIN_HOME; `}
 
-	#Go to the adjustments upper bound.
+	# Go to the adjustments upper bound.
 	new upper_bound `{ return GTK_SPIN_END; `}
 
-	#Change by a specified amount.
+	# Change by a specified amount.
 	new user_defined `{ return GTK_SPIN_USER_DEFINED; `}
 end
 
-#A widget to unlock or lock privileged operations
-#@https://developer.gnome.org/gtk3/stable/GtkLockButton.html
+# A widget to unlock or lock privileged operations
+# See: https://developer.gnome.org/gtk3/stable/GtkLockButton.html
 extern class GtkLockButton
 	super GtkButton
 end
 
-#A button to launch a color selection dialog
-#@https://developer.gnome.org/gtk3/stable/GtkColorButton.html
+# A button to launch a color selection dialog
+# See: https://developer.gnome.org/gtk3/stable/GtkColorButton.html
 extern class GtkColorButton `{GtkColorButton *`}
 	super GtkButton
 
-	new is extern `{
-		return (GtkColorButton *)gtk_color_button_new(  );
-	`}
-
-	fun color=( col : GdkColor ) is extern `{
-
-		/* deprecated
-		GdkColor *c = malloc(sizeof(GdkColor));
-		c->pixel = 50;
-		c->red = 50;
-		c->green = 50;
-		c->blue = 50;
-
-		gtk_color_button_set_color( (GtkColorButton*)recv, c );*/
+	new `{
+		return (GtkColorButton *)gtk_color_button_new();
 	`}
 end
 

--- a/lib/gtk/v3_4/v3_4.nit
+++ b/lib/gtk/v3_4/v3_4.nit
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module v3_4 is pkgconfig("gtk+-3.0")
+module v3_4 is pkgconfig "gtk+-3.0"
 
 import gtk_widgets_ext
 import gtk_dialogs

--- a/lib/gtk/v3_6.nit
+++ b/lib/gtk/v3_6.nit
@@ -16,16 +16,16 @@
 # limitations under the License.
 
 # GTK+ services added at version 3.6
-module v3_6 is pkgconfig("gtk+-3.0")
+module v3_6 is pkgconfig "gtk+-3.0"
 
 import v3_4
 
-#An entry which shows a search icon
-#@https://developer.gnome.org/gtk3/stable/GtkSearchEntry.html
+# An entry which shows a search icon
+# See: https://developer.gnome.org/gtk3/stable/GtkSearchEntry.html
 extern class GtkSearchEntry `{GtkSearchEntry *`}
 	super GtkEntry
 
-	new is extern `{
-		return (GtkSearchEntry *)gtk_search_entry_new( );	
+	new `{
+		return (GtkSearchEntry *)gtk_search_entry_new();
 	`}
 end

--- a/lib/gtk/v3_8.nit
+++ b/lib/gtk/v3_8.nit
@@ -21,7 +21,7 @@ import v3_6
 
 redef class GtkWidget
 	# Get the visibility of the widget, check if it's parents are visible too
-	fun visible: Bool is extern `{
+	fun visible: Bool `{
 		return gtk_widget_is_visible(recv);
 	`}
 end

--- a/tests/test_gtk.nit
+++ b/tests/test_gtk.nit
@@ -47,9 +47,10 @@ class MyApp
 	do
 		init_gtk
 
-		win = new GtkWindow( 0 )
+		win = new GtkWindow(new GtkWindowType.toplevel)
+		win.connect_destroy_signal_to_quit
 
-		container = new GtkGrid(2,1,true)
+		container = new GtkGrid
 		win.add( container )
 
 		lbl = new GtkLabel( "Hello world" )


### PR DESCRIPTION
You should read this PR commit by commit as the style update touches almost every line. The style update adds and removes spaces, and it removes empty and commented methods. It does not touch the documentation, there is still a lot of work to do there.

Please read the commit description of "lib/gtk: ignore deprecated warnings" for the rationale of the change.

GTK will be used to implement the abstract UI on GNU/Linux.