### PR TITLE
Fix nitunit for `String::format`

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -851,8 +851,8 @@ abstract class Text
 
 	# Gives the formatted string back as a Nit string with `args` in place
 	#
-	# 	assert "This %1 is a %2.".format("String", "formatted String") == "This String is a formatted String"
-	# 	assert "\\%1 This string".format("String") == "\\%1 This string"
+	#    assert "This %1 is a %2.".format("String", "formatted String") == "This String is a formatted String."
+	#    assert "\\%1 This string".format("String") == "\\%1 This string"
 	fun format(args: Object...): String do
 		var s = new Array[Text]
 		var curr_st = 0

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -345,7 +345,7 @@ abstract class Text
 		end
 		return true
 	end
-			
+
 	# Removes the whitespaces at the beginning of self
 	#
 	#     assert " \n\thello \n\t".l_trim == "hello \n\t"
@@ -1005,7 +1005,7 @@ abstract class String
 	#     assert "Hello World!".to_lower     == "hello world!"
 	fun to_lower : SELFTYPE is abstract
 
-	# Takes a camel case `self` and converts it to snake case 
+	# Takes a camel case `self` and converts it to snake case
 	#
 	#     assert "randomMethodId".to_snake_case == "random_method_id"
 	#
@@ -1055,11 +1055,11 @@ abstract class String
 				prev_is_upper = false
 			end
 		end
-		
+
 		return new_str.to_s
 	end
 
-	# Takes a snake case `self` and converts it to camel case 
+	# Takes a snake case `self` and converts it to camel case
 	#
 	#     assert "random_method_id".to_camel_case == "randomMethodId"
 	#


### PR DESCRIPTION
Since the code block was badly indented, it was not tested by `nitunit`.

Once the indentation was corrected, `nitunit` found that the test was failing.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>