### PR TITLE
i18n annot: superstrings

### DIFF
--- a/examples/langannot.nit
+++ b/examples/langannot.nit
@@ -35,3 +35,9 @@ example
 
 of the language annotation capacities
 """
+
+var s = "example"
+
+print "This superstring {s} rocks"
+
+print "This superstring %1 rocks".format(s)

--- a/examples/languages/en/LC_MESSAGES/langannot.po
+++ b/examples/languages/en/LC_MESSAGES/langannot.po
@@ -6,4 +6,12 @@ msgstr "This String is a test"
 msgid "Multiline string\n\nexample\n\n\nof the language annotation capacities\n"
 msgstr "Multiline string\n\nexample\n\n\nof the language annotation capacities\n"
 
+#: langannot::langannot 39--9:17
+msgid "example"
+msgstr "example"
+
+#: langannot::langannot 41--7:34, langannot::langannot 43--7:33
+msgid "This superstring %1 rocks"
+msgstr "This superstring %1 rocks"
+
 # Generated file, do not modify

--- a/examples/languages/fr/LC_MESSAGES/langannot.po
+++ b/examples/languages/fr/LC_MESSAGES/langannot.po
@@ -6,4 +6,12 @@ msgstr "Cette chaîne de caractères est un test"
 msgid "Multiline string\n\nexample\n\n\nof the language annotation capacities\n"
 msgstr "Example de\n\nchaine multiligne\n\n\navec annotation de localisation\n"
 
+#: langannot::langannot 39--9:17
+msgid "example"
+msgstr "exemple"
+
+#: langannot::langannot 41--7:34, langannot::langannot 43--7:33
+msgid "This superstring %1 rocks"
+msgstr "Cet %1 de superstring est génial"
+
 # Generated file, do not modify

--- a/examples/languages/ja/LC_MESSAGES/langannot.po
+++ b/examples/languages/ja/LC_MESSAGES/langannot.po
@@ -6,4 +6,12 @@ msgstr "この文字列はてストです"
 msgid "Multiline string\n\nexample\n\n\nof the language annotation capacities\n"
 msgstr "複数行の文字列\n\nなサンプルプログラム\n\n\n新しい国際化アノテーションとともに\n"
 
+#: langannot::langannot 39--9:17
+msgid "example"
+msgstr "サンプル"
+
+#: langannot::langannot 41--7:34, langannot::langannot 43--7:33
+msgid "This superstring %1 rocks"
+msgstr "このスパ文字列%1は驚くべきです"
+
 # Generated file, do not modify

--- a/examples/languages/langannot.pot
+++ b/examples/languages/langannot.pot
@@ -6,4 +6,12 @@ msgstr ""
 msgid "Multiline string\n\nexample\n\n\nof the language annotation capacities\n"
 msgstr ""
 
+#: langannot::langannot 39--9:17
+msgid "example"
+msgstr ""
+
+#: langannot::langannot 41--7:34, langannot::langannot 43--7:33
+msgid "This superstring %1 rocks"
+msgstr ""
+
 # Generated file, do not modify

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -849,6 +849,39 @@ abstract class Text
 		return hash_cache.as(not null)
 	end
 
+	# Gives the formatted string back as a Nit string with `args` in place
+	#
+	# 	assert "This %1 is a %2.".format("String", "formatted String") == "This String is a formatted String"
+	# 	assert "\\%1 This string".format("String") == "\\%1 This string"
+	fun format(args: Object...): String do
+		var s = new Array[Text]
+		var curr_st = 0
+		var i = 0
+		while i < length do
+			# Skip escaped characters
+			if self[i] == '\\' then
+				i += 1
+			# In case of format
+			else if self[i] == '%' then
+				var fmt_st = i
+				i += 1
+				var ciph_st = i
+				while i < length and self[i].is_numeric do
+					i += 1
+				end
+				i -= 1
+				var fmt_end = i
+				var ciph_len = fmt_end - ciph_st + 1
+				s.push substring(curr_st, fmt_st - curr_st)
+				s.push args[substring(ciph_st, ciph_len).to_i - 1].to_s
+				curr_st = i + 1
+			end
+			i += 1
+		end
+		s.push substring(curr_st, length - curr_st)
+		return s.to_s
+	end
+
 end
 
 # All kinds of array-based text representations.


### PR DESCRIPTION
Added the support of superstrings in the i18n annotation.

The first commit introduces a string format to use when replacing superstrings.
The second and third commits are updates to the i18n annotation and the test that goes along with it.