### PR TITLE
Rename the visit function of minilang example.

### DIFF
--- a/contrib/nitcc/examples/minilang.nit
+++ b/contrib/nitcc/examples/minilang.nit
@@ -13,45 +13,45 @@ class Interpretor
 	# The current values assigned to each variable
 	var vars = new HashMap[String, Int]
 
-	redef fun visit(n) do n.accept_calculator(self)
+	redef fun visit(n) do n.accept_minilang(self)
 end
 
 redef class Node
 	# Execution of the node by the interpreter `v`
-	fun accept_calculator(v: Interpretor) do visit_children(v)
+	fun accept_minilang(v: Interpretor) do visit_children(v)
 end
 
 redef class Nint
-	redef fun accept_calculator(v) do v.stack.push(text.to_i)
+	redef fun accept_minilang(v) do v.stack.push(text.to_i)
 end
 
 redef class Ns_assign
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.vars[n_id.text] = v.stack.pop
 	end
 end
 
 redef class Ns_print
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		printn v.stack.pop
 	end
 end
 redef class Ns_print_str
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		var text = n_str.text
 		text = text.substring(1, text.length-2)
 		printn text
 	end
 end
 redef class Ns_println
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		print ""
 	end
 end
 redef class Ns_if
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		v.enter_visit(n_c)
 		if v.bstack.pop then
 			v.enter_visit(n_then)
@@ -62,7 +62,7 @@ redef class Ns_if
 	end
 end
 redef class Ns_while
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		loop
 			v.enter_visit(n_c)
 			if not v.bstack.pop then break
@@ -73,7 +73,7 @@ end
 
 
 redef class Nc_and
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		var b1 = v.bstack.pop
 		var b2 = v.bstack.pop
@@ -82,7 +82,7 @@ redef class Nc_and
 end
 
 redef class Nc_or
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		var b1 = v.bstack.pop
 		var b2 = v.bstack.pop
@@ -91,93 +91,93 @@ redef class Nc_or
 end
 
 redef class Nc_not
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(not v.bstack.pop)
 	end
 end
 
 redef class Nc_eq
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop == v.stack.pop)
 	end
 end
 
 redef class Nc_ne
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop != v.stack.pop)
 	end
 end
 
 redef class Nc_lt
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop > v.stack.pop)
 	end
 end
 
 redef class Nc_le
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop >= v.stack.pop)
 	end
 end
 
 redef class Nc_gt
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop < v.stack.pop)
 	end
 end
 
 redef class Nc_ge
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.bstack.push(v.stack.pop <= v.stack.pop)
 	end
 end
 
 redef class Ne_add
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.stack.push(v.stack.pop+v.stack.pop)
 	end
 end
 redef class Ne_sub
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		var n1 = v.stack.pop
 		v.stack.push(v.stack.pop-n1)
 	end
 end
 redef class Ne_neg
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.stack.push(-v.stack.pop)
 	end
 end
 redef class Ne_mul
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		v.stack.push(v.stack.pop*v.stack.pop)
 	end
 end
 redef class Ne_div
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		super
 		var n1 = v.stack.pop
 		v.stack.push(v.stack.pop/n1)
 	end
 end
 redef class Ne_var
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		v.stack.push v.vars[n_id.text]
 	end
 end
 redef class Ne_read
-	redef fun accept_calculator(v) do
+	redef fun accept_minilang(v) do
 		var t = gets
 		v.stack.push(t.to_i)
 	end


### PR DESCRIPTION
This PR rename the visit function of the ```minilang.nit``` file. The previous name was incoherent with the module purpose.