### PR TITLE
nitdoc: introduce tabbed view to hidde less important data

### DIFF
--- a/share/nitdoc/css/nitdoc.css
+++ b/share/nitdoc/css/nitdoc.css
@@ -197,6 +197,20 @@ article.nospace {
 	border-left: 2px solid #0d8921;
 }
 
+
+.pull-right .dropdown-toggle {
+	padding: 0 5px;
+}
+
+/* Hide the "..." link */
+
+article .dropdown, article .dropdown {
+	visibility: hidden;
+}
+article:hover .dropdown, article:target .dropdown {
+	visibility: visible;
+}
+
 /*
  * Page parts
  */
@@ -271,20 +285,6 @@ article.nospace {
 
 .list-definition .list-definition {
 	margin-left: 30px;
-}
-
-.source-link {
-	display: none;
-	float: right;
-	margin-top: 10px;
-}
-
-.source-link a {
-	color: #0d8921;
-}
-
-article:hover .source-link, article:target .source-link {
-	display: block;
 }
 
 /*

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -126,4 +126,6 @@ class GraphArticle
 
 	# Dot script of the graph.
 	var dot: Text
+
+	redef var is_empty = false
 end

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -41,12 +41,14 @@ end
 redef class MModulePage
 	redef fun build_inh_list(v, doc) do
 		var section = new ImportationListSection(mentity)
+		var group = new PanelGroup("List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
-		section.add_child new HierarchyListArticle(mentity, "Imports", imports)
+		group.add_child new HierarchyListArticle(mentity, "Imports", imports)
 		var clients = self.clients.to_a
 		v.name_sorter.sort(clients)
-		section.add_child new HierarchyListArticle(mentity, "Clients", clients)
+		group.add_child new HierarchyListArticle(mentity, "Clients", clients)
+		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
 	end
@@ -55,18 +57,20 @@ end
 redef class MClassPage
 	redef fun build_inh_list(v, doc) do
 		var section = new InheritanceListSection(mentity)
+		var group = new PanelGroup("List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
-		section.add_child new HierarchyListArticle(mentity, "Parents", parents)
+		group.add_child new HierarchyListArticle(mentity, "Parents", parents)
 		var ancestors = self.ancestors.to_a
 		v.name_sorter.sort(ancestors)
-		section.add_child new HierarchyListArticle(mentity, "Ancestors", ancestors)
+		group.add_child new HierarchyListArticle(mentity, "Ancestors", ancestors)
 		var children = self.children.to_a
 		v.name_sorter.sort(children)
-		section.add_child new HierarchyListArticle(mentity, "Children", children)
+		group.add_child new HierarchyListArticle(mentity, "Children", children)
 		var descendants = self.descendants.to_a
 		v.name_sorter.sort(descendants)
-		section.add_child new HierarchyListArticle(mentity, "Descendants", descendants)
+		group.add_child new HierarchyListArticle(mentity, "Descendants", descendants)
+		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
 	end
@@ -74,13 +78,13 @@ end
 
 # FIXME diff hack
 class ImportationListSection
-	super DocSection
+	super TabbedGroup
 	super MEntityComposite
 end
 
 # FIXME diff hack
 class InheritanceListSection
-	super DocSection
+	super TabbedGroup
 	super MEntityComposite
 end
 

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -54,26 +54,40 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mmodule_list(v: IntroRedefListPhase, doc: DocModel, mmodule: MModule) do
+		var section = new IntrosRedefsSection(mentity)
+		var group = new PanelGroup("List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
-		add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
 		var redefs = mmodule.redef_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(redefs)
-		add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		section.add_child group
+		add_child(section)
 	end
 
 	# TODO this should move to MEntity?
 	private fun build_mclassdef_list(v: IntroRedefListPhase, doc: DocModel, mclassdef: MClassDef) do
+		var section = new IntrosRedefsSection(mentity)
+		var group = new PanelGroup("List")
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)
-		add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
 		var redefs = mclassdef.collect_redef_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(redefs)
-		add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		section.add_child group
+		add_child(section)
 	end
 
+end
+
+# Section that contains the intros and redefs lists.
+class IntrosRedefsSection
+	super TabbedGroup
+	super MEntitySection
 end
 
 # An article that displays a list of introduced / refined mentities.

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -266,6 +266,21 @@ redef class MPropertyPage
 	end
 end
 
+# A group of sections that can be displayed together in a tab.
+#
+# Display the first child and hide less relevant data in other panels.
+class TabbedGroup
+	super DocSection
+end
+
+# A group of sections that can be displayed together in a tab panel.
+class PanelGroup
+	super DocSection
+
+	# The title of this group.
+	var group_title: String
+end
+
 # A DocComposite element about a MEntity.
 class MEntityComposite
 	super DocComposite
@@ -316,6 +331,7 @@ end
 
 # An article that displaus a list of definition belonging to a MEntity.
 class DefinitionListArticle
+	super TabbedGroup
 	super MEntityArticle
 end
 

--- a/src/doc/html_templates/html_components.nit
+++ b/src/doc/html_templates/html_components.nit
@@ -36,6 +36,120 @@ class DocHTMLLabel
 	end
 end
 
+# A component that display tabbed data.
+class DocTabs
+	super BSComponent
+
+	# HTML id of this component.
+	var html_id: String
+
+	# Text displayed on the tabs dropdown button.
+	var drop_text: String
+
+	# Panels to display in this tab group.
+	var panels = new Array[DocTabPanel]
+
+	# Droplist containing links to panels.
+	#
+	# Can also be used to add external links.
+	var drop_list: DocTabsDrop is lazy do return new DocTabsDrop(html_id, drop_text)
+
+	# Adds a new `panel` to that tab.
+	#
+	# You should always use this instead of `panels.add` because it also set the
+	# `drop_list` entry.
+	fun add_panel(panel: DocTabPanel) do
+		drop_list.add_li panel.render_tab
+		panels.add panel
+	end
+
+	redef fun rendering do
+		if panels.is_empty then return
+		panels.first.is_active = true
+		add "<div role=\"tabpanel\">"
+		if drop_list.items.length > 1 then add drop_list
+		add " <div class=\"tab-content\">"
+		for panel in panels do
+			add panel
+		end
+		add " </div>"
+		add "</div>"
+	end
+end
+
+# A list of tab regrouped in a dropdown
+class DocTabsDrop
+	super UnorderedList
+
+	# HTML id used by the tabs group.
+	var html_id: String
+
+	# Title to display in the tab item.
+	var html_title: String
+
+	redef fun rendering do
+		add """<ul id="{{{html_id}}}-tabs" class="nav pull-right" role="tablist">"""
+		add """ <li role="presentation" class="dropdown pull-right">"""
+		add """  <a href="#" id="{{{html_id}}}-drop" class="dropdown-toggle"
+		          data-toggle="dropdown" aria-controls="{{{html_id}}}-contents"
+		          aria-expanded="false">"""
+        add html_title
+		add """ <span class="glyphicon glyphicon-menu-hamburger"></span>"""
+		add """ </a>"""
+		add """ <ul class="dropdown-menu" role="menu"
+		         aria-labelledby="{{{html_id}}}-drop" id="{{{html_id}}}-contents">"""
+		for item in items do add item
+		add "  </ul>"
+        add " </li>"
+        add "</ul>"
+	end
+end
+
+# A panel that goes in a DocTabs.
+class DocTabPanel
+	super BSComponent
+
+	# HTML id of this panel.
+	var html_id: String
+
+	# Title of this panel as displayed in the tab label.
+	var tab_title: String
+
+	# HTML content of this panel.
+	var html_content: Writable is writable
+
+	# Is this panel visible by default?
+	var is_active = false
+
+	redef fun rendering do
+		var active = ""
+		if is_active then active = "active in"
+		add "<div role=\"tabpanel\" class=\"tab-pane fade {active}\""
+		add "  id=\"{html_id}\" aria-labelledby=\"{html_id}-tab\">"
+		add html_content
+		add "</div>"
+	end
+
+	private fun render_tab: DocTabItem do return new DocTabItem(tab_title, html_id)
+end
+
+# A ListItem that goes in a DocTabsDrop.
+private class DocTabItem
+	super ListItem
+
+	# Panel id to trigger when the link is clicked.
+	var target_id: String
+
+	redef fun rendering do
+		add "<li{render_css_classes}>"
+		add " <a role=\"tab\" data-toggle=\"tab\" aria-expanded=\"false\" tabindex=\"-1\""
+		add "   id=\"{target_id}-tab\" href=\"#{target_id}\" aria-controls=\"{target_id}\">"
+		add text
+		add " </a>"
+		add "</li>"
+	end
+end
+
 # A HTML tag attribute
 #  `<tag attr="value">`
 #

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -319,6 +319,15 @@ redef class DocComposite
 		end
 		lst.add_li new ListItem(content)
 	end
+
+	# ID used in HTML tab labels.
+	#
+	# We sanitize it for Boostrap JS panels that do not like ":" and "." in ids.
+	var html_tab_id: String is lazy do
+		var id = html_id.replace(":", "")
+		id = id.replace(".", "")
+		return "{id}-tab"
+	end
 end
 
 redef class DocSection
@@ -346,6 +355,24 @@ redef class DocArticle
 		render_body
 		addn "</article>"
 	end
+end
+
+redef class TabbedGroup
+	redef fun render_body do
+		var tabs = new DocTabs("{html_id}.tabs", "")
+		for child in children do
+			if child.is_hidden then continue
+			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+		end
+		addn tabs
+	end
+end
+
+redef class PanelGroup
+	redef var html_id is lazy do return "group:{group_title.to_lower.to_snake_case}"
+	redef var html_title = null
+	redef var toc_title is lazy do return group_title
+	redef var is_toc_hidden = true
 end
 
 redef class HomeArticle
@@ -513,6 +540,7 @@ redef class DefinitionArticle
 	end
 
 	redef fun render_body do
+		var tabs = new DocTabs("{html_id}.tabs", "")
 		if not is_no_body then
 			var comment
 			if is_short_comment then
@@ -520,9 +548,15 @@ redef class DefinitionArticle
 			else
 				comment = mentity.html_comment
 			end
-			if comment != null then	addn comment
+			if comment != null then
+				tabs.add_panel new DocTabPanel("{html_tab_id}-comment", "Comment", comment)
+			end
 		end
-		super
+		for child in children do
+			if child.is_hidden then continue
+			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+		end
+		addn tabs
 	end
 end
 
@@ -530,7 +564,7 @@ redef class HierarchyListArticle
 	redef var html_id is lazy do return "article:{list_title}_{mentity.nitdoc_id}.hierarchy"
 	redef var html_title is lazy do return list_title
 	redef fun is_empty do return mentities.is_empty
-	redef fun is_toc_hidden do return mentities.is_empty
+	redef var is_toc_hidden = true
 
 	redef fun render_body do
 		var lst = new UnorderedList
@@ -542,8 +576,16 @@ redef class HierarchyListArticle
 	end
 end
 
-redef class IntrosRedefsListArticle
+redef class IntrosRedefsSection
 	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.intros_redefs"
+	redef var toc_title do return "Intros / Redefs"
+	redef var html_title = null
+	redef var html_subtitle = null
+	redef var is_toc_hidden = true
+end
+
+redef class IntrosRedefsListArticle
+	redef var html_id is lazy do return "article:{list_title}_{mentity.nitdoc_id}.intros_redefs"
 	redef var html_title is lazy do return list_title
 	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -472,20 +472,21 @@ redef class IntroArticle
 	# Link to source to display if any.
 	var html_source_link: nullable Writable is noinit, writable
 
-	redef fun render_title do
+	redef fun render_body do
+		var tabs = new DocTabs("{html_id}.tabs", "")
+		var comment = mentity.html_comment
+		if comment != null then
+			tabs.add_panel new DocTabPanel("{html_tab_id}-comment", "Comment", comment)
+		end
+		for child in children do
+			if child.is_hidden then continue
+			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+		end
 		var lnk = html_source_link
 		if lnk != null then
-			add "<div class='source-link'>"
-			add lnk
-			addn "</div>"
+			tabs.drop_list.items.add new ListItem(lnk)
 		end
-		super
-	end
-
-	redef fun render_body do
-		var comment = mentity.html_comment
-		if comment != null then	addn comment
-		super
+		addn tabs
 	end
 end
 
@@ -529,16 +530,6 @@ redef class DefinitionArticle
 	# Link to source to display if any.
 	var html_source_link: nullable Writable is noinit, writable
 
-	redef fun render_title do
-		var lnk = html_source_link
-		if lnk != null then
-			add "<div class='source-link'>"
-			add lnk
-			addn "</div>"
-		end
-		super
-	end
-
 	redef fun render_body do
 		var tabs = new DocTabs("{html_id}.tabs", "")
 		if not is_no_body then
@@ -555,6 +546,10 @@ redef class DefinitionArticle
 		for child in children do
 			if child.is_hidden then continue
 			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+		end
+		var lnk = html_source_link
+		if lnk != null then
+			tabs.drop_list.items.add new ListItem(lnk)
 		end
 		addn tabs
 	end


### PR DESCRIPTION
This PR introduce discrete tabs in the Nitdoc HTML output to hidde less important data like linearization tree, subclasses list etc.
This makes the main page more clean and readable.

Just pass the mouse over a definition to make the tab menu appear and select the details you want to see.
I also moved the source link here.

One can see the difference on [`Array[E]::SELF`](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/class_standard__collection__array__Array.html#article:standard__collection__array__Array__SELF.definition). Notice the little burger menu on the right of the signature.

Démos:
* [stdlib](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/index.html)
* [nitc](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/nitc/index.html)