### PR TITLE
introduce plain_to_s

### DIFF
--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -1230,7 +1230,7 @@ end
 # Print `objects` on the standard output (`stdout`).
 fun printn(objects: Object...)
 do
-	sys.stdout.write(objects.to_s)
+	sys.stdout.write(objects.plain_to_s)
 end
 
 # Print an `object` on the standard output (`stdout`) and add a newline.

--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -2220,6 +2220,12 @@ redef class Collection[E]
 	# Concatenate elements.
 	redef fun to_s
 	do
+		return plain_to_s
+	end
+
+	# Concatenate element without separators
+	fun plain_to_s: String
+	do
 		var s = new FlatBuffer
 		for e in self do if e != null then s.append(e.to_s)
 		return s.to_s
@@ -2255,7 +2261,7 @@ end
 redef class Array[E]
 
 	# Fast implementation
-	redef fun to_s
+	redef fun plain_to_s
 	do
 		var l = length
 		if l == 0 then return ""

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -1629,7 +1629,7 @@ redef class ASuperstringExpr
 			array.add(i)
 		end
 		var i = v.array_instance(array, v.mainmodule.object_type)
-		var res = v.send(v.force_get_primitive_method("to_s", i.mtype), [i])
+		var res = v.send(v.force_get_primitive_method("plain_to_s", i.mtype), [i])
 		assert res != null
 		return res
 	end

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -559,7 +559,7 @@ redef class ASuperstringExpr
 	redef fun accept_rapid_type_visitor(v)
 	do
 		var mmodule = v.analysis.mainmodule
-		var object_type = mmodule.object_type
+		var object_type = mmodule.string_type
 		var arraytype = mmodule.array_type(object_type)
 		v.add_type(arraytype)
 		var nattype = mmodule.native_array_type(object_type)

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -9,10 +9,10 @@ redef class Deserializer
 	redef fun deserialize_class(name)
 	do
 		# Module: test_serialization
-		if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
+		if name == "Array[String]" then return new Array[String].from_deserializer(self)
 		if name == "Array[nullable Object]" then return new Array[nullable Object].from_deserializer(self)
 		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
-		if name == "Array[String]" then return new Array[String].from_deserializer(self)
+		if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
 		if name == "HashMap[Serializable, Array[Couple[Serializable, Int]]]" then return new HashMap[Serializable, Array[Couple[Serializable, Int]]].from_deserializer(self)
 		if name == "Array[Couple[Serializable, Int]]" then return new Array[Couple[Serializable, Int]].from_deserializer(self)
 		return super


### PR DESCRIPTION
In order to have a more POLA `to_s` on collections, it is required that a new method with the old behavior is provided for clients that need it (especially the interpreter that use it for superstrings).

the compiler use `native_to_s` for superstrings but `c_src/nitg` still use `to_s` on array, so a regeneration of the bootstrap is required before changing the behavior of `to_s` on collections.