### PR TITLE
Clean nit compilation directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .project
 EIFGENs
 
-.nit_compile*
 .nitunit
 .nitpretty
 *.orig

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ man:
 	$(MAKE) -C share/man
 
 clean:
-	rm -rf -- .nit_compile 2> /dev/null || true
 	rm -rf -- doc/stdlib doc/nitc || true
 	cd c_src; make clean
 	cd src; make clean
@@ -78,5 +77,4 @@ clean:
 	cd share/man; make clean
 	for m in $(PROGS); do \
 		$(MAKE) clean -C "$$m"; \
-		test -d $$m/.nit_compile && rm -r $$m/.nit_compile; \
 		done || true

--- a/benchmarks/bench_engines.sh
+++ b/benchmarks/bench_engines.sh
@@ -81,7 +81,7 @@ function run_compiler()
 		bench_command "nitmd" "markdown" "./nitmd.$title.bin" markdown/benches/out/mixed.md 80
 	fi
 
-	rm -r *.bin .nit_compile out 2> /dev/null
+	rm -r *.bin out 2> /dev/null
 }
 
 ## HANDLE OPTIONS ##

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -16,7 +16,6 @@ bin/jwrapper:
 clean:
 	rm -f bin/javap_test_parser bin/jwrapper
 	rm -f gen/*
-	rm -rf .nit_compile/
 	rm src/javap_lexer.nit src/javap_parser.nit src/javap_test_parser.nit
 
 .PHONY: grammar bin/jwrapper

--- a/contrib/nitcc/src/Makefile
+++ b/contrib/nitcc/src/Makefile
@@ -38,7 +38,7 @@ tests:
 	cd ../tests && ./run
 
 clean:
-	rm -r .nit_compile \
+	rm -r \
 		*.dot *.out \
 		nitcc_lexer.nit nitcc_parser.nit nitcc_test_parser.nit nitcc_parser_gen \
 		nitcc0 nitcc1 \

--- a/contrib/nitiwiki/Makefile
+++ b/contrib/nitiwiki/Makefile
@@ -12,4 +12,3 @@ doc:
 
 clean:
 	rm -rf bin
-	rm -rf -- .nit_compile 2> /dev/null || true

--- a/contrib/online_ide/Makefile
+++ b/contrib/online_ide/Makefile
@@ -5,7 +5,6 @@ default:
 	../../bin/nitc --semi-global sources/nit/pnacl_nit.nit -I ../../src/
 	cp pnacl_nit/pnacl_nit.pexe www/pnacl/ -f
 	rm -rf pnacl_nit/
-	rm -rf .nit_compile
 
 build-www:
 	rm -rf www/src

--- a/contrib/pep8analysis/.gitignore
+++ b/contrib/pep8analysis/.gitignore
@@ -1,5 +1,3 @@
-.nit_compile/
-
 doc/
 bin/
 out/

--- a/contrib/refund/Makefile
+++ b/contrib/refund/Makefile
@@ -25,5 +25,4 @@ check: refund
 
 clean:
 	rm -rf bin
-	rm -rf -- .nit_compile 2> /dev/null || true
 	cd tests; make clean

--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -20,7 +20,7 @@ By default, the generated executables are produced in the current directory.
 
 Internally, nitc rely on the presence of a C compiler. Usually gcc (but nitc was successfully tested with clang).
 A compilation directory is therefore created and (re-)used.
-By default, the compilation directory is named `.nit_compile`.
+By default, the compilation directory is named `nit_compile` and is removed after the compilation.
 (see `--compile-dir` for details.)
 
 Currently, because Nit is still in heavy development, the compilation directory is not cleaned after the compilation.
@@ -168,7 +168,9 @@ See the documentation of these specific modules for details.
 `--compile-dir`
 :   Directory used to generate temporary files.
 
-    By default, it is named `.nit_compile`.
+    By default, it is named `nit_compile` and created in the current directory and destroyed after the compilation.
+
+    If the option `--compile_dir` or `--no-cc` is used, then the directory is not destroyed and let as is.
 
 `--no-cc`
 :   Do not invoke the C compiler.
@@ -183,6 +185,8 @@ See the documentation of these specific modules for details.
     Will produce a `hello` directory that contains the required C files to finish the compilation.
     Only the C files required for the program are generated.
     The final binary will be generated in the same directory.
+
+    Note that, to be useful, the compilation directory is not destroyed when `--no-cc` is used.
 
 `-m`
 :   Additional module to mix-in.

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,5 +53,5 @@ parser/parser.nit:
 	cd parser; make
 
 clean:
-	rm -rf -- .nit_compile* version.nit nitc_0 2> /dev/null || true
+	rm -rf -- version.nit nitc_0 2> /dev/null || true
 	cd parser; make clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,6 +35,7 @@ $(BINS): nitc_0 parser/parser.nit
 	@echo '***************************************************************'
 	./git-gen-version.sh
 	./nitc_0 ${NITCOPT} -v --dir ../bin $(SRCS)
+	rm -r .nit_compile || true # to clean old .nit_compile generated file
 
 $(OBJS): nitc_0 parser/parser.nit
 	./git-gen-version.sh
@@ -45,6 +46,7 @@ $(OBJS): nitc_0 parser/parser.nit
 	@echo '* Compile nitc from C source files                            *'
 	@echo '***************************************************************'
 	cd ../c_src; make
+	rm ../c_src/*.o || true # to reduce disc used
 
 parser/parser.nit:
 	@echo '***************************************************************'

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -169,6 +169,9 @@ class MakefileToolchain
 	do
 		var compile_dir = compile_dir
 
+		# Remove the compilation directory unless explicitly set
+		var auto_remove = toolcontext.opt_compile_dir.value == null
+
 		# Generate the .h and .c files
 		# A single C file regroups many compiled rumtime functions
 		# Note that we do not try to be clever an a small change in a Nit source file may change the content of all the generated .c files
@@ -196,6 +199,10 @@ class MakefileToolchain
 		self.toolcontext.info("*** COMPILING C ***", 1)
 
 		compile_c_code(compile_dir)
+
+		if auto_remove then
+			sys.system("rm -r -- '{root_compile_dir.escape_to_sh}/'")
+		end
 
 		time1 = get_time
 		self.toolcontext.info("*** END COMPILING C: {time1-time0} ***", 2)

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -115,15 +115,12 @@ redef class ToolContext
 end
 
 redef class ModelBuilder
-	# The compilation directory
-	var compile_dir: String
-
 	# Simple indirection to `Toolchain::write_and_make`
 	protected fun write_and_make(compiler: AbstractCompiler)
 	do
 		var platform = compiler.target_platform
 		var toolchain = platform.toolchain(toolcontext, compiler)
-		compile_dir = toolchain.compile_dir
+		compiler.toolchain = toolchain
 		toolchain.write_and_make
 	end
 end
@@ -496,6 +493,11 @@ abstract class AbstractCompiler
 	# The modelbuilder used to know the model and the AST
 	var modelbuilder: ModelBuilder is protected writable
 
+	# The associated toolchain
+	#
+	# Set by `modelbuilder.write_and_make` and permit sub-routines to access the current toolchain if required.
+	var toolchain: Toolchain is noinit
+
 	# Is hardening asked? (see --hardening)
 	fun hardening: Bool do return self.modelbuilder.toolcontext.opt_hardening.value
 
@@ -559,7 +561,7 @@ abstract class AbstractCompiler
 	# Binds the generated C function names to Nit function names
 	fun build_c_to_nit_bindings
 	do
-		var compile_dir = modelbuilder.compile_dir
+		var compile_dir = toolchain.compile_dir
 
 		var stream = new FileWriter.open("{compile_dir}/c_functions_hash.c")
 		stream.write("#include <string.h>\n")

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -142,13 +142,20 @@ class Toolchain
 	# Compiler of the target program
 	var compiler: AbstractCompiler
 
-	# Directory where to generate all C files
-	fun compile_dir: String
+	# Directory where to generate all files
+	#
+	# The option `--compile_dir` change this directory.
+	fun root_compile_dir: String
 	do
 		var compile_dir = toolcontext.opt_compile_dir.value
 		if compile_dir == null then compile_dir = "nit_compile"
 		return compile_dir
 	end
+
+	# Directory where to generate all C files
+	#
+	# By default it is `root_compile_dir` but some platform may require that it is a subdirectory.
+	fun compile_dir: String do return root_compile_dir
 
 	# Write all C files and compile them
 	fun write_and_make is abstract
@@ -168,6 +175,7 @@ class MakefileToolchain
 		var time0 = get_time
 		self.toolcontext.info("*** WRITING C ***", 1)
 
+		root_compile_dir.mkdir
 		compile_dir.mkdir
 
 		var cfiles = new Array[String]

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -149,7 +149,7 @@ class Toolchain
 	fun compile_dir: String
 	do
 		var compile_dir = toolcontext.opt_compile_dir.value
-		if compile_dir == null then compile_dir = ".nit_compile"
+		if compile_dir == null then compile_dir = "nit_compile"
 		return compile_dir
 	end
 
@@ -327,7 +327,7 @@ class MakefileToolchain
 		var outpath = real_outpath.escape_to_mk
 		if outpath != real_outpath then
 			# If the name is crazy and need escaping, we will do an indirection
-			# 1. generate the binary in the .nit_compile dir under an escaped name
+			# 1. generate the binary in the nit_compile dir under an escaped name
 			# 2. copy the binary at the right place in the `all` goal.
 			outpath = mainmodule.c_name
 		end

--- a/src/compiler/compiler_ffi/light.nit
+++ b/src/compiler/compiler_ffi/light.nit
@@ -37,7 +37,7 @@ redef class MModule
 		var n = nmodule(v)
 		if n == null then return
 		n.ensure_compile_ffi_wrapper
-		finalize_ffi_wrapper(v.compiler.modelbuilder.compile_dir, v.compiler.mainmodule)
+		finalize_ffi_wrapper(v.compiler.toolchain.compile_dir, v.compiler.mainmodule)
 		for file in ffi_files do v.compiler.extern_bodies.add(file)
 
 		ensure_compile_nitni_base(v)
@@ -49,7 +49,7 @@ extern void nitni_global_ref_decr(void*);
 """
 
 		var cflags = self.cflags[""].join(" ")
-		nitni_ccu.write_as_nitni(self, v.compiler.modelbuilder.compile_dir)
+		nitni_ccu.write_as_nitni(self, v.compiler.toolchain.compile_dir)
 
 		for file in nitni_ccu.files do
 			var f = new ExternCFile(file, cflags)

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -288,7 +288,7 @@ $(call import-module,android/native_app_glue)
 		# Android resources folder
 		var res_dir = project_root / "res"
 		if res_dir.file_exists then
-			# copy the res folder to .nit_compile
+			# copy the res folder to the compile dir
 			res_dir = res_dir.realpath
 			toolcontext.exec_and_check(["cp", "-R", res_dir, android_project_root], "Android project error")
 		end

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -52,7 +52,7 @@ class AndroidToolchain
 
 	redef fun compile_dir
 	do
-		var android_project_root = "{super}/android/"
+		var android_project_root = "{root_compile_dir}/android/"
 		self.android_project_root = android_project_root
 		return "{android_project_root}/jni/nit_compile/"
 	end
@@ -255,7 +255,7 @@ $(call import-module,android/native_app_glue)
 		end
 
 		toolcontext.exec_and_check(["ln", "-s", "{share_dir}/libgc/arm/include/gc/",
-			"{android_project_root}/jni/nit_compile/gc"], "Android project error")
+			"{compile_dir}/gc"], "Android project error")
 
 		### Link to assets (for mnit and others)
 		# This will be accessed from `android_project_root`

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -56,7 +56,7 @@ private class IOSToolchain
 	# Compile C files in `ios_project_root/app_project.name`
 	redef fun compile_dir
 	do
-		ios_project_root = super/"ios"
+		ios_project_root = root_compile_dir/"ios"
 		return ios_project_root/app_project.short_name
 	end
 

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -45,7 +45,7 @@ end
 private class IOSToolchain
 	super MakefileToolchain
 
-	# Root of the iOS project, usually `.nit_compile/ios/`
+	# Root of the iOS project, usually `nit_compile/ios/`
 	var ios_project_root: String is noinit
 
 	# `app.nit` project for the current compilation target

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,4 +46,4 @@ store:
 	./store_save.sh *.nit
 
 clean:
-	rm -r -f -- out/ alt .nit_compile errlist errlist.bak *.xml 2> /dev/null || true
+	rm -r -f -- out/ alt nit_compile errlist errlist.bak *.xml 2> /dev/null || true

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -35,7 +35,7 @@ JNI_LIB_PATH=`dirname ${paths[0]}`
 shopt -u nullglob
 
 outdir="out"
-compdir=".nit_compile"
+compdir="nit_compile"
 
 usage()
 {
@@ -48,7 +48,7 @@ Usage: $e [options] modulenames
 --engine    Use a specific engine (default=nitc)
 --noskip    Do not skip a test even if the .skip file matches
 --outdir    Use a specific output folder (default=out/)
---compdir   Use a specific temporary compilation folder (default=.nit_compile)
+--compdir   Use a specific temporary compilation folder (default=$compdir)
 --node      Run as a node in parallel, will not output context information
 --autosav   Copy the .res files directly in the sav folder overriding existing .res files
 END
@@ -564,6 +564,8 @@ END
 				cat -- "$ff.compile.log"
 				cat >&2 -- "$ff.cmp.err"
 			fi
+			# Clean
+			rm -r "$compdir" 2>/dev/null
 		fi
 		if [ "$engine" = "emscripten" ]; then
 			echo > "$ff.bin" "nodejs $ffout \"\$@\""


### PR DESCRIPTION
This PR cause the compilation directory to be removed after compilation.

This auto-removal is disabled if `--compile-dir` or `--no-cc` is used because it is a sane default I think.
Moreover, the compilation directory is renamed by defaut to `nit_compile` because there is no more point to make it hidden since its presence means an active request (`--no-cc`).

The PR is a bit premature since the boostrap will fail since `rmdir` requires the light FFI, so it is planned to be merged after the regen of c_src.

Close #792