### PR TITLE
Annotation lateinit

### DIFF
--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -84,6 +84,7 @@ readonly
 writable
 autoinit
 noautoinit
+lateinit
 nosuper
 old_style_init
 abstract

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -206,9 +206,9 @@ redef class ModelBuilder
 				var mreadpropdef = npropdef.mreadpropdef
 				if mreadpropdef == null or mreadpropdef.msignature == null then return # Skip broken attribute
 				if npropdef.noinit then continue # Skip noinit attribute
-				var atautoinit = npropdef.get_single_annotation("autoinit", self)
-				if atautoinit != null then
-					# For autoinit attributes, call the reader to force
+				var atlateinit = npropdef.get_single_annotation("lateinit", self)
+				if atlateinit != null then
+					# For lateinit attributes, call the reader to force
 					# the lazy initialization of the attribute.
 					initializers.add(mreadpropdef.mproperty)
 					mreadpropdef.mproperty.is_autoinit = true
@@ -1187,17 +1187,17 @@ redef class AAttrPropdef
 		end
 
 		var atlazy = self.get_single_annotation("lazy", modelbuilder)
-		var atautoinit = self.get_single_annotation("autoinit", modelbuilder)
-		if atlazy != null or atautoinit != null then
-			if atlazy != null and atautoinit != null then
-				modelbuilder.error(atlazy, "Error: `lazy` incompatible with `autoinit`.")
+		var atlateinit = self.get_single_annotation("lateinit", modelbuilder)
+		if atlazy != null or atlateinit != null then
+			if atlazy != null and atlateinit != null then
+				modelbuilder.error(atlazy, "Error: `lazy` incompatible with `lateinit`.")
 				return
 			end
 			if not has_value then
 				if atlazy != null then
 					modelbuilder.error(atlazy, "Error: `lazy` attributes need a value.")
-				else if atautoinit != null then
-					modelbuilder.error(atautoinit, "Error: `autoinit` attributes need a value.")
+				else if atlateinit != null then
+					modelbuilder.error(atlateinit, "Error: `lateinit` attributes need a value.")
 				end
 				has_value = true
 				return

--- a/tests/base_init_autoinit2.nit
+++ b/tests/base_init_autoinit2.nit
@@ -19,8 +19,8 @@ class A
 	var b: Object is noautoinit
 	#alt1#var b2: Object = get(-4) is noautoinit
 	var c: Object is noautoinit
-	var d: Object = get(2) is autoinit
-	#alt2#var d2: Object = get(-2) is autoinit, lazy
+	var d: Object = get(2) is lateinit
+	#alt2#var d2: Object = get(-2) is lateinit, lazy
 	var e: Object = get(1)
 	fun setc(v: Object) is autoinit do self.c = get(v)
 	init do

--- a/tests/sav/base_init_autoinit2_alt2.res
+++ b/tests/sav/base_init_autoinit2_alt2.res
@@ -1,1 +1,1 @@
-alt/base_init_autoinit2_alt2.nit:23,40--43: Error: `lazy` incompatible with `autoinit`.
+alt/base_init_autoinit2_alt2.nit:23,40--43: Error: `lazy` incompatible with `lateinit`.


### PR DESCRIPTION
#857 introduced `autoinit` on attributes that has a default value to initialize them latter.

This is a rarely used feature. It is also not POLA because it overloads the name `autoinit` that has a different meaning on methods cf #1308.

Thus in order to polaize the spec, the annotation is renamed `lateinit`. So close #1308.
Note: maybe the annotation will just be removed in a future PR, this one is a last attempt to keep it.

Related to #1322; required by #1311