### PR TITLE
Markdown location

### DIFF
--- a/lib/markdown/test_markdown.nit
+++ b/lib/markdown/test_markdown.nit
@@ -2366,43 +2366,46 @@ end
 class TestBlock
 	super TestSuite
 
+	# A dummy location for testing purposes.
+	var loc = new MDLocation(0, 0, 0, 0)
+
 	fun test_has_blocks do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		assert not subject.has_blocks
-		subject.first_block = new MDBlock
+		subject.first_block = new MDBlock(loc)
 		assert subject.has_blocks
 	end
 
 	fun test_count_blocks do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		assert subject.count_blocks == 0
-		subject.first_block = new MDBlock
+		subject.first_block = new MDBlock(loc)
 		assert subject.count_blocks == 1
-		subject.first_block.next = new MDBlock
+		subject.first_block.next = new MDBlock(loc)
 		assert subject.count_blocks == 2
 	end
 
 	fun test_has_lines do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		assert not subject.has_lines
-		subject.first_line = new MDLine("")
+		subject.first_line = new MDLine(loc, "")
 		assert subject.has_lines
 	end
 
 	fun test_count_lines do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		assert subject.count_lines == 0
-		subject.first_line = new MDLine("")
+		subject.first_line = new MDLine(loc, "")
 		assert subject.count_lines == 1
-		subject.first_line.next = new MDLine("")
+		subject.first_line.next = new MDLine(loc, "")
 		assert subject.count_lines == 2
 	end
 
 	fun test_split do
-		var line1 = new MDLine("line1")
-		var line2 = new MDLine("line2")
-		var line3 = new MDLine("line3")
-		var subject = new MDBlock
+		var line1 = new MDLine(loc, "line1")
+		var line2 = new MDLine(loc, "line2")
+		var line3 = new MDLine(loc, "line3")
+		var subject = new MDBlock(loc)
 		subject.add_line line1
 		subject.add_line line2
 		subject.add_line line3
@@ -2417,19 +2420,19 @@ class TestBlock
 	end
 
 	fun test_add_line do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		assert subject.count_lines == 0
-		subject.add_line new MDLine("")
+		subject.add_line new MDLine(loc, "")
 		assert subject.count_lines == 1
-		subject.add_line new MDLine("")
+		subject.add_line new MDLine(loc, "")
 		assert subject.count_lines == 2
 	end
 
 	fun test_remove_line do
-		var line1 = new MDLine("line1")
-		var line2 = new MDLine("line2")
-		var line3 = new MDLine("line3")
-		var subject = new MDBlock
+		var line1 = new MDLine(loc, "line1")
+		var line2 = new MDLine(loc, "line2")
+		var line3 = new MDLine(loc, "line3")
+		var subject = new MDBlock(loc)
 		subject.add_line line1
 		subject.add_line line2
 		subject.add_line line3
@@ -2442,29 +2445,29 @@ class TestBlock
 	end
 
 	fun test_transform_headline1 do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		var kind = new BlockHeadline(subject)
-		subject.add_line new MDLine(" #   Title 1   ")
+		subject.add_line new MDLine(loc, " #   Title 1   ")
 		kind.transform_headline(subject)
 		assert kind.depth == 1
 		assert subject.first_line.value == "Title 1"
 	end
 
 	fun test_transform_headline2 do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		var kind = new BlockHeadline(subject)
-		subject.add_line new MDLine(" #####Title 5   ")
+		subject.add_line new MDLine(loc, " #####Title 5   ")
 		kind.transform_headline(subject)
 		assert kind.depth == 5
 		assert subject.first_line.value == "Title 5"
 	end
 
 	fun test_remove_quote_prefix do
-		var subject = new MDBlock
+		var subject = new MDBlock(loc)
 		var kind = new BlockQuote(subject)
-		subject.add_line new MDLine(" > line 1")
-		subject.add_line new MDLine(" > line 2")
-		subject.add_line new MDLine(" > line 3")
+		subject.add_line new MDLine(loc, " > line 1")
+		subject.add_line new MDLine(loc, " > line 2")
+		subject.add_line new MDLine(loc, " > line 3")
 		kind.remove_block_quote_prefix(subject)
 		assert subject.first_line.value == "line 1"
 		assert subject.first_line.next.value == "line 2"
@@ -2472,51 +2475,51 @@ class TestBlock
 	end
 
 	fun test_remove_leading_empty_lines_1 do
-		var block = new MDBlock
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("   text")
-		block.add_line new MDLine("")
+		var block = new MDBlock(loc)
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "   text")
+		block.add_line new MDLine(loc, "")
 		assert block.remove_leading_empty_lines
 		assert block.first_line.value == "   text"
 	end
 
 	fun test_remove_leading_empty_lines_2 do
-		var block = new MDBlock
-		block.add_line new MDLine("   text")
+		var block = new MDBlock(loc)
+		block.add_line new MDLine(loc, "   text")
 		block.remove_leading_empty_lines
 		assert block.first_line.value == "   text"
 	end
 
 	fun test_remove_trailing_empty_lines_1 do
-		var block = new MDBlock
-		block.add_line new MDLine("")
-		block.add_line new MDLine("text")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
+		var block = new MDBlock(loc)
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "text")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
 		assert block.remove_trailing_empty_lines
 		assert block.last_line.value == "text"
 	end
 
 	fun test_remove_trailing_empty_lines_2 do
-		var block = new MDBlock
-		block.add_line new MDLine("text  ")
+		var block = new MDBlock(loc)
+		block.add_line new MDLine(loc, "text  ")
 		assert not block.remove_trailing_empty_lines
 		assert block.last_line.value == "text  "
 	end
 
 	fun test_remove_surrounding_empty_lines do
-		var block = new MDBlock
-		block.add_line new MDLine("")
-		block.add_line new MDLine("text")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
-		block.add_line new MDLine("")
+		var block = new MDBlock(loc)
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "text")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
+		block.add_line new MDLine(loc, "")
 		assert block.remove_surrounding_empty_lines
 		assert block.first_line.value == "text"
 		assert block.last_line.value == "text"
@@ -2526,118 +2529,121 @@ end
 class TestLine
 	super TestSuite
 
+	# A dummy location for testing purposes.
+	var loc = new MDLocation(0, 0, 0, 0)
+
 	var subject: MDLine
 
 	fun test_is_empty do
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert subject.is_empty
-		subject = new MDLine("    ")
+		subject = new MDLine(loc, "    ")
 		assert subject.is_empty
-		subject = new MDLine("test")
+		subject = new MDLine(loc, "test")
 		assert not subject.is_empty
-		subject = new MDLine("    test")
+		subject = new MDLine(loc, "    test")
 		assert not subject.is_empty
 	end
 
 	fun test_leading do
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert subject.leading == 0
-		subject = new MDLine("    ")
+		subject = new MDLine(loc, "    ")
 		assert subject.leading == 4
-		subject = new MDLine("test")
+		subject = new MDLine(loc, "test")
 		assert subject.leading == 0
-		subject = new MDLine("    test")
+		subject = new MDLine(loc, "    test")
 		assert subject.leading == 4
 	end
 
 	fun test_trailing do
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert subject.trailing == 0
-		subject = new MDLine("    ")
+		subject = new MDLine(loc, "    ")
 		assert subject.trailing == 0
-		subject = new MDLine("test   ")
+		subject = new MDLine(loc, "test   ")
 		assert subject.trailing == 3
-		subject = new MDLine("    test ")
+		subject = new MDLine(loc, "    test ")
 		assert subject.trailing == 1
 	end
 
 	fun test_line_type do
 		var v = new MarkdownProcessor
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert v.line_kind(subject) isa LineEmpty
-		subject = new MDLine("    ")
+		subject = new MDLine(loc, "    ")
 		assert v.line_kind(subject) isa LineEmpty
-		subject = new MDLine("text   ")
+		subject = new MDLine(loc, "text   ")
 		assert v.line_kind(subject) isa LineOther
-		subject = new MDLine("  # Title")
+		subject = new MDLine(loc, "  # Title")
 		assert v.line_kind(subject) isa LineHeadline
-		subject = new MDLine("  ### Title")
+		subject = new MDLine(loc, "  ### Title")
 		assert v.line_kind(subject) isa LineHeadline
-		subject = new MDLine("    code")
+		subject = new MDLine(loc, "    code")
 		assert v.line_kind(subject) isa LineCode
-		subject = new MDLine("   Title  ")
-		subject.next = new MDLine("== ")
+		subject = new MDLine(loc, "   Title  ")
+		subject.next = new MDLine(loc, "== ")
 		assert v.line_kind(subject) isa LineHeadline1
-		subject = new MDLine("   Title  ")
-		subject.next = new MDLine("-- ")
+		subject = new MDLine(loc, "   Title  ")
+		subject.next = new MDLine(loc, "-- ")
 		assert v.line_kind(subject) isa LineHeadline2
-		subject = new MDLine("  *    *   * ")
+		subject = new MDLine(loc, "  *    *   * ")
 		assert v.line_kind(subject) isa LineHR
-		subject = new MDLine("  *** ")
+		subject = new MDLine(loc, "  *** ")
 		assert v.line_kind(subject) isa LineHR
-		subject = new MDLine("- -- ")
+		subject = new MDLine(loc, "- -- ")
 		assert v.line_kind(subject) isa LineHR
-		subject = new MDLine("--------- ")
+		subject = new MDLine(loc, "--------- ")
 		assert v.line_kind(subject) isa LineHR
-		subject = new MDLine(" >")
+		subject = new MDLine(loc, " >")
 		assert v.line_kind(subject) isa LineBlockquote
-		subject = new MDLine("<p></p>")
+		subject = new MDLine(loc, "<p></p>")
 		assert v.line_kind(subject) isa LineXML
-		subject = new MDLine("<p>")
+		subject = new MDLine(loc, "<p>")
 		assert v.line_kind(subject) isa LineOther
-		subject = new MDLine("  * foo")
+		subject = new MDLine(loc, "  * foo")
 		assert v.line_kind(subject) isa LineUList
-		subject = new MDLine("- foo")
+		subject = new MDLine(loc, "- foo")
 		assert v.line_kind(subject) isa LineUList
-		subject = new MDLine("+ foo")
+		subject = new MDLine(loc, "+ foo")
 		assert v.line_kind(subject) isa LineUList
-		subject = new MDLine("1. foo")
+		subject = new MDLine(loc, "1. foo")
 		assert v.line_kind(subject) isa LineOList
-		subject = new MDLine("   11111. foo")
+		subject = new MDLine(loc, "   11111. foo")
 		assert v.line_kind(subject) isa LineOList
 	end
 
 	fun test_line_type_ext do
 		var v = new MarkdownProcessor
-		subject = new MDLine("  ~~~")
+		subject = new MDLine(loc, "  ~~~")
 		assert v.line_kind(subject) isa LineFence
-		subject = new MDLine("  ```")
+		subject = new MDLine(loc, "  ```")
 		assert v.line_kind(subject) isa LineFence
 	end
 
 	fun test_count_chars do
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert subject.count_chars('*') == 0
-		subject = new MDLine("* ")
+		subject = new MDLine(loc, "* ")
 		assert subject.count_chars('*') == 1
-		subject = new MDLine(" * text")
+		subject = new MDLine(loc, " * text")
 		assert subject.count_chars('*') == 0
-		subject = new MDLine(" *    *    *")
+		subject = new MDLine(loc, " *    *    *")
 		assert subject.count_chars('*') == 3
-		subject = new MDLine("text ** ")
+		subject = new MDLine(loc, "text ** ")
 		assert subject.count_chars('*') == 0
 	end
 
 	fun test_count_chars_start do
-		subject = new MDLine("")
+		subject = new MDLine(loc, "")
 		assert subject.count_chars_start('*') == 0
-		subject = new MDLine("* ")
+		subject = new MDLine(loc, "* ")
 		assert subject.count_chars_start('*') == 1
-		subject = new MDLine(" * text")
+		subject = new MDLine(loc, " * text")
 		assert subject.count_chars_start('*') == 1
-		subject = new MDLine(" *    *    * text")
+		subject = new MDLine(loc, " *    *    * text")
 		assert subject.count_chars_start('*') == 3
-		subject = new MDLine("text ** ")
+		subject = new MDLine(loc, "text ** ")
 		assert subject.count_chars_start('*') == 0
 	end
 end

--- a/lib/markdown/wikilinks.nit
+++ b/lib/markdown/wikilinks.nit
@@ -32,7 +32,7 @@ redef class MarkdownProcessor
 		if not token isa TokenLink then return token
 		if pos + 1 < text.length then
 			var c = text[pos + 1]
-			if c == '[' then return new TokenWikiLink(pos, c)
+			if c == '[' then return new TokenWikiLink(token.location, pos, c)
 		end
 		return token
 	end


### PR DESCRIPTION
Introduce location in markdown parser so tools can easily retrieve the original position of a block or a token in the input file/string.

Commits:
* 2d139eb introduces de Location concept and update the parser
* fda150d isn't interesting since it only update signature in the test file
* dacc7ba adds some test suites for the locations