### PR TITLE
Clean up Android and Linux app.nit libraries

### DIFF
--- a/examples/mnit_simple/src/test_intent.nit
+++ b/examples/mnit_simple/src/test_intent.nit
@@ -32,14 +32,14 @@ redef class App
 
 	fun test_intent
 	do
-		intent = new Intent(self)
+		intent = new Intent
 		intent.action = intent_action.view.to_s
 		intent.data   = "content://contacts/people/"
 
-		intent.launch_activity
+		start_activity intent
 		intent.destroy
 
-		intent = new Intent(self)
+		intent = new Intent
 		var p1 = new Point(10, 20)
 		intent["a_point"] = p1
 		var p2 = intent["a_point"]

--- a/lib/android/android.nit
+++ b/lib/android/android.nit
@@ -24,7 +24,7 @@ import platform
 import native_app_glue
 import dalvik
 private import log
-private import android_data_store
+private import data_store
 
 # Uses Android logs to print everything
 redef fun print(text) do log_write(priority_info, app.log_prefix.to_cstring, text.to_s.to_cstring)

--- a/lib/android/data_store.nit
+++ b/lib/android/data_store.nit
@@ -17,7 +17,7 @@
 # Implements `app::data_store` using `shared_preferences`
 #
 # We use the shared preferences named "data_store" to store the data.
-module android_data_store
+module data_store
 
 import app::data_store
 private import shared_preferences

--- a/lib/android/intent/intent_api10.nit
+++ b/lib/android/intent/intent_api10.nit
@@ -18,7 +18,7 @@
 # `android.content.Intent` for the android platform
 module intent_api10
 
-import native_app_glue
+import dalvik
 import android::bundle
 import serialization
 private import json_serialization
@@ -33,6 +33,8 @@ in "Java" `{
 
 extern class NativeIntent in "Java" `{ android.content.Intent `}
 	super JavaObject
+
+	new in "Java" `{ return new Intent(); `}
 
 	fun add_category(category: JavaString) in "Java" `{ recv.addCategory(category); `}
 	fun add_flags(flags: Int) in "Java" `{ recv.addFlags((int)flags); `}
@@ -626,23 +628,7 @@ end
 
 # Services allowing to launch an activity and start/stop services
 class Intent
-	protected var intent: NativeIntent
-	protected var context: NativeActivity
-
-	init (app: App)
-	do
-		self.context = app.native_activity
-		setup
-	end
-
-	private fun set_vars(intent: NativeIntent) do
-		self.intent = intent.new_global_ref
-	end
-
-	private fun setup import context, intent, set_vars in "Java" `{
-		Intent intent = new Intent();
-		Intent_set_vars(recv, intent);
-	`}
+	protected var intent: NativeIntent = (new NativeIntent).new_global_ref is lazy
 
 	# The general action to be performed
 	#

--- a/lib/android/intent/intent_api10.nit
+++ b/lib/android/intent/intent_api10.nit
@@ -1311,14 +1311,6 @@ class Intent
 		sys.jni_env.pop_local_frame
 		return self
 	end
-	# Execute the intent and launch the appropriate application
-	fun launch_activity do context.start_activity(intent)
-
-	# Start a service that will be running until the `stop_service` call
-	fun start_service do context.start_service(intent)
-
-	# Stop service
-	fun stop_service do context.stop_service(intent)
 
 	# Deletes intent global reference
 	fun destroy do self.intent.delete_global_ref
@@ -1328,9 +1320,9 @@ class Intent
 end
 
 redef extern class NativeActivity
-	fun start_activity(intent: NativeIntent) in "Java" `{ recv.startActivity(intent); `}
-	fun start_service(intent: NativeIntent) in "Java" `{ recv.startService(intent); `}
-	fun stop_service(intent: NativeIntent) in "Java" `{ recv.stopService(intent); `}
+	private fun start_activity(intent: NativeIntent) in "Java" `{ recv.startActivity(intent); `}
+	private fun start_service(intent: NativeIntent) in "Java" `{ recv.startService(intent); `}
+	private fun stop_service(intent: NativeIntent) in "Java" `{ recv.stopService(intent); `}
 end
 
 # Allows user to get values with enum-like syntax : `intent_action.main`
@@ -1348,4 +1340,16 @@ end
 private class StringCopyHashSet
 	var collection = new HashSet[String]
 	fun add(element: JavaString) do collection.add element.to_s
+end
+
+redef class App
+
+	# Execute the intent and launch the appropriate application
+	fun start_activity(intent: Intent) do native_activity.start_activity(intent.intent)
+
+	# Start a service that will be running until the `stop_service` call
+	fun start_service(intent: Intent) do native_activity.start_service(intent.intent)
+
+	# Stop service
+	fun stop_service(intent: Intent) do native_activity.stop_service(intent.intent)
 end

--- a/lib/android/shared_preferences/shared_preferences_api10.nit
+++ b/lib/android/shared_preferences/shared_preferences_api10.nit
@@ -17,7 +17,7 @@
 # Services to save/load data using `android.content.SharedPreferences` for the android platform
 module shared_preferences_api10
 
-import native_app_glue
+import dalvik
 import serialization
 private import json_serialization
 

--- a/lib/android/toast.nit
+++ b/lib/android/toast.nit
@@ -17,7 +17,7 @@
 # Services to display a _toast_, a small popup on Android
 module toast
 
-import native_app_glue
+import dalvik
 
 in "Java" `{
 	import android.widget.Toast;
@@ -34,7 +34,7 @@ redef class App
 
 	private fun native_toast(message: JavaString, is_long: Bool)
 	import native_activity in "Java" `{
-		final android.app.NativeActivity context = App_native_activity(recv);
+		final android.app.Activity context = App_native_activity(recv);
 		final CharSequence final_message = message;
 		final int duration = is_long? Toast.LENGTH_LONG: Toast.LENGTH_SHORT;
 

--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -14,34 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Views and services to use the Android native user interface
-#
-# Events, such as a button click, come from the UI thread and are then
-# passed to the main thread. It is recommended to specialize one of the
-# methods of the main thread to customize the response to a given event.
-#
-# This graph shows the path of a button click:
-# ~~~raw
-#     UI Thread     #   Main thread
-#
-#       User
-#        |
-#        V
-# Button::click_ui --> Button::click
-#                           |
-#                           V
-#                    App::catch_event
-# ~~~
-module ui is min_api_version 14
+# Native services from the `android.view` and `android.widget` namespaces
+module native_ui is min_api_version 14
 
 import nit_activity
-import pthreads::concurrent_collections
 
 in "Java" `{
 	import android.app.Activity;
 
 	import android.view.Gravity;
-	import android.view.MotionEvent;
 	import android.view.ViewGroup;
 	import android.view.ViewGroup.MarginLayoutParams;
 
@@ -54,31 +35,6 @@ in "Java" `{
 	import java.lang.*;
 	import java.util.*;
 `}
-
-# An event from the `app.nit` framework
-interface AppEvent
-	# Reaction to this event
-	fun react do end
-end
-
-# A control click event
-class ClickEvent
-	super AppEvent
-
-	# Sender of this event
-	var sender: Button
-
-	redef fun react do sender.click self
-end
-
-# Receiver of events not handled directly by the sender
-interface EventCatcher
-	fun catch_event(event: AppEvent) do end
-end
-
-redef class App
-	super EventCatcher
-end
 
 redef extern class NativeActivity
 
@@ -97,101 +53,6 @@ redef extern class NativeActivity
 		});
 	`}
 end
-
-# An `Object` that raises events
-abstract class Eventful
-	var event_catcher: EventCatcher = app is lazy, writable
-end
-
-#
-## Nity classes and services
-#
-
-# An Android control with text
-abstract class TextView
-	super Finalizable
-	super Eventful
-
-	# Native Java variant to this Nity class
-	type NATIVE: NativeTextView
-
-	# The native Java object encapsulated by `self`
-	var native: NATIVE is noinit
-
-	# Get the text of this view
-	fun text: String
-	do
-		var jstr = native.text
-		var str = jstr.to_s
-		jstr.delete_local_ref
-		return str
-	end
-
-	# Set the text of this view
-	fun text=(value: Text)
-	do
-		var jstr = value.to_s.to_java_string
-		native.text = jstr
-		jstr.delete_local_ref
-	end
-
-	# Get whether this view is enabled or not
-	fun enabled: Bool do return native.enabled
-
-	# Set if this view is enabled
-	fun enabled=(val: Bool) do native.enabled = val
-
-	# Set the size of the text in this view at `dpi`
-	fun text_size=(dpi: Numeric) do native.text_size = dpi.to_f
-
-	private var finalized = false
-	redef fun finalize
-	do
-		if not finalized then
-			native.delete_global_ref
-			finalized = true
-		end
-	end
-end
-
-# An Android button
-class Button
-	super TextView
-
-	redef type NATIVE: NativeButton
-
-	init
-	do
-		var native = new NativeButton(app.native_activity, self)
-		self.native = native.new_global_ref
-	end
-
-	# Click event
-	#
-	# By default, this method calls `app.catch_event`. It can be specialized
-	# with custom behavior or the receiver of `catch_event` can be changed
-	# with `event_catcher=`.
-	fun click(event: AppEvent) do event_catcher.catch_event(event)
-
-	private fun click_from_native do click(new ClickEvent(self))
-end
-
-# An Android editable text field
-class EditText
-	super TextView
-
-	redef type NATIVE: NativeEditText
-
-	init
-	do
-		var native = new NativeEditText(app.activities.first.native)
-		self.native = native.new_global_ref
-	end
-end
-
-#
-## Native classes
-#
 
 # A `View` for Android
 extern class NativeView in "Java" `{ android.view.View `}
@@ -322,22 +183,6 @@ extern class NativeButton in "Java" `{ android.widget.Button `}
 	super NativeTextView
 
 	redef type SELF: NativeButton
-
-	new (context: NativeActivity, sender_object: Object)
-	import Button.click_from_native in "Java" `{
-		final int final_sender_object = sender_object;
-
-		return new Button(context){
-			@Override
-			public boolean onTouchEvent(MotionEvent event) {
-				if(event.getAction() == MotionEvent.ACTION_DOWN) {
-					Button_click_from_native(final_sender_object);
-					return true;
-				}
-				return false;
-			}
-		};
-	`}
 
 	redef fun new_global_ref: SELF import sys, Sys.jni_env `{
 		Sys sys = NativeButton_sys(recv);

--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -23,6 +23,7 @@ in "Java" `{
 	import android.app.Activity;
 
 	import android.view.Gravity;
+	import android.view.View;
 	import android.view.ViewGroup;
 	import android.view.ViewGroup.MarginLayoutParams;
 
@@ -60,6 +61,19 @@ extern class NativeView in "Java" `{ android.view.View `}
 
 	fun minimum_width=(val: Int) in "Java" `{ recv.setMinimumWidth((int)val); `}
 	fun minimum_height=(val: Int) in "Java" `{ recv.setMinimumHeight((int)val); `}
+
+	fun enabled: Bool in "Java" `{ return recv.isEnabled(); `}
+	fun enabled=(value: Bool) in "Java" `{
+		final View final_recv = recv;
+		final boolean final_value = value;
+
+		((Activity)recv.getContext()).runOnUiThread(new Runnable() {
+			@Override
+			public void run()  {
+				final_recv.setEnabled(final_value);
+			}
+		});
+	`}
 end
 
 # A collection of `NativeView`
@@ -67,6 +81,11 @@ extern class NativeViewGroup in "Java" `{ android.view.ViewGroup `}
 	super NativeView
 
 	fun add_view(view: NativeView) in "Java" `{ recv.addView(view); `}
+
+	fun add_view_with_weight(view: NativeView, weight: Float)
+	in "Java" `{
+		recv.addView(view, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, (float)weight));
+	`}
 end
 
 # A `NativeViewGroup` organized in a line
@@ -84,11 +103,6 @@ extern class NativeLinearLayout in "Java" `{ android.widget.LinearLayout `}
 			LinearLayout.LayoutParams.MATCH_PARENT,
 			LinearLayout.LayoutParams.WRAP_CONTENT);
 		recv.addView(view, params);
-	`}
-
-	fun add_view_with_weight(view: NativeView, weight: Float)
-	in "Java" `{
-		recv.addView(view, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, (float)weight));
 	`}
 end
 
@@ -139,23 +153,13 @@ extern class NativeTextView in "Java" `{ android.widget.TextView `}
 		});
 	`}
 
-	fun enabled: Bool in "Java" `{ return recv.isEnabled(); `}
-	fun enabled=(value: Bool) in "Java" `{
-		final TextView final_recv = recv;
-		final boolean final_value = value;
-
-		((Activity)recv.getContext()).runOnUiThread(new Runnable() {
-			@Override
-			public void run()  {
-				final_recv.setEnabled(final_value);
-			}
-		});
-	`}
-
 	fun gravity_center in "Java" `{
 		recv.setGravity(Gravity.CENTER);
 	`}
 
+	fun text_size: Float in "Java" `{
+		return recv.getTextSize();
+	`}
 	fun text_size=(dpi: Float) in "Java" `{
 		recv.setTextSize(android.util.TypedValue.COMPLEX_UNIT_DIP, (float)dpi);
 	`}

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -1,0 +1,154 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Copyright 2014 Alexis Laferrière <alexis.laf@xymus.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Views and services to use the Android native user interface
+module ui
+
+import native_ui
+
+# An event from the `app.nit` framework
+interface AppEvent
+	# Reaction to this event
+	fun react do end
+end
+
+# A control click event
+class ClickEvent
+	super AppEvent
+
+	# Sender of this event
+	var sender: Button
+
+	redef fun react do sender.click self
+end
+
+# Receiver of events not handled directly by the sender
+interface EventCatcher
+	fun catch_event(event: AppEvent) do end
+end
+
+redef class App
+	super EventCatcher
+end
+
+# An `Object` that raises events
+abstract class Eventful
+	var event_catcher: EventCatcher = app is lazy, writable
+end
+
+#
+## Nity classes and services
+#
+
+# An Android control with text
+abstract class TextView
+	super Finalizable
+	super Eventful
+
+	# Native Java variant to this Nity class
+	type NATIVE: NativeTextView
+
+	# The native Java object encapsulated by `self`
+	var native: NATIVE is noinit
+
+	# Get the text of this view
+	fun text: String
+	do
+		var jstr = native.text
+		var str = jstr.to_s
+		jstr.delete_local_ref
+		return str
+	end
+
+	# Set the text of this view
+	fun text=(value: Text)
+	do
+		var jstr = value.to_s.to_java_string
+		native.text = jstr
+		jstr.delete_local_ref
+	end
+
+	# Get whether this view is enabled or not
+	fun enabled: Bool do return native.enabled
+
+	# Set if this view is enabled
+	fun enabled=(val: Bool) do native.enabled = val
+
+	# Set the size of the text in this view at `dpi`
+	fun text_size=(dpi: Numeric) do native.text_size = dpi.to_f
+
+	private var finalized = false
+	redef fun finalize
+	do
+		if not finalized then
+			native.delete_global_ref
+			finalized = true
+		end
+	end
+end
+
+# An Android button
+class Button
+	super TextView
+
+	redef type NATIVE: NativeButton
+
+	init
+	do
+		var native = new NativeButton(app.native_activity, self)
+		self.native = native.new_global_ref
+	end
+
+	# Click event
+	#
+	# By default, this method calls `app.catch_event`. It can be specialized
+	# with custom behavior or the receiver of `catch_event` can be changed
+	# with `event_catcher=`.
+	fun click(event: AppEvent) do event_catcher.catch_event(event)
+
+	private fun click_from_native do click(new ClickEvent(self))
+end
+
+# An Android editable text field
+class EditText
+	super TextView
+
+	redef type NATIVE: NativeEditText
+
+	init
+	do
+		var native = new NativeEditText(app.activities.first.native)
+		self.native = native.new_global_ref
+	end
+end
+
+redef class NativeButton
+	new (context: NativeActivity, sender_object: Object)
+	import Button.click_from_native in "Java" `{
+		final int final_sender_object = sender_object;
+
+		return new android.widget.Button(context){
+			@Override
+			public boolean onTouchEvent(android.view.MotionEvent event) {
+				if(event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+					Button_click_from_native(final_sender_object);
+					return true;
+				}
+				return false;
+			}
+		};
+	`}
+end

--- a/lib/android/vibration.nit
+++ b/lib/android/vibration.nit
@@ -21,7 +21,7 @@ module vibration is
 	android_manifest("""<uses-permission android:name="android.permission.VIBRATE" />""")
 end
 
-import native_app_glue
+import dalvik
 
 # Handle to an Android vibrator
 extern class Vibrator in "Java" `{ android.os.Vibrator `}

--- a/lib/linux/data_store.nit
+++ b/lib/linux/data_store.nit
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module linux_data_store
+# `app::data_store` implementation on GNU/Linux
+module data_store
 
 import app::data_store
 private import xdg_basedir

--- a/lib/linux/linux.nit
+++ b/lib/linux/linux.nit
@@ -18,4 +18,4 @@
 module linux
 
 import app
-private import linux_data_store
+private import data_store


### PR DESCRIPTION
The prefix in `linux_data_store` and `android_data_store` is no longer needed.

Importing only `dalvik` from an Android module makes it compatible with both implementations: the newer nit_activity and the older native_app_glue still used by games.