### PR TITLE
modelize: ask that attributes in refinements are either noautoninit or have a value

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -2452,7 +2452,7 @@ extern class NativeString `{ char* `}
 end
 
 redef class Sys
-	private var args_cache: nullable Sequence[String]
+	private var args_cache: nullable Sequence[String] = null
 
 	# The arguments of the program as given by the OS
 	fun program_args: Sequence[String]

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1217,6 +1217,10 @@ redef class AAttrPropdef
 			return
 		end
 
+		if not mclassdef.is_intro and not has_value and not noinit then
+			modelbuilder.advice(self, "attr-in-refinement", "Warning: attributes in refinement need a value or `noautoinit`.")
+		end
+
 		var writename = name + "="
 		var atwritable = self.get_single_annotation("writable", modelbuilder)
 		if atwritable != null then


### PR DESCRIPTION
Without value, attributes in introductions does not have the same semantic that attributes in refinements

In introduction attributes are implicitly `autoinit`, in refinements they are `noautoinit`.

This is not POLA since

* this confuse beginners
* readers have to remember if they are in an intro or a refinement
* aditionnal cognitive fragility in constructors (more cases and rules to take in account)

This PR make `autoinit` the default and ask that attributes declared in refinement are either annotated `noautoinit` or have a default value.
This way, the writer has to think about the implication of adding a new attributes in existing classes, especially to think about their initialization. Thus this could help the programmer to avoid bad error.

For the moment, I just display a warning because I want to wait for feedback before doing a big migration (or doing nothing if people hate that), I also want to use jenkins to count and locate these new warnings.

Related to #1322