### PR TITLE
Separate Erasure Compiler bugfix

### DIFF
--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -273,7 +273,7 @@ class SeparateErasureCompiler
 			#Build BOX
 			self.provide_declaration("BOX_{c_name}", "val* BOX_{c_name}({mtype.ctype_extern});")
 			v.add_decl("/* allocate {mtype} */")
-			v.add_decl("val* BOX_{mtype.c_name}({mtype.ctype} value) \{")
+			v.add_decl("val* BOX_{mtype.c_name}({mtype.ctype_extern} value) \{")
 			v.add("struct instance_{c_name}*res = nit_alloc(sizeof(struct instance_{c_name}));")
 			v.require_declaration("class_{c_name}")
 			v.add("res->class = &class_{c_name};")


### PR DESCRIPTION
In commit [12aa160](https://github.com/privat/nit/commit/12aa16093122a9f55976585b76b01869d6899634) by @xymus, the signature of a BOX was updated to the ctype_extern, i.e. void\* for all pointers.

The callsite was modified to ctype_extern in separate compiler but was not updated in separate erasure compiler.

This caused a bug in #1309 when NativeString was introduced in BufferedStream as the buffer, since the callsite and signature were defined with different signatures, the prototype with void\*, the implementation with char\*.

This PR fixes the bug by setting both to void\* as in separate compiler.