### PR TITLE
Improve internal mechanisms of the nitvm

### DIFF
--- a/src/vm/virtual_machine.nit
+++ b/src/vm/virtual_machine.nit
@@ -532,7 +532,6 @@ redef class MClass
 				if p isa MMethod then
 					self_methods += 1
 					p.offset = relative_offset_meth
-					p.absolute_offset = offset_methods + relative_offset_meth
 					relative_offset_meth += 1
 
 					intro_mmethods.add(p)
@@ -540,7 +539,6 @@ redef class MClass
 				if p isa MAttribute then
 					nb_introduced_attributes += 1
 					p.offset = relative_offset_attr
-					p.absolute_offset = offset_attributes + relative_offset_attr
 					relative_offset_attr += 1
 
 					intro_mattributes.add(p)
@@ -802,21 +800,21 @@ redef class MClass
 	end
 end
 
+redef class MProperty
+	# Relative offset of this in the runtime instance
+	# (beginning of the block of its introducing class for attributes or methods)
+	var offset: Int
+end
+
 redef class MAttribute
 	# Relative offset of this attribute in the runtime instance
 	# (beginning of the block of its introducing class)
-	var offset: Int
-
-	# Absolute offset of this attribute in the runtime instance (beginning of the attribute table)
-	var absolute_offset: Int
+	redef var offset: Int
 end
 
 redef class MMethod
 	# Relative offset of this method in the virtual table (from the beginning of the block)
-	var offset: Int
-
-	# Absolute offset of this method in the virtual table (from the beginning of the vtable)
-	var absolute_offset: Int
+	redef var offset: Int
 end
 
 # Redef MutableInstance to improve implementation of attributes in objects


### PR DESCRIPTION
This PR fixes a bug that was hidden in the nitvm for a too long time, the recursion in class loading was bad and is now corrected.

Then a more accurate mechanism is introduce to deal with positions of methods and attributes in internal structures of classes and objects.
When a method dispatch is performed, this mechanism allows to ask precisely for a class the position of a block of methods (or attributes). This should increase the proportion of object mechanisms "compiled" in an efficient way.

Finally, the class loading is optimized: an indirectly loaded class is not fully constructed and allocated.
Instead, its identifier is computed to allow subtyping tests.

For now, these more accurate mechanisms need recompilations of callsite. This sould be done in further PR.