### PR TITLE
Serialization caching and prepare for other engines

### DIFF
--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -395,6 +395,7 @@ redef class SimpleCollection[E]
 
 	redef init from_deserializer(v: Deserializer)
 	do
+		super
 		if v isa JsonDeserializer then
 			v.notify_of_creation self
 			init
@@ -466,10 +467,11 @@ redef class Map[K, V]
 	# Instantiate a new `Array` from its serialized representation.
 	redef init from_deserializer(v: Deserializer)
 	do
-		init
+		super
 
 		if v isa JsonDeserializer then
 			v.notify_of_creation self
+			init
 
 			var length = v.deserialize_attribute("__length").as(Int)
 			var keys = v.path.last["__keys"].as(SequenceRead[nullable Object])

--- a/lib/serialization/caching.nit
+++ b/lib/serialization/caching.nit
@@ -24,6 +24,21 @@ abstract class CachingSerializer
 
 	# Cache of known objects
 	var cache = new SerializerCache is lazy, writable
+
+	# Link the cache of `self` with `deserializer`
+	#
+	# This allows reference objects by id when they are known by the other side
+	# of the stream.
+	#
+	# Use `cache` if it is a `DuplexCache`, otherwise create a new one.
+	fun link(deserializer: CachingDeserializer)
+	do
+		var mem = self.cache
+		if not mem isa DuplexCache then mem = new DuplexCache
+
+		self.cache = mem
+		deserializer.cache = mem
+	end
 end
 
 # A `Deserializer` with a `cache`

--- a/lib/serialization/caching.nit
+++ b/lib/serialization/caching.nit
@@ -81,3 +81,23 @@ class DeserializerCache
 	# Associate `object` to `id`
 	fun []=(id: Int, object: Object) do received[id] = object
 end
+
+# A shared cache for serialization and deserialization
+class DuplexCache
+	super SerializerCache
+	super DeserializerCache
+
+	redef fun new_id_for(object)
+	do
+		var id = super
+		received[id] = object
+		return id
+	end
+
+	redef fun []=(id, object)
+	do
+		super
+		assert object isa Serializable
+		sent[object] = id
+	end
+end

--- a/lib/serialization/caching.nit
+++ b/lib/serialization/caching.nit
@@ -1,0 +1,83 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Services for caching serialization engines
+module caching
+
+import serialization
+private import engine_tools
+
+# A `Serializer` with a `cache`
+abstract class CachingSerializer
+	super Serializer
+
+	# Cache of known objects
+	var cache = new SerializerCache is lazy, writable
+end
+
+# A `Deserializer` with a `cache`
+abstract class CachingDeserializer
+	super Deserializer
+
+	# Cache of known objects
+	var cache = new DeserializerCache is lazy, writable
+end
+
+# Cache of sent objects
+#
+# Used by `Serializer` to avoid duplicating objects, by serializing them once,
+# then using a reference.
+class SerializerCache
+	# Map of already serialized objects to the reference id
+	private var sent: Map[Serializable, Int] = new StrictHashMap[Serializable, Int]
+
+	# Is `object` known?
+	fun has_object(object: Serializable): Bool do return sent.keys.has(object)
+
+	# Get the id for `object`
+	#
+	# Require: `has_object(object)`
+	fun id_for(object: Serializable): Int
+	do
+		assert sent.keys.has(object)
+		return sent[object]
+	end
+
+	# Get a new id for `object` and store it
+	#
+	# Require: `not has_object(object)`
+	fun new_id_for(object: Serializable): Int
+	do
+		var id = sent.length
+		sent[object] = id
+		return id
+	end
+end
+
+# Cache of received objects sorted by there reference id
+#
+# Used by `Deserializer` to find already deserialized objects by their reference.
+class DeserializerCache
+	# Map of references to already deserialized objects.
+	private var received: Map[Int, Object] = new StrictHashMap[Int, Object]
+
+	# Is there an object associated to `id`?
+	fun has_id(id: Int): Bool do return received.keys.has(id)
+
+	# Get the object associated to `id`
+	fun object_for(id: Int): nullable Object do return received[id]
+
+	# Associate `object` to `id`
+	fun []=(id: Int, object: Object) do received[id] = object
+end

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -146,6 +146,12 @@ redef interface Object
 	#
 	# Used to determine if an object has already been serialized.
 	fun is_same_serialized(other: nullable Object): Bool do return is_same_instance(other)
+
+	# Hash value use for serialization
+	#
+	# Used in combination with `is_same_serialized`. If two objects are the same
+	# in a serialization context, they must have the same `serialization_hash`.
+	fun serialization_hash: Int do return object_id
 end
 
 # Instances of this class are not delayed and instead serialized immediately

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -13,8 +13,6 @@ redef class Deserializer
 		if name == "Array[nullable Object]" then return new Array[nullable Object].from_deserializer(self)
 		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
 		if name == "Array[String]" then return new Array[String].from_deserializer(self)
-		if name == "HashMap[Serializable, Array[Couple[Serializable, Int]]]" then return new HashMap[Serializable, Array[Couple[Serializable, Int]]].from_deserializer(self)
-		if name == "Array[Couple[Serializable, Int]]" then return new Array[Couple[Serializable, Int]].from_deserializer(self)
 		return super
 	end
 end


### PR DESCRIPTION
Duplex caching allows a client and server to keep copies of the "same" instances (same as in `is_same_serialized`) and only refer to it with an integer. This allows for lighter communication over network. I'm working on an example using `DuplexCache` with the binary serializer that I will soon PR.

Modifications to the `StrictHashMap` allow for much faster read access.