### PR TITLE
Intro AppComponent to notify all elements of an app of its life cycle

### DIFF
--- a/contrib/friendz/src/friendz.nit
+++ b/contrib/friendz/src/friendz.nit
@@ -1583,7 +1583,7 @@ redef class App
 	# Wanted screen height
 	var screen_height = 480
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 		game = new Game

--- a/contrib/friendz/src/friendz_android.nit
+++ b/contrib/friendz/src/friendz_android.nit
@@ -18,7 +18,7 @@ redef class App
 	# Zoom applied for the device display from the game logic coordinates
 	var zoom = 1.0
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/contrib/inkscape_tools/tests/app/src/s2pn.nit
+++ b/contrib/inkscape_tools/tests/app/src/s2pn.nit
@@ -22,7 +22,7 @@ redef class App
 
 	init do super
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/examples/mnit_ballz/src/ballz_android.nit
+++ b/examples/mnit_ballz/src/ballz_android.nit
@@ -41,7 +41,7 @@ redef class App
 		super
 	end
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 		screen = new Screen(self, display.as(Display))

--- a/examples/mnit_dino/src/dino.nit
+++ b/examples/mnit_dino/src/dino.nit
@@ -35,7 +35,7 @@ redef class App
 	var imgs : nullable ImageSet = null
 	var splash : nullable SplashScreen = null
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/examples/mnit_moles/src/moles.nit
+++ b/examples/mnit_moles/src/moles.nit
@@ -233,7 +233,7 @@ redef class App
 
 	var screen: nullable Screen = null
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/examples/mnit_simple/src/simple.nit
+++ b/examples/mnit_simple/src/simple.nit
@@ -26,7 +26,7 @@ redef class App
 
 	var img : nullable I = null
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/examples/mnit_simple/src/test_audio.nit
+++ b/examples/mnit_simple/src/test_audio.nit
@@ -26,7 +26,7 @@ redef class App
 	var test_assets = false
 	var test_ressources = true
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 		if test_assets then

--- a/examples/mnit_simple/src/test_data_store.nit
+++ b/examples/mnit_simple/src/test_data_store.nit
@@ -21,7 +21,7 @@ import simple
 import app::data_store
 
 redef class App
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/examples/shoot/src/shoot.nit
+++ b/examples/shoot/src/shoot.nit
@@ -315,7 +315,7 @@ redef class App
 	var img_boss_left: Image
 	var img_boss_right: Image
 
-	redef fun window_created
+	redef fun on_create
 	do
 		super
 

--- a/lib/android/android.nit
+++ b/lib/android/android.nit
@@ -30,41 +30,35 @@ redef class App
 	redef fun init_window
 	do
 		super
-		window_created
+		on_create
+		on_restore_state
+		on_start
 	end
 
 	redef fun term_window
 	do
 		super
-		window_closing
+		on_stop
 	end
 
 	# Is the application currently paused?
 	var paused = true
 
-	redef fun window_created
-	do
-		super
-		paused = false
-	end
-
-	redef fun window_closing
-	do
-		paused = true
-		super
-	end
-
 	redef fun pause
 	do
 		paused = true
+		on_pause
 		super
 	end
 
 	redef fun resume
 	do
 		paused = false
+		on_resume
 		super
 	end
+
+	redef fun save_state do on_save_state
 
 	redef fun lost_focus
 	do
@@ -78,5 +72,5 @@ redef class App
 		super
 	end
 
-	redef fun destroy do exit 0
+	redef fun destroy do on_destroy
 end

--- a/lib/android/assets_and_resources.nit
+++ b/lib/android/assets_and_resources.nit
@@ -24,7 +24,7 @@
 # impossible for you to compile the apk correctly
 module assets_and_resources
 
-import native_app_glue
+import dalvik
 import java
 import java::io
 

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -40,6 +40,7 @@ module audio
 import java
 import java::io
 import assets_and_resources
+import native_app_glue # FIXME update this module to use nit_activity
 import app::audio
 
 in "Java" `{

--- a/lib/android/nit_activity.nit
+++ b/lib/android/nit_activity.nit
@@ -189,7 +189,11 @@ class Activity
 	# as registered by `on_save_instance_state`.
 	#
 	# Followed by `on_start`.
-	fun on_create(save_state: NativeBundle) do end
+	fun on_create(save_state: NativeBundle)
+	do
+		app.on_create
+		app.on_restore_state
+	end
 
 	# Notification from Android, the activity has been restarted
 	#
@@ -199,28 +203,30 @@ class Activity
 	# Notification from Android, the activity has been started
 	#
 	# Followed by `on_resume` or `on_stop`.
-	fun on_start do end
+	fun on_start do app.on_start
 
 	# Notification from Android, the activity has been resumed
 	#
 	# Followed by `on_pause`
-	fun on_resume do end
+	fun on_resume do app.on_resume
 
 	# Notification from Android, the activity has been paused
 	#
 	# Followed by `on_resume` or `on_stop`.
-	fun on_pause do end
+	fun on_pause do app.on_pause
 
 	# Notification from Android, the activity has been stopped
 	#
 	# Followed by `on_restart` or `on_destroy`.
-	fun on_stop do end
+	fun on_stop do app.on_stop
 
 	# Notification from Android, the activity is being destroyed
 	#
 	# Clean up and exit.
 	fun on_destroy
 	do
+		app.on_destroy
+
 		native.delete_global_ref
 		app.activities.remove self
 	end
@@ -233,7 +239,7 @@ class Activity
 	# Notification from Android, the activity may be stopped, save state
 	#
 	# Occurs before `on_stop` and, without guarantee, before or after `on_pause`.
-	fun on_save_instance_state(save_state: NativeBundle) do end
+	fun on_save_instance_state(save_state: NativeBundle) do app.on_save_state
 
 	# Notification from Android, the system is running low on memory
 	#

--- a/lib/app/app_base.nit
+++ b/lib/app/app_base.nit
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Base of the _app.nit_ framework, defines `App`
 module app_base is
 	new_annotation app_name
 	new_annotation app_namespace
@@ -22,9 +23,11 @@ end
 
 # App subclasses are cross-platform applications
 #
-# This class is redefed by plateform modules and so
-# App can be specialized directly in the user app.
+# This class is refined by platform modules and so
+# App can be specialized directly in the user application code.
 class App
+	super AppComponent
+
 	protected init do end
 
 	# Starts the internal setup of graphical and other stuff
@@ -33,14 +36,47 @@ class App
 
 	# Main entry point of your application
 	fun run do end
+end
 
-	# Main init method for graphical stuff
-	# Is called when display is ready so graphical assets
-	# can be loaded at this time.
-	fun window_created do end
+# An element of an application that is notified of the application life cycle
+#
+# Most users of _app.nit_ need only to implement `on_create` to setup the application.
+#
+# On mobile devices, the application can be stopped a anytime when another application takes the foreground.
+# Implement the callbacks `on_save_state` and `on_load_state` to keep the state of the application between execution,
+# for an illusion of continuous execution.
+abstract class AppComponent
 
-	# Called before destroying the window
-	fun window_closing do end
+	# The application is being created
+	#
+	# You should build the UI at this time.
+	fun on_create do end
+
+	# The application is starting or restarting, it is visible to the user
+	fun on_start do end
+
+	# The application enters the active state, it is in the foreground and interactive
+	fun on_resume do end
+
+	# The application leaves the active state but is still partially visible
+	#
+	# It may still be visible in the background.
+	# It may then go back to `on_resume` or `on_stop`.
+	fun on_pause do end
+
+	# The application is completely hidden from the user
+	#
+	# It may then be destroyed (`on_destroy`) or go back to `on_start`.
+	fun on_stop do end
+
+	# The application is being destroyed
+	fun on_destroy do end
+
+	# The application may be destroyed soon, save its state for a future `on_restore_state`
+	fun on_save_state do end
+
+	# The application is launching, restore its state from a previous `on_save_state`
+	fun on_restore_state do end
 end
 
 # Print a warning
@@ -52,5 +88,6 @@ end
 
 # The running `App`
 fun app: App do return once new App
+
 app.setup
 app.run

--- a/lib/mnit/mnit_null.nit
+++ b/lib/mnit/mnit_null.nit
@@ -87,7 +87,7 @@ redef class App
 	do
 		super
 		display = new NullDisplay
-		window_created
+		on_create
 	end
 
 	# Force the printing of blit operations

--- a/lib/mnit_linux/linux_app.nit
+++ b/lib/mnit_linux/linux_app.nit
@@ -36,7 +36,20 @@ redef class App
 
 		super
 
-		window_created
+		on_create
+		on_restore_state
+		on_start
+		on_resume
+	end
+
+	redef fun run
+	do
+		super
+
+		on_pause
+		on_save_state
+		on_stop
+		on_destroy
 	end
 
 	redef fun generate_input


### PR DESCRIPTION
The names of callbacks on the life cycle have been inspired by Android's. There is an equivalent to each of them in iOS, their naming is more precise but more complicated, so they looked less nity.

As of now, only `App` specialize `AppComponent`, but more users in the UI module will soon be introduced.

The implementation of this life cycle in mnit and the old Android implementation using the NDK is a bit awkward. But you will notice that it is much better in the newer NitActivity based implementation, which is the future!