### PR TITLE
Fix C compiler warning on Java FFI and Android apps

### DIFF
--- a/src/c_tools.nit
+++ b/src/c_tools.nit
@@ -47,33 +47,37 @@ class CCompilationUnit
 	# files to compile TODO check is appropriate
 	var files = new Array[String]
 
-	fun add_local_function( efc : CFunction )
+	# Add `c_function` as a `static` function local to this unit
+	fun add_local_function(c_function: CFunction)
 	do
-		body_decl.add "static {efc.signature};\n"
+		body_decl.add "static {c_function.signature};\n"
 		body_impl.add "\n"
-		body_impl.add efc.to_writer
+		body_impl.add c_function.to_writer
 	end
 
-	fun add_exported_function( efc : CFunction )
+	# Add `c_function` as a public function to this unit
+	fun add_exported_function(c_function: CFunction)
 	do
-		header_decl.add( "{efc.signature};\n" )
-		body_impl.add( "\n" )
-		body_impl.add( efc.to_writer )
+		header_decl.add "{c_function.signature};\n"
+		body_impl.add "\n"
+		body_impl.add c_function.to_writer
 	end
 
-	fun compile_header_core( stream : Writer )
+	# Write the core of the header to `stream`
+	fun compile_header_core(stream: Writer)
 	do
-		header_c_base.write_to( stream )
-		header_custom.write_to( stream )
-		header_c_types.write_to( stream )
-		header_decl.write_to( stream )
+		header_c_base.write_to stream
+		header_custom.write_to stream
+		header_c_types.write_to stream
+		header_decl.write_to stream
 	end
 
-	fun compile_body_core( stream : Writer )
+	# Write the core of the body to `stream`
+	fun compile_body_core(stream: Writer)
 	do
-		body_decl.write_to( stream )
-		body_custom.write_to( stream )
-		body_impl.write_to( stream )
+		body_decl.write_to stream
+		body_custom.write_to stream
+		body_impl.write_to stream
 	end
 end
 

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -424,7 +424,7 @@ redef class MExplicitCall
 		var csignature = mproperty.build_c_implementation_signature(recv_mtype, mmodule, "___indirect", long_signature, from_java_call_context)
 		var cf = new CFunction("JNIEXPORT {csignature}")
 		cf.exprs.add "\t{mproperty.build_ccall(recv_mtype, mainmodule, null, long_signature, from_java_call_context, null)}\n"
-		ccu.add_local_function cf
+		ccu.add_non_static_local_function cf
 
 		# In Java, declare the extern method as a private static local method
 		var java_signature = mproperty.build_csignature(recv_mtype, mainmodule, null, short_signature, java_call_context)
@@ -651,3 +651,17 @@ end
 private fun java_call_context: JavaCallContext do return new JavaCallContext
 private fun to_java_call_context: ToJavaCallContext do return new ToJavaCallContext
 private fun from_java_call_context: FromJavaCallContext do return new FromJavaCallContext
+
+redef class CCompilationUnit
+	# Similar to `add_local_function` but not `static`
+	#
+	# Used when the signature contains a visibility attribute.
+	private fun add_non_static_local_function(c_function: CFunction)
+	do
+		body_decl.add c_function.signature
+		body_decl.add ";\n"
+
+		body_impl.add "\n"
+		body_impl.add c_function.to_writer
+	end
+end


### PR DESCRIPTION
The generated C code used `static JNIEXPORT`, when the macro was expanded it duplicated the visibility attribute. It was reported by the C compiler as a warning. This PR removes the `static` part.