### PR TITLE
metrics: `--nullables` distinguishes safe and unsafe calls on `null`

### DIFF
--- a/src/metrics/nullables_metrics.nit
+++ b/src/metrics/nullables_metrics.nit
@@ -109,6 +109,7 @@ private class NullableSends
 
 	var total_sends: Int = 0
 	var nullable_sends: Int = 0
+	var nullable_eq_sends: Int = 0
 	var buggy_sends: Int = 0
 
 	# Get a new visitor on a classef to add type count in `typecount`.
@@ -130,7 +131,12 @@ private class NullableSends
 			end
 			t = t.anchor_to(self.nclassdef.mclassdef.mmodule, self.nclassdef.mclassdef.bound_mtype)
 			if t isa MNullableType then
-				self.nullable_sends += 1
+				var name = n.callsite.mproperty.name
+				if name == "==" or name == "!=" or name == "is_same_instance" then
+					self.nullable_eq_sends += 1
+				else
+					self.nullable_sends += 1
+				end
 			else if t isa MClassType then
 				# Nothing
 			else
@@ -146,6 +152,7 @@ do
 	print "--- Sends on Nullable Receiver ---"
 	var total_sends = 0
 	var nullable_sends = 0
+	var nullable_eq_sends = 0
 	var buggy_sends = 0
 
 	# Visit all the source code to collect data
@@ -155,10 +162,12 @@ do
 			visitor.enter_visit(nclassdef)
 			total_sends += visitor.total_sends
 			nullable_sends += visitor.nullable_sends
+			nullable_eq_sends += visitor.nullable_eq_sends
 			buggy_sends += visitor.buggy_sends
 		end
 	end
 	print "Total number of sends: {total_sends}"
-	print "Number of sends on a nullable receiver: {nullable_sends} ({div(nullable_sends*100,total_sends)}%)"
+	print "Number of sends on a unsafe nullable receiver: {nullable_sends} ({div(nullable_sends*100,total_sends)}%)"
+	print "Number of sends on a safe nullable receiver: {nullable_eq_sends} ({div(nullable_eq_sends*100,total_sends)}%)"
 	print "Number of buggy sends (cannot determine the type of the receiver): {buggy_sends} ({div(buggy_sends*100,total_sends)}%)"
 end

--- a/tests/sav/nitmetrics_args1.res
+++ b/tests/sav/nitmetrics_args1.res
@@ -772,7 +772,8 @@ Statistics of type usage:
 	  sum: 0
 --- Sends on Nullable Receiver ---
 Total number of sends: 19
-Number of sends on a nullable receiver: 0 (0.00%)
+Number of sends on a unsafe nullable receiver: 0 (0.00%)
+Number of sends on a safe nullable receiver: 0 (0.00%)
 Number of buggy sends (cannot determine the type of the receiver): 0 (0.00%)
 
 # RTA metrics


### PR DESCRIPTION
In reaction of recent updates on #394 I wanted to have some up-to-date numbers.

`nitmetrics --nullable` can count the sends on nullable receivers but safe and unsafe calls where merged. Note: safe calls on nullable are things like `x == null`, that is safe even if `x` is a nullable thing.
So this PR distinguishes safe and unsafe calls.

Some numbers:

~~~
nitmetrics --nullables ../lib ../src/nit*.nit
Total number of sends: 60262
Number of sends on a unsafe nullable receiver: 1750 (2.90%)
Number of sends on a safe nullable receiver: 2639 (4.37%)
~~~