### PR TITLE
Apply serialization in calculator, a_star, more_collections, Couple and Container

### DIFF
--- a/examples/calculator/src/calculator.nit
+++ b/examples/calculator/src/calculator.nit
@@ -96,7 +96,7 @@ class CalculatorWindow
 
 	redef fun on_save_state
 	do
-		app.data_store["context"] = context.to_json
+		app.data_store["context"] = context
 		super
 	end
 
@@ -104,11 +104,10 @@ class CalculatorWindow
 	do
 		super
 
-		var save = app.data_store["context"]
-		if save == null then return
-		assert save isa String
+		var context = app.data_store["context"]
+		if not context isa CalculatorContext then return
 
-		self.context = new CalculatorContext.from_json(save)
+		self.context = context
 		display.text = context.display_text
 	end
 end

--- a/examples/calculator/src/calculator_logic.nit
+++ b/examples/calculator/src/calculator_logic.nit
@@ -15,10 +15,12 @@
 # Business logic of a calculator
 module calculator_logic
 
-import json::dynamic
+import serialization
 
 # Hold the state of the calculator and its services
 class CalculatorContext
+	auto_serializable
+
 	# Result of the last operation
 	var result: nullable Numeric = null
 
@@ -119,52 +121,6 @@ class CalculatorContext
 
 		self.result = result
 		self.current = null
-	end
-
-	# Serialize calculator state to Json
-	fun to_json: String
-	do
-		# Do not save NaN nor inf
-		var result = self.result
-		if result != null and (result.to_f.is_nan or result.to_f.is_inf != 0) then result = null
-
-		var self_last_op = self.last_op
-		var last_op
-		if self_last_op == null then
-			last_op = "null"
-		else last_op = "\"{self_last_op}\""
-
-		var self_current = self.current
-		var current
-		if self_current == null then
-			current = "null"
-		else current = "\"{self_current}\""
-
-		return """
-{
-	"result": {{{result or else "null"}}},
-	"last_op": {{{last_op}}},
-	"current": {{{current}}}
-}"""
-	end
-
-	# Load calculator state from Json
-	init from_json(json_string: String)
-	do
-		var json = json_string.to_json_value
-		if json.is_error then
-			print "Loading state failed: {json.to_error}"
-			return
-		end
-
-		var result = json["result"]
-		if result.is_numeric then self.result = result.to_numeric
-
-		var last_op = json["last_op"]
-		if last_op.is_string then self.last_op = last_op.to_s.chars.first
-
-		var current = json["current"]
-		if current.is_string then self.current = new FlatBuffer.from(current.to_s)
 	end
 end
 

--- a/lib/more_collections.nit
+++ b/lib/more_collections.nit
@@ -15,6 +15,8 @@
 # Highly specific, but useful, collections-related classes.
 module more_collections
 
+import serialization
+
 # Simple way to store an `HashMap[K, Array[V]]`
 #
 # Unlike standard HashMap, MultiHashMap provides a new
@@ -30,6 +32,7 @@ module more_collections
 #     assert m["four"] == ['i', 'i', 'i', 'i']
 #     assert m["zzz"] == new Array[Char]
 class MultiHashMap[K, V]
+	auto_serializable
 	super HashMap[K, Array[V]]
 
 	# Add `v` to the array associated with `k`.
@@ -61,6 +64,8 @@ end
 # assert hm2[2, "not-two"] == null
 # ~~~~
 class HashMap2[K1, K2, V]
+	auto_serializable
+
 	private var level1 = new HashMap[K1, HashMap[K2, V]]
 
 	# Return the value associated to the keys `k1` and `k2`.
@@ -108,6 +113,8 @@ end
 # assert hm3[2, "not-two", 22] == null
 # ~~~~
 class HashMap3[K1, K2, K3, V]
+	auto_serializable
+
 	private var level1 = new HashMap[K1, HashMap2[K2, K3, V]]
 
 	# Return the value associated to the keys `k1`, `k2`, and `k3`.
@@ -186,6 +193,7 @@ end
 # assert dma.default == [65]
 # ~~~~
 class DefaultMap[K, V]
+	auto_serializable
 	super HashMap[K, V]
 
 	# The default value.

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -164,3 +164,37 @@ redef class NativeString super DirectSerializable end
 redef class String super DirectSerializable end
 redef class SimpleCollection[E] super Serializable end
 redef class Map[K, V] super Serializable end
+
+redef class Couple[F, S]
+	super Serializable
+
+	redef init from_deserializer(v)
+	do
+		v.notify_of_creation self
+		var first = v.deserialize_attribute("first")
+		var second = v.deserialize_attribute("second")
+		init(first, second)
+	end
+
+	redef fun core_serialize_to(v)
+	do
+		v.serialize_attribute("first", first)
+		v.serialize_attribute("second", second)
+	end
+end
+
+redef class Container[E]
+	super Serializable
+
+	redef init from_deserializer(v)
+	do
+		v.notify_of_creation self
+		var item = v.deserialize_attribute("item")
+		init item
+	end
+
+	redef fun core_serialize_to(v)
+	do
+		v.serialize_attribute("item", first)
+	end
+end

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -15,6 +15,7 @@ redef class Deserializer
 		if name == "Array[String]" then return new Array[String].from_deserializer(self)
 		if name == "HashMap[Serializable, Array[Couple[Serializable, Int]]]" then return new HashMap[Serializable, Array[Couple[Serializable, Int]]].from_deserializer(self)
 		if name == "Array[Couple[Serializable, Int]]" then return new Array[Couple[Serializable, Int]].from_deserializer(self)
+		if name == "Couple[Serializable, Int]" then return new Couple[Serializable, Int].from_deserializer(self)
 		return super
 	end
 end


### PR DESCRIPTION
Use `auto_serialize` in the calculator example, and remove the old custom JSON serialization.

The `a_star` module needed special care and could not rely only on `auto_serialize`. This was to avoid serializing graphs as a deep tree, instead we serialize the nodes first, then the links and we rebuild the graph at deserialization.

Besides that, more collections support the serialization.