### PR TITLE
nitdoc: display constructors list in MClass page

### DIFF
--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -16,6 +16,7 @@
 module doc_structure
 
 import doc_concerns
+import modelize
 
 # StructurePhase populates the DocPage content with section and article.
 #
@@ -177,6 +178,12 @@ redef class MClassPage
 		mentity.intro_mmodule.mgroup.mproject.booster_rank = 0
 		mentity.intro_mmodule.mgroup.booster_rank = 0
 		mentity.intro_mmodule.booster_rank = 0
+		var constructors = new ConstructorsSection(mentity)
+		var minit = mentity.root_init
+		if minit != null then
+			constructors.add_child new DefinitionArticle(minit)
+		end
+		section.add_child constructors
 		section.add_child new ConcernsArticle(mentity, concerns)
 		for mentity in concerns do
 			var ssection = new ConcernSection(mentity)
@@ -187,7 +194,12 @@ redef class MClassPage
 					v.name_sorter.sort(group)
 					for mprop in group do
 						for mpropdef in mpropdefs_for(mprop, mentity) do
-							ssection.add_child new DefinitionArticle(mpropdef)
+							if mpropdef isa MMethodDef and mpropdef.mproperty.is_init then
+								if mpropdef == minit then continue
+								constructors.add_child new DefinitionArticle(mpropdef)
+							else
+								ssection.add_child new DefinitionArticle(mpropdef)
+							end
 						end
 					end
 				end
@@ -287,6 +299,11 @@ class MEntityComposite
 
 	# MEntity documented by this page element.
 	var mentity: MEntity
+end
+
+# A list of constructors.
+class ConstructorsSection
+	super MEntitySection
 end
 
 # A Section about a Concern.

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -462,22 +462,50 @@ redef class MMethodDef
 
 	# FIXME annotation should be handled in their own way
 	redef fun html_modifiers do
+		if mproperty.is_init then
+			var res = new Array[String]
+			if mproperty.visibility != public_visibility then
+				res.add mproperty.visibility.to_s
+			end
+			return res
+		end
 		var res = super
 		if is_abstract then
 			res.add "abstract"
 		else if is_intern then
 			res.add "intern"
 		end
-		if mproperty.is_init then
-			res.add "init"
-		else
-			res.add "fun"
-		end
+		res.add "fun"
 		return res
 	end
 
-	redef fun html_short_signature do return msignature.html_short_signature
-	redef fun html_signature do return msignature.html_signature
+	redef fun html_declaration do
+		if mproperty.is_init then
+			var tpl = new Template
+			tpl.add "<span>"
+			tpl.add html_modifiers.join(" ")
+			tpl.add " "
+			tpl.add html_link
+			tpl.add html_signature
+			tpl.add "</span>"
+			return tpl
+		end
+		return super
+	end
+
+	redef fun html_short_signature do
+		if mproperty.is_root_init and new_msignature != null then
+			return new_msignature.html_short_signature
+		end
+		return msignature.html_short_signature
+	end
+
+	redef fun html_signature do
+		if mproperty.is_root_init and new_msignature != null then
+			return new_msignature.html_signature
+		end
+		return msignature.html_signature
+	end
 end
 
 redef class MVirtualTypeProp

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -447,6 +447,13 @@ redef class MEntitySection
 	redef var html_subtitle is lazy do return mentity.html_declaration
 end
 
+redef class ConstructorsSection
+	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.constructors"
+	redef var html_title = "Constructors"
+	redef var html_subtitle = null
+	redef fun is_toc_hidden do return is_empty
+end
+
 redef class ConcernSection
 	redef var html_id is lazy do return "concern:{mentity.nitdoc_id}"
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"


### PR DESCRIPTION
Nitdoc now displays a list of available constructors for a class.

Fixes #875
Fixes #1195

Demos from [Jenkins::CI-nitdoc](http://gresil.org/jenkins/job/CI-nitdoc):
* [Standard library](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/index.html)
* [Nit compilers and tools](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/nitc/index.html)