### PR TITLE
Serialization support SimpleCollection and Map, also bug fixes

### DIFF
--- a/lib/bucketed_game.nit
+++ b/lib/bucketed_game.nit
@@ -22,8 +22,11 @@
 # such as a forest with many individual trees.
 module bucketed_game
 
+import serialization
+
 # Something acting on the game
 class Turnable[G: Game]
+	auto_serializable
 
 	# Execute `turn` for this instance.
 	fun do_turn(turn: GameTurn[G]) is abstract
@@ -32,6 +35,8 @@ end
 # Something acting on the game from time to time
 class Bucketable[G: Game]
 	super Turnable[G]
+	auto_serializable
+
 	private var act_at: nullable Int = null
 
 	# Cancel the previously registered acting turn
@@ -44,6 +49,7 @@ end
 # Optimized organization of `Bucketable` instances
 class Buckets[G: Game]
 	super Turnable[G]
+	auto_serializable
 
 	# Bucket type used in this implementation.
 	type BUCKET: HashSet[Bucketable[G]]
@@ -112,10 +118,12 @@ end
 # Event raised at the first turn
 class FirstTurnEvent
 	super GameEvent
+	auto_serializable
 end
 
 # Game logic on the client
 class ThinGame
+	auto_serializable
 
 	# Game tick when `self` should act.
 	#
@@ -125,17 +133,19 @@ end
 
 # Game turn on the client
 class ThinGameTurn[G: ThinGame]
+	auto_serializable
 
 	# Game tick when `self` should act.
 	var tick: Int is protected writable
 
-	# List of game events occured for `self`.
-	var events = new List[GameEvent] is protected writable
+	# Game events occurred for `self`.
+	var events = new Array[GameEvent] is protected writable
 end
 
 # Game turn on the full logic
 class GameTurn[G: Game]
 	super ThinGameTurn[G]
+	auto_serializable
 
 	# Game that `self` belongs to.
 	var game: G
@@ -163,6 +173,7 @@ end
 # Full game logic
 class Game
 	super ThinGame
+	auto_serializable
 
 	# Game type used in this implementation.
 	type G: Game

--- a/lib/json_serialization.nit
+++ b/lib/json_serialization.nit
@@ -142,7 +142,7 @@ class JsonDeserializer
 				var class_name = object["__class"]
 				assert class_name isa String
 
-				assert not id_to_object.keys.has(id) else print "Error: Object with id '{id}' is deserialized twice."
+				assert not id_to_object.keys.has(id) else print "Error: Object with id '{id}' of {class_name} is deserialized twice."
 
 				# advance on path
 				path.push object

--- a/lib/json_serialization.nit
+++ b/lib/json_serialization.nit
@@ -258,7 +258,7 @@ redef class Array[E]
 	end
 
 	# Instanciate a new `Array` from its serialized representation.
-	init from_deserializer(v: Deserializer)
+	redef init from_deserializer(v: Deserializer)
 	do
 		if v isa JsonDeserializer then
 			v.notify_of_creation self

--- a/lib/json_serialization.nit
+++ b/lib/json_serialization.nit
@@ -111,7 +111,7 @@ class JsonDeserializer
 	redef fun notify_of_creation(new_object)
 	do
 		var id = just_opened_id
-		assert id != null
+		if id == null then return # Register `new_object` only once
 		id_to_object[id] = new_object
 	end
 

--- a/lib/json_serialization.nit
+++ b/lib/json_serialization.nit
@@ -42,7 +42,7 @@ class JsonSerializer
 
 	redef fun serialize_reference(object)
 	do
-		if refs_map.keys.has(object) then
+		if refs_map.has_key(object) then
 			# if already serialized, add local reference
 			var id = ref_id_for(object)
 			stream.write "\{\"__kind\": \"ref\", \"__id\": {id}\}"
@@ -53,12 +53,12 @@ class JsonSerializer
 	end
 
 	# Map of references to already serialized objects.
-	var refs_map = new HashMap[Serializable,Int]
+	private var refs_map = new StrictHashMap[Serializable,Int]
 
 	# Get the internal serialized reference for this `object`.
 	private fun ref_id_for(object: Serializable): Int
 	do
-		if refs_map.keys.has(object) then
+		if refs_map.has_key(object) then
 			return refs_map[object]
 		else
 			var id = refs_map.length
@@ -81,8 +81,8 @@ class JsonDeserializer
 	# Depth-first path in the serialized object tree.
 	var path = new Array[JsonObject]
 
-	# Map of refenrences to already deserialized objects.
-	var id_to_object = new HashMap[Int, Object]
+	# Map of references to already deserialized objects.
+	private var id_to_object = new StrictHashMap[Int, Object]
 
 	# Last encountered object reference id.
 	#
@@ -128,7 +128,7 @@ class JsonDeserializer
 				var id = object["__id"]
 				assert id isa Int
 
-				assert id_to_object.keys.has(id)
+				assert id_to_object.has_key(id)
 				return id_to_object[id]
 			end
 
@@ -142,7 +142,7 @@ class JsonDeserializer
 				var class_name = object["__class"]
 				assert class_name isa String
 
-				assert not id_to_object.keys.has(id) else print "Error: Object with id '{id}' of {class_name} is deserialized twice."
+				assert not id_to_object.has_key(id) else print "Error: Object with id '{id}' of {class_name} is deserialized twice."
 
 				# advance on path
 				path.push object
@@ -271,4 +271,60 @@ redef class Array[E]
 			end
 		end
 	end
+end
+
+# Maps instances to a value, uses `is_same_instance`
+#
+# Warning: This class does not implement all the services from `Map`.
+private class StrictHashMap[K, V]
+	super Map[K, V]
+
+	# private
+	var map = new HashMap[K, Array[Couple[K, V]]]
+
+	redef var length = 0
+
+	redef fun is_empty do return length == 0
+
+	# private
+	fun node_at(key: K): nullable Couple[K, V]
+	do
+		if not map.keys.has(key) then return null
+
+		var arr = map[key]
+		for couple in arr do
+			if couple.first.is_same_serialized(key) then
+				return couple
+			end
+		end
+
+		return null
+	end
+
+	redef fun [](key)
+	do
+		var node = node_at(key)
+		assert node != null
+		return node.second
+	end
+
+	redef fun []=(key, value)
+	do
+		var node = node_at(key)
+		if node != null then
+			node.second = value
+			return
+		end
+
+		var arr
+		if not map.keys.has(key) then
+			arr = new Array[Couple[K, V]]
+			map[key] = arr
+		else arr = map[key]
+
+		arr.add new Couple[K, V](key, value)
+		self.length += 1
+	end
+
+	redef fun has_key(key) do return node_at(key) != null
 end

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -162,4 +162,5 @@ redef class Int super DirectSerializable end
 redef class Float super DirectSerializable end
 redef class NativeString super DirectSerializable end
 redef class String super DirectSerializable end
-redef class Array[E] super Serializable end
+redef class SimpleCollection[E] super Serializable end
+redef class Map[K, V] super Serializable end

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -141,6 +141,13 @@ interface Serializable
 	init from_deserializer(deserializer: Deserializer) do end
 end
 
+redef interface Object
+	# Is `self` the same as `other` in a serialization context?
+	#
+	# Used to determine if an object has already been serialized.
+	fun is_same_serialized(other: nullable Object): Bool do return is_same_instance(other)
+end
+
 # Instances of this class are not delayed and instead serialized immediately
 # This applies mainly to `universal` types
 interface DirectSerializable

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -63,7 +63,7 @@ interface Serializer
 	fun serialize_attribute(name: String, value: nullable Object)
 	do
 		if not try_to_serialize(value) then
-			warn("argument {value.class_name}::{name} is not serializable.")
+			warn("argument {name} of type {value.class_name} is not serializable.")
 		end
 	end
 

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -134,6 +134,11 @@ interface Serializable
 	# The subclass change the default behavior, which will accept references,
 	# to force to always serialize copies of `self`.
 	private fun serialize_to_or_delay(v: Serializer) do v.serialize_reference(self)
+
+	# Create an instance of this class from the `deserializer`
+	#
+	# This constructor is refined by subclasses to correctly build their instances.
+	init from_deserializer(deserializer: Deserializer) do end
 end
 
 # Instances of this class are not delayed and instead serialized immediately

--- a/lib/standard/kernel.nit
+++ b/lib/standard/kernel.nit
@@ -63,7 +63,7 @@ interface Object
 
 	# Have `self` and `other` the same value?
 	#
-	# The exact meaning of "same value" is let to the subclasses.
+	# The exact meaning of "same value" is left to the subclasses.
 	# Implicitly, the default implementation, is `is_same_instance`
 	fun ==(other: nullable Object): Bool do return self.is_same_instance(other)
 
@@ -85,7 +85,7 @@ interface Object
 	# Display class name on stdout (debug only).
 	# This method MUST not be used by programs, it is here for debugging
 	# only and can be removed without any notice
-	fun output_class_name is intern	
+	fun output_class_name is intern
 
 	# The hash code of the object.
 	# Assuming that a == b -> a.hash == b.hash
@@ -223,11 +223,11 @@ end
 # Something that can be cloned
 #
 # This interface introduces the `clone` method used to duplicate an instance
-# Its specific semantic is let to the subclasses.
+# Its specific semantic is left to the subclasses.
 interface Cloneable
 	# Duplicate `self`
 	#
-	# The specific semantic of this method is let to the subclasses;
+	# The specific semantic of this method is left to the subclasses;
 	# Especially, if (and how) attributes are cloned (depth vs. shallow).
 	#
 	# As a rule of thumb, the principle of least astonishment should

--- a/src/frontend/serialization_phase.nit
+++ b/src/frontend/serialization_phase.nit
@@ -99,9 +99,6 @@ private class SerializationPhasePreModel
 	# Add a constructor to the automated nclassdef
 	fun generate_deserialization_init(nclassdef: AStdClassdef)
 	do
-		# Do not generate constructors for abstract classes
-		if nclassdef.n_classkind isa AAbstractClasskind then return
-
 		var npropdefs = nclassdef.n_propdefs
 
 		var code = new Array[String]

--- a/src/frontend/serialization_phase.nit
+++ b/src/frontend/serialization_phase.nit
@@ -105,8 +105,9 @@ private class SerializationPhasePreModel
 		var npropdefs = nclassdef.n_propdefs
 
 		var code = new Array[String]
-		code.add "init from_deserializer(v: Deserializer)"
+		code.add "redef init from_deserializer(v: Deserializer)"
 		code.add "do"
+		code.add "	super"
 		code.add "	v.notify_of_creation self"
 
 		for attribute in npropdefs do if attribute isa AAttrPropdef then

--- a/src/frontend/serialization_phase.nit
+++ b/src/frontend/serialization_phase.nit
@@ -123,7 +123,7 @@ private class SerializationPhasePreModel
 
 			code.add ""
 			code.add "\tvar {name} = v.deserialize_attribute(\"{name}\")"
-			code.add "\tassert {name} isa {type_name} else print \"Unsupported type for attribute '{name}', got '\{{name}.class_name\}' (ex {type_name})\""
+			code.add "\tassert {name} isa {type_name} else print \"Unsupported type for `\{class_name\}::{name}`, got '\{{name}.class_name\}'; expected {type_name}\""
 			code.add "\tself.{name} = {name}"
 		end
 

--- a/tests/sav/nitg-e/test_serialization.res
+++ b/tests/sav/nitg-e/test_serialization.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/nitg-e/test_serialization_redef.res
+++ b/tests/sav/nitg-e/test_serialization_redef.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/nitg-e/test_serialization_redef_alt0.res
+++ b/tests/sav/nitg-e/test_serialization_redef_alt0.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/nitg-e/test_serialization_redef_alt1.res
+++ b/tests/sav/nitg-e/test_serialization_redef_alt1.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/nitg-e/test_serialization_redef_alt2.res
+++ b/tests/sav/nitg-e/test_serialization_redef_alt2.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -13,6 +13,9 @@ redef class Deserializer
 		if name == "Array[nullable Object]" then return new Array[nullable Object].from_deserializer(self)
 		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
 		if name == "Array[String]" then return new Array[String].from_deserializer(self)
+		if name == "StrictHashMap[Serializable, Int]" then return new StrictHashMap[Serializable, Int].from_deserializer(self)
+		if name == "HashMap[Serializable, Array[Couple[Serializable, Int]]]" then return new HashMap[Serializable, Array[Couple[Serializable, Int]]].from_deserializer(self)
+		if name == "Array[Couple[Serializable, Int]]" then return new Array[Couple[Serializable, Int]].from_deserializer(self)
 		return super
 	end
 end

--- a/tests/sav/test_deserialization_serial.res
+++ b/tests/sav/test_deserialization_serial.res
@@ -63,3 +63,12 @@
 # Back in Nit:
 <E: 33.33>
 
+# Nit:
+<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+
+# Json:
+{"__kind": "obj", "__id": 0, "__class": "G", "hs": {"__kind": "obj", "__id": 1, "__class": "HashSet[Int]", "__length": 2, "__items": [-1, 0]}, "s": {"__kind": "obj", "__id": 2, "__class": "ArraySet[String]", "__length": 2, "__items": ["one", "two"]}, "hm": {"__kind": "obj", "__id": 3, "__class": "HashMap[String, Int]", "__length": 2, "__keys": ["one", "two"], "__values": [1, 2]}, "am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap[String, String]", "__length": 2, "__keys": ["three", "four"], "__values": ["3", "4"]}}
+
+# Back in Nit:
+<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+

--- a/tests/sav/test_serialization.res
+++ b/tests/sav/test_serialization.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_serialization_redef.res
+++ b/tests/sav/test_serialization_redef.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_serialization_redef_alt0.res
+++ b/tests/sav/test_serialization_redef_alt0.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_serialization_redef_alt1.res
+++ b/tests/sav/test_serialization_redef_alt1.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_serialization_redef_alt2.res
+++ b/tests/sav/test_serialization_redef_alt2.res
@@ -14,7 +14,7 @@
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl false> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "ref", "__id": 2}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": null, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__length": 3, "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/test_deserialization.nit
+++ b/tests/test_deserialization.nit
@@ -98,7 +98,7 @@ class E
 	redef fun to_s do return "<E: a: {a.join(", ")}; b: {b.join(", ")}>"
 end
 
-# Class with generics
+# Parameterized class
 class F[N: Numeric]
 	auto_serializable
 
@@ -106,6 +106,31 @@ class F[N: Numeric]
 	init(n: N) do self.n = n
 
 	redef fun to_s do return "<E: {n}>"
+end
+
+# Other collections
+class G
+	auto_serializable
+
+	var hs = new HashSet[Int]
+	var s: Set[String] = new ArraySet[String]
+	var hm = new HashMap[String, Int]
+	var am = new ArrayMap[String, String]
+
+	init
+	do
+		hs.add -1
+		hs.add 0
+		s.add "one"
+		s.add "two"
+		hm["one"] = 1
+		hm["two"] = 2
+		am["three"] = 3.to_s
+		am["four"] = 4.to_s
+	end
+
+	redef fun to_s do return "<G: hs: {hs.join(", ")}; s: {s.join(", ")}; "+
+		"hm: {hm.join(", ", ". ")}; am: {am.join(", ", ". ")}>"
 end
 
 var a = new A(true, 'a', 0.1234, 1234, "asdf", null)
@@ -116,9 +141,10 @@ d.d = d
 var e = new E
 var fi = new F[Int](2222)
 var ff = new F[Float](33.33)
+var g = new G
 
 # Default works only with Nit serial
-var tests = new Array[Serializable].with_items(a, b, c, d, e, fi, ff)
+var tests = [a, b, c, d, e, fi, ff, g: Serializable]
 
 # Alt1 should work without nitserial
 #alt1# tests = new Array[Serializable].with_items(a, b, c, d)

--- a/tests/test_deserialization_serial.nit
+++ b/tests/test_deserialization_serial.nit
@@ -22,16 +22,24 @@ import serialization
 redef class Deserializer
 	redef fun deserialize_class(name)
 	do
-			if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
-			if name == "Array[nullable Serializable]" then return new Array[nullable Serializable].from_deserializer(self)
-			if name == "F[Int]" then return new F[Int].from_deserializer(self)
-			if name == "F[Float]" then return new F[Float].from_deserializer(self)
-			if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
-			if name == "Array[String]" then return new Array[String].from_deserializer(self)
-			if name == "Array[HashMap[String, nullable Object]]" then return new Array[HashMap[String, nullable Object]].from_deserializer(self)
-			if name == "Array[Match]" then return new Array[Match].from_deserializer(self)
-			if name == "Array[nullable Object]" then return new Array[nullable Object].from_deserializer(self)
-			if name == "Array[FlatBuffer]" then return new Array[FlatBuffer].from_deserializer(self)
+		# Module: test_deserialization
+		if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
+		if name == "Array[nullable Serializable]" then return new Array[nullable Serializable].from_deserializer(self)
+		if name == "F[Int]" then return new F[Int].from_deserializer(self)
+		if name == "F[Float]" then return new F[Float].from_deserializer(self)
+		if name == "HashSet[Int]" then return new HashSet[Int].from_deserializer(self)
+		if name == "ArraySet[String]" then return new ArraySet[String].from_deserializer(self)
+		if name == "HashMap[String, Int]" then return new HashMap[String, Int].from_deserializer(self)
+		if name == "ArrayMap[String, String]" then return new ArrayMap[String, String].from_deserializer(self)
+		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
+		if name == "Array[String]" then return new Array[String].from_deserializer(self)
+		if name == "HashMap[Serializable, Int]" then return new HashMap[Serializable, Int].from_deserializer(self)
+		if name == "Array[JsonObject]" then return new Array[JsonObject].from_deserializer(self)
+		if name == "HashMap[Int, Object]" then return new HashMap[Int, Object].from_deserializer(self)
+		if name == "Array[Node]" then return new Array[Node].from_deserializer(self)
+		if name == "Array[LRState]" then return new Array[LRState].from_deserializer(self)
+		if name == "Array[Couple[String, String]]" then return new Array[Couple[String, String]].from_deserializer(self)
+		if name == "Array[nullable Jsonable]" then return new Array[nullable Jsonable].from_deserializer(self)
 		return super
 	end
 end


### PR DESCRIPTION
This PR is the result of using Nit serialization to implement game saving/loading in WBTW.

Update the serialization to work with (or avoid) the new auto constructors.

Support serializing Sets and Maps.

The `is_same_serialized` fix a problem where two instances were wrongly serialized as being the same. Because it previously used a `HashMap` (and thus `==`), two different _empty_ arrays were serialized as one and resulted in a single object on deserialization.

Once this and #1348 are merge, I'll update the calculator example to use the serialization.