### PR TITLE
nitdoc: refactoring and cleaning

### DIFF
--- a/share/nitdoc/css/nitdoc.css
+++ b/share/nitdoc/css/nitdoc.css
@@ -81,9 +81,6 @@ article.nospace {
 	color: #666;
 }
 
-#sidebar .panel-body ul .list-labeled>li {
-}
-
 #sidebar .panel-body ul ul ul>li {
 	font-size: 13px;
 	color: #999;

--- a/src/doc/console_templates/console_templates.nit
+++ b/src/doc/console_templates/console_templates.nit
@@ -81,11 +81,6 @@ redef class ConcernSection
 	end
 end
 
-redef class ConstructorsSection
-	redef var cs_title = "Constructors"
-	redef var cs_subtitle = null
-end
-
 redef class MEntityComposite
 	redef var cs_title is lazy do return mentity.cs_name
 	redef var cs_subtitle is lazy do return mentity.cs_namespace

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -91,6 +91,16 @@ abstract class DocComposite
 	# Parent element.
 	var parent: nullable DocComposite = null is writable
 
+	# Element uniq id.
+	#
+	# The `id` is used as name for the generated element (if any).
+	# Because multiple elements can be generated in the same container
+	# it should be uniq.
+	#
+	# The `id` can also be used to establish links between elements
+	# (HTML links, HTML anchors, vim links, etc.).
+	var id: String is writable
+
 	# Does `self` have a `parent`?
 	fun is_root: Bool do return parent == null
 
@@ -122,8 +132,10 @@ end
 # The root uses a specific subclass to provide different a different behavior
 # than other `DocComposite` elements.
 class DocRoot
+	noautoinit
 	super DocComposite
 
+	redef var id = "<root>"
 	# No op for `RootSection`.
 	redef fun parent=(p) do end
 end

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -101,6 +101,9 @@ abstract class DocComposite
 	# (HTML links, HTML anchors, vim links, etc.).
 	var id: String is writable
 
+	# Item title if any.
+	var title: nullable String
+
 	# Does `self` have a `parent`?
 	fun is_root: Bool do return parent == null
 
@@ -136,6 +139,8 @@ class DocRoot
 	super DocComposite
 
 	redef var id = "<root>"
+	redef var title = "<root>"
+
 	# No op for `RootSection`.
 	redef fun parent=(p) do end
 end

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -124,6 +124,9 @@ abstract class DocComposite
 	# Does `self` have `children`?
 	fun is_empty: Bool do return children.is_empty
 
+	# Title used in table of content if any.
+	var toc_title: nullable String is writable, lazy do return title
+
 	# Add a `child` to `self`.
 	#
 	# Shortcut for `children.add`.

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -75,6 +75,15 @@ class DocPage
 	var root = new DocRoot
 
 	redef fun to_s do return title
+
+	# Pretty prints the content of this page.
+	fun pretty_print: Writable do
+		var res = new Template
+		res.addn "page: {title}"
+		res.addn ""
+		root.pretty_print_in(res)
+		return res
+	end
 end
 
 # `DocPage` elements that can be nested in another.
@@ -127,6 +136,20 @@ abstract class DocComposite
 	fun depth: Int do
 		if parent == null then return 0
 		return parent.depth + 1
+	end
+
+	# Pretty prints this composite recursively.
+	fun pretty_print: Writable do
+		var res = new Template
+		pretty_print_in(res)
+		return res
+	end
+
+	# Appends the Pretty print of this composite in `res`.
+	private fun pretty_print_in(res: Template) do
+		res.add "#" * depth
+		res.addn " {id}"
+		for child in children do child.pretty_print_in(res)
 	end
 end
 

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -121,8 +121,10 @@ abstract class DocComposite
 	# Children are ordered, this order can be changed by the `DocPhase`.
 	var children = new Array[DocComposite]
 
-	# Does `self` have `children`?
-	fun is_empty: Bool do return children.is_empty
+	# Is `self` not displayed in the page.
+	#
+	# By default, empty elements are hidden.
+	fun is_hidden: Bool do return children.is_empty
 
 	# Title used in table of content if any.
 	var toc_title: nullable String is writable, lazy do return title

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -129,6 +129,11 @@ abstract class DocComposite
 	# Title used in table of content if any.
 	var toc_title: nullable String is writable, lazy do return title
 
+	# Is `self` hidden in the table of content?
+	var is_toc_hidden: Bool is writable, lazy do
+		return toc_title == null or is_hidden
+	end
+
 	# Add a `child` to `self`.
 	#
 	# Shortcut for `children.add`.

--- a/src/doc/doc_phases/doc_console.nit
+++ b/src/doc/doc_phases/doc_console.nit
@@ -140,7 +140,7 @@ interface NitxQuery
 	# Pretty prints the results for the console.
 	fun make_results(nitx: Nitx, results: Array[NitxMatch]): DocPage do
 		var page = new DocPage("results", "Results")
-		page.root.add_child(new QueryResultArticle("results.article", self, results))
+		page.root.add_child(new QueryResultArticle("results.article", "Results", self, results))
 		return page
 	end
 
@@ -216,7 +216,7 @@ class CommentQuery
 			var res = results.first.as(MEntityMatch)
 			var mentity = res.mentity
 			var page = new DocPage("results", "Results")
-			var article = new DefinitionArticle("results.article", mentity)
+			var article = new DefinitionArticle("results.article", "Results", mentity)
 			article.cs_title = mentity.name
 			article.cs_subtitle = mentity.cs_declaration
 			page.root.add_child article
@@ -389,7 +389,7 @@ class CodeQuery
 	redef fun make_results(nitx, results) do
 		var page = new DocPage("results", "Code Results")
 		for res in results do
-			page.add new CodeQueryArticle("results.article", self, res.as(CodeMatch))
+			page.add new CodeQueryArticle("results.article", "Results", self, res.as(CodeMatch))
 		end
 		return page
 	end

--- a/src/doc/doc_phases/doc_console.nit
+++ b/src/doc/doc_phases/doc_console.nit
@@ -140,7 +140,7 @@ interface NitxQuery
 	# Pretty prints the results for the console.
 	fun make_results(nitx: Nitx, results: Array[NitxMatch]): DocPage do
 		var page = new DocPage("results", "Results")
-		page.root.add_child(new QueryResultArticle(self, results))
+		page.root.add_child(new QueryResultArticle("results.article", self, results))
 		return page
 	end
 
@@ -215,8 +215,8 @@ class CommentQuery
 		if len == 1 then
 			var res = results.first.as(MEntityMatch)
 			var mentity = res.mentity
-			var page = new DocPage("resultats", "Results")
-			var article = new DefinitionArticle(mentity)
+			var page = new DocPage("results", "Results")
+			var article = new DefinitionArticle("results.article", mentity)
 			article.cs_title = mentity.name
 			article.cs_subtitle = mentity.cs_declaration
 			page.root.add_child article
@@ -389,7 +389,7 @@ class CodeQuery
 	redef fun make_results(nitx, results) do
 		var page = new DocPage("results", "Code Results")
 		for res in results do
-			page.add new CodeQueryArticle(self, res.as(CodeMatch))
+			page.add new CodeQueryArticle("results.article", self, res.as(CodeMatch))
 		end
 		return page
 	end

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -124,5 +124,5 @@ class GraphArticle
 	# Dot script of the graph.
 	var dot: Text
 
-	redef var is_empty = false
+	redef var is_hidden = false
 end

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -73,7 +73,7 @@ redef class MModulePage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle("{mentity.nitdoc_id}.graph", mentity, name, "Importation Graph", op)
+		return new GraphArticle("{mentity.nitdoc_id}.graph", "Importation Graph", name, op)
 	end
 end
 
@@ -107,7 +107,7 @@ redef class MClassPage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle("{mentity.nitdoc_id}.graph", mentity, name, "Inheritance Graph", op)
+		return new GraphArticle("{mentity.nitdoc_id}.graph", "Inheritance Graph", name, op)
 	end
 end
 
@@ -116,13 +116,10 @@ end
 # The graph is stored in dot format.
 # The final output is delayed untill rendering.
 class GraphArticle
-	super MEntityComposite
+	super DocArticle
 
 	# Graph ID (used for outputing file with names).
 	var graph_id: String
-
-	# Graph title to display.
-	var graph_title: String
 
 	# Dot script of the graph.
 	var dot: Text

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -73,7 +73,7 @@ redef class MModulePage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle(mentity, name, "Importation Graph", op)
+		return new GraphArticle("article:{mentity.nitdoc_id}.graph", mentity, name, "Importation Graph", op)
 	end
 end
 
@@ -107,7 +107,7 @@ redef class MClassPage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle(mentity, name, "Inheritance Graph", op)
+		return new GraphArticle("article:{mentity.nitdoc_id}.graph", mentity, name, "Inheritance Graph", op)
 	end
 end
 
@@ -119,7 +119,7 @@ class GraphArticle
 	super MEntityComposite
 
 	# Graph ID (used for outputing file with names).
-	var id: String
+	var graph_id: String
 
 	# Graph title to display.
 	var graph_title: String

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -125,4 +125,5 @@ class GraphArticle
 	var dot: Text
 
 	redef var is_hidden = false
+	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -73,7 +73,7 @@ redef class MModulePage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle("article:{mentity.nitdoc_id}.graph", mentity, name, "Importation Graph", op)
+		return new GraphArticle("{mentity.nitdoc_id}.graph", mentity, name, "Importation Graph", op)
 	end
 end
 
@@ -107,7 +107,7 @@ redef class MClassPage
 			end
 		end
 		op.append("\}\n")
-		return new GraphArticle("article:{mentity.nitdoc_id}.graph", mentity, name, "Inheritance Graph", op)
+		return new GraphArticle("{mentity.nitdoc_id}.graph", mentity, name, "Inheritance Graph", op)
 	end
 end
 

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -45,10 +45,10 @@ redef class MModulePage
 		var group = new PanelGroup("list.group", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
-		group.add_child new HierarchyListArticle("{id}.imports", "Imports", imports)
+		group.add_child new MEntitiesListArticle("{id}.imports", "Imports", imports)
 		var clients = self.clients.to_a
 		v.name_sorter.sort(clients)
-		group.add_child new HierarchyListArticle("{id}.clients", "Clients", clients)
+		group.add_child new MEntitiesListArticle("{id}.clients", "Clients", clients)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -62,16 +62,16 @@ redef class MClassPage
 		var group = new PanelGroup("list.group", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
-		group.add_child new HierarchyListArticle("{id}.parents", "Parents", parents)
+		group.add_child new MEntitiesListArticle("{id}.parents", "Parents", parents)
 		var ancestors = self.ancestors.to_a
 		v.name_sorter.sort(ancestors)
-		group.add_child new HierarchyListArticle("{id}.ancestors", "Ancestors", ancestors)
+		group.add_child new MEntitiesListArticle("{id}.ancestors", "Ancestors", ancestors)
 		var children = self.children.to_a
 		v.name_sorter.sort(children)
-		group.add_child new HierarchyListArticle("{id}.children", "Children", children)
+		group.add_child new MEntitiesListArticle("{id}.children", "Children", children)
 		var descendants = self.descendants.to_a
 		v.name_sorter.sort(descendants)
-		group.add_child new HierarchyListArticle("{id}.descendants", "Descendants", descendants)
+		group.add_child new MEntitiesListArticle("{id}.descendants", "Descendants", descendants)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -88,14 +88,4 @@ end
 class InheritanceListSection
 	super TabbedGroup
 	super MEntityComposite
-end
-
-# Dislay a hierarchical list of mentities.
-class HierarchyListArticle
-	super DocArticle
-
-	# MEntities to display in this list.
-	var mentities: Array[MEntity]
-
-	redef fun is_hidden do return mentities.is_empty
 end

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -58,7 +58,7 @@ end
 redef class MClassPage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new InheritanceListSection("{id}.inheritance", mentity)
+		var section = new TabbedGroup("{id}.inheritance", "Inheritance")
 		var group = new PanelGroup("list.group", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
@@ -80,12 +80,6 @@ end
 
 # FIXME diff hack
 class ImportationListSection
-	super TabbedGroup
-	super MEntityComposite
-end
-
-# FIXME diff hack
-class InheritanceListSection
 	super TabbedGroup
 	super MEntityComposite
 end

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -45,10 +45,10 @@ redef class MModulePage
 		var group = new PanelGroup("list.group", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
-		group.add_child new HierarchyListArticle("{id}.imports", mentity, "Imports", imports)
+		group.add_child new HierarchyListArticle("{id}.imports", "Imports", imports)
 		var clients = self.clients.to_a
 		v.name_sorter.sort(clients)
-		group.add_child new HierarchyListArticle("{id}.clients", mentity, "Clients", clients)
+		group.add_child new HierarchyListArticle("{id}.clients", "Clients", clients)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -62,16 +62,16 @@ redef class MClassPage
 		var group = new PanelGroup("list.group", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
-		group.add_child new HierarchyListArticle("{id}.parents", mentity, "Parents", parents)
+		group.add_child new HierarchyListArticle("{id}.parents", "Parents", parents)
 		var ancestors = self.ancestors.to_a
 		v.name_sorter.sort(ancestors)
-		group.add_child new HierarchyListArticle("{id}.ancestors", mentity, "Ancestors", ancestors)
+		group.add_child new HierarchyListArticle("{id}.ancestors", "Ancestors", ancestors)
 		var children = self.children.to_a
 		v.name_sorter.sort(children)
-		group.add_child new HierarchyListArticle("{id}.children", mentity, "Children", children)
+		group.add_child new HierarchyListArticle("{id}.children", "Children", children)
 		var descendants = self.descendants.to_a
 		v.name_sorter.sort(descendants)
-		group.add_child new HierarchyListArticle("{id}.descendants", mentity, "Descendants", descendants)
+		group.add_child new HierarchyListArticle("{id}.descendants", "Descendants", descendants)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -92,10 +92,7 @@ end
 
 # Dislay a hierarchical list of mentities.
 class HierarchyListArticle
-	super MEntityArticle
-
-	# Title displayed in the top of this list.
-	var list_title: String
+	super DocArticle
 
 	# MEntities to display in this list.
 	var mentities: Array[MEntity]

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -41,7 +41,7 @@ end
 redef class MModulePage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new ImportationListSection("section:{id}.importation", mentity)
+		var section = new ImportationListSection("{id}.importation", mentity)
 		var group = new PanelGroup("group:list", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
@@ -58,7 +58,7 @@ end
 redef class MClassPage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new InheritanceListSection("section:{id}.inheritance", mentity)
+		var section = new InheritanceListSection("{id}.inheritance", mentity)
 		var group = new PanelGroup("group:list", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -40,14 +40,15 @@ end
 
 redef class MModulePage
 	redef fun build_inh_list(v, doc) do
-		var section = new ImportationListSection(mentity)
-		var group = new PanelGroup("List")
+		var id = mentity.nitdoc_id
+		var section = new ImportationListSection("section:{id}.importation", mentity)
+		var group = new PanelGroup("group:list", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
-		group.add_child new HierarchyListArticle(mentity, "Imports", imports)
+		group.add_child new HierarchyListArticle("article:Imports_{id}.hierarchy", mentity, "Imports", imports)
 		var clients = self.clients.to_a
 		v.name_sorter.sort(clients)
-		group.add_child new HierarchyListArticle(mentity, "Clients", clients)
+		group.add_child new HierarchyListArticle("article:Clients_{id}.hierarchy", mentity, "Clients", clients)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -56,20 +57,21 @@ end
 
 redef class MClassPage
 	redef fun build_inh_list(v, doc) do
-		var section = new InheritanceListSection(mentity)
-		var group = new PanelGroup("List")
+		var id = mentity.nitdoc_id
+		var section = new InheritanceListSection("section:{id}.inheritance", mentity)
+		var group = new PanelGroup("group:list", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
-		group.add_child new HierarchyListArticle(mentity, "Parents", parents)
+		group.add_child new HierarchyListArticle("article:Parents_{id}.hierarchy", mentity, "Parents", parents)
 		var ancestors = self.ancestors.to_a
 		v.name_sorter.sort(ancestors)
-		group.add_child new HierarchyListArticle(mentity, "Ancestors", ancestors)
+		group.add_child new HierarchyListArticle("article:Ancestors_{id}.hierarchy", mentity, "Ancestors", ancestors)
 		var children = self.children.to_a
 		v.name_sorter.sort(children)
-		group.add_child new HierarchyListArticle(mentity, "Children", children)
+		group.add_child new HierarchyListArticle("article:Children_{id}.hierarchy", mentity, "Children", children)
 		var descendants = self.descendants.to_a
 		v.name_sorter.sort(descendants)
-		group.add_child new HierarchyListArticle(mentity, "Descendants", descendants)
+		group.add_child new HierarchyListArticle("article:Descendants_{id}.hierarchy", mentity, "Descendants", descendants)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -42,7 +42,7 @@ redef class MModulePage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
 		var section = new ImportationListSection("{id}.importation", mentity)
-		var group = new PanelGroup("group:list", "List")
+		var group = new PanelGroup("list.group", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
 		group.add_child new HierarchyListArticle("{id}.imports", mentity, "Imports", imports)
@@ -59,7 +59,7 @@ redef class MClassPage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
 		var section = new InheritanceListSection("{id}.inheritance", mentity)
-		var group = new PanelGroup("group:list", "List")
+		var group = new PanelGroup("list.group", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
 		group.add_child new HierarchyListArticle("{id}.parents", mentity, "Parents", parents)

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -96,4 +96,6 @@ class HierarchyListArticle
 
 	# MEntities to display in this list.
 	var mentities: Array[MEntity]
+
+	redef fun is_hidden do return mentities.is_empty
 end

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -41,7 +41,7 @@ end
 redef class MModulePage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new ImportationListSection("{id}.importation", mentity)
+		var section = new TabbedGroup("{id}.importation", "Dependencies")
 		var group = new PanelGroup("list.group", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
@@ -76,10 +76,4 @@ redef class MClassPage
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
 	end
-end
-
-# FIXME diff hack
-class ImportationListSection
-	super TabbedGroup
-	super MEntityComposite
 end

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -45,10 +45,10 @@ redef class MModulePage
 		var group = new PanelGroup("group:list", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
-		group.add_child new HierarchyListArticle("article:Imports_{id}.hierarchy", mentity, "Imports", imports)
+		group.add_child new HierarchyListArticle("{id}.imports", mentity, "Imports", imports)
 		var clients = self.clients.to_a
 		v.name_sorter.sort(clients)
-		group.add_child new HierarchyListArticle("article:Clients_{id}.hierarchy", mentity, "Clients", clients)
+		group.add_child new HierarchyListArticle("{id}.clients", mentity, "Clients", clients)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)
@@ -62,16 +62,16 @@ redef class MClassPage
 		var group = new PanelGroup("group:list", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
-		group.add_child new HierarchyListArticle("article:Parents_{id}.hierarchy", mentity, "Parents", parents)
+		group.add_child new HierarchyListArticle("{id}.parents", mentity, "Parents", parents)
 		var ancestors = self.ancestors.to_a
 		v.name_sorter.sort(ancestors)
-		group.add_child new HierarchyListArticle("article:Ancestors_{id}.hierarchy", mentity, "Ancestors", ancestors)
+		group.add_child new HierarchyListArticle("{id}.ancestors", mentity, "Ancestors", ancestors)
 		var children = self.children.to_a
 		v.name_sorter.sort(children)
-		group.add_child new HierarchyListArticle("article:Children_{id}.hierarchy", mentity, "Children", children)
+		group.add_child new HierarchyListArticle("{id}.children", mentity, "Children", children)
 		var descendants = self.descendants.to_a
 		v.name_sorter.sort(descendants)
-		group.add_child new HierarchyListArticle("article:Descendants_{id}.hierarchy", mentity, "Descendants", descendants)
+		group.add_child new HierarchyListArticle("{id}.descendants", mentity, "Descendants", descendants)
 		section.add_child group
 		section.parent = root.children.first
 		root.children.first.children.insert(section, 1)

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -586,7 +586,7 @@ end
 redef class GraphArticle
 	redef fun init_html_render(v, doc, page) do
 		var output_dir = v.ctx.output_dir
-		var path = output_dir / id
+		var path = output_dir / graph_id
 		var path_sh = path.escape_to_sh
 		var file = new FileWriter.open("{path}.dot")
 		file.write(dot)

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -471,7 +471,7 @@ redef class MEntitySection
 			title.add mentity.html_signature
 			html_title = title
 			html_subtitle = mentity.html_namespace
-			toc_title = mentity.html_name
+			html_toc_title = mentity.html_name
 		end
 		super
 	end
@@ -484,16 +484,16 @@ redef class ConcernSection
 		var mentity = self.mentity
 		if page isa MGroupPage then
 			html_title = null
-			toc_title = mentity.html_name
+			html_toc_title = mentity.html_name
 			is_toc_hidden = false
 		else if page.mentity isa MModule and mentity isa MModule then
 			var title = new Template
 			if mentity == page.mentity then
 				title.add "in "
-				toc_title = "in {mentity.html_name}"
+				html_toc_title = "in {mentity.html_name}"
 			else
 				title.add "from "
-				toc_title = "from {mentity.html_name}"
+				html_toc_title = "from {mentity.html_name}"
 			end
 			title.add mentity.html_namespace
 			html_title = title
@@ -503,7 +503,7 @@ redef class ConcernSection
 			title.add "in "
 			title.add mentity.html_namespace
 			html_title = title
-			toc_title = "in {mentity.html_name}"
+			html_toc_title = "in {mentity.html_name}"
 		end
 		super
 	end
@@ -532,7 +532,7 @@ redef class DefinitionArticle
 			title.add mentity.html_icon
 			title.add mentity.html_namespace
 			html_title = title
-			toc_title = mentity.html_name
+			html_toc_title = mentity.html_name
 			if mentity isa MModule then
 				html_source_link = v.html_source_link(mentity.location)
 			end
@@ -542,7 +542,7 @@ redef class DefinitionArticle
 			title.add mentity.mmodule.html_namespace
 			html_title = mentity.html_declaration
 			html_subtitle = title
-			toc_title = "in {mentity.html_name}"
+			html_toc_title = "in {mentity.html_name}"
 			html_source_link = v.html_source_link(mentity.location)
 			if page isa MEntityPage and mentity.is_intro and mentity.mmodule != page.mentity then
 				is_short_comment = true
@@ -555,13 +555,13 @@ redef class DefinitionArticle
 				title.add mentity.html_declaration
 				html_title = title
 				html_subtitle = mentity.html_namespace
-				toc_title = mentity.html_name
+				html_toc_title = mentity.html_name
 			else
 				var title = new Template
 				title.add "in "
 				title.add mentity.mclassdef.html_link
 				html_title = title
-				toc_title = "in {mentity.mclassdef.html_name}"
+				html_toc_title = "in {mentity.mclassdef.html_name}"
 			end
 			html_source_link = v.html_source_link(mentity.location)
 		end
@@ -576,7 +576,7 @@ redef class HomeArticle
 	redef fun init_html_render(v, doc, page) do
 		if v.ctx.opt_custom_title.value != null then
 			self.html_title = v.ctx.opt_custom_title.value.to_s
-			self.toc_title = v.ctx.opt_custom_title.value.to_s
+			self.html_toc_title = v.ctx.opt_custom_title.value.to_s
 		end
 		self.content = v.ctx.opt_custom_intro.value
 		super

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -372,7 +372,7 @@ redef class MClassPage
 		if not mprop_is_local(mprop) then
 			classes.add "inherit"
 			var cls_url = mprop.intro.mclassdef.mclass.nitdoc_url
-			var def_url = "{cls_url}#article:{mprop.nitdoc_id}.definition"
+			var def_url = "{cls_url}#{mprop.nitdoc_id}.definition"
 			var lnk = new Link(def_url, mprop.html_name)
 			var mdoc = mprop.intro.mdoc_or_fallback
 			if mdoc != null then lnk.title = mdoc.short_comment
@@ -388,7 +388,7 @@ redef class MClassPage
 		end
 		var def = select_mpropdef(mprop)
 		var anc = def.html_link_to_anchor
-		anc.href = "#article:{def.nitdoc_id}.definition"
+		anc.href = "#{def.nitdoc_id}.definition"
 		var lnk = new Template
 		lnk.add new DocHTMLLabel.with_classes(classes)
 		lnk.add anc

--- a/src/doc/doc_phases/doc_indexing.nit
+++ b/src/doc/doc_phases/doc_indexing.nit
@@ -43,7 +43,7 @@ class IndexingPhase
 				if not doc.mpropdefs.has(mpropdef) then continue
 				var full_name = mpropdef.mclassdef.mclass.full_name
 				var cls_url = mpropdef.mclassdef.mclass.nitdoc_url
-				var def_url = "{cls_url}#article:{mpropdef.nitdoc_id}.definition"
+				var def_url = "{cls_url}#{mpropdef.nitdoc_id}.definition"
 				add_result_for(mproperty.name, full_name, def_url)
 			end
 		end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -55,7 +55,7 @@ redef class DefinitionArticle
 	# TODO this should move to MEntity?
 	private fun build_mmodule_list(v: IntroRedefListPhase, doc: DocModel, mmodule: MModule) do
 		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
-		var group = new PanelGroup("group:list", "List")
+		var group = new PanelGroup("list.group", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
 		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", mentity, "Introduces", intros)
@@ -69,7 +69,7 @@ redef class DefinitionArticle
 	# TODO this should move to MEntity?
 	private fun build_mclassdef_list(v: IntroRedefListPhase, doc: DocModel, mclassdef: MClassDef) do
 		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
-		var group = new PanelGroup("group:list", "List")
+		var group = new PanelGroup("list.group", "List")
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -99,4 +99,6 @@ class IntrosRedefsListArticle
 
 	# Intro mentities to list.
 	var mentities: Array[MEntity]
+
+	redef fun is_hidden do return mentities.is_empty
 end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -54,30 +54,30 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mmodule_list(v: IntroRedefListPhase, doc: DocModel, mmodule: MModule) do
-		var section = new IntrosRedefsSection(mentity)
-		var group = new PanelGroup("List")
+		var section = new IntrosRedefsSection("article:{mentity.nitdoc_id}.intros_redefs", mentity)
+		var group = new PanelGroup("group:list", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
-		group.add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("article:Introduces_{mentity.nitdoc_id}.intros_redefs", mentity, "Introduces", intros)
 		var redefs = mmodule.redef_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(redefs)
-		group.add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("article:Redefines_{mentity.nitdoc_id}.intros_redefs", mentity, "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
 
 	# TODO this should move to MEntity?
 	private fun build_mclassdef_list(v: IntroRedefListPhase, doc: DocModel, mclassdef: MClassDef) do
-		var section = new IntrosRedefsSection(mentity)
-		var group = new PanelGroup("List")
+		var section = new IntrosRedefsSection("article:{mentity.nitdoc_id}.intros_redefs", mentity)
+		var group = new PanelGroup("group:list", "List")
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)
-		group.add_child new IntrosRedefsListArticle(mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("article:Introduces_{mentity.nitdoc_id}.intros_redefs", mentity, "Introduces", intros)
 		var redefs = mclassdef.collect_redef_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(redefs)
-		group.add_child new IntrosRedefsListArticle(mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("article:Redefines_{mentity.nitdoc_id}.intros_redefs", mentity, "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -88,6 +88,8 @@ end
 class IntrosRedefsSection
 	super TabbedGroup
 	super MEntitySection
+
+	redef var is_toc_hidden = true
 end
 
 # An article that displays a list of introduced / refined mentities.
@@ -101,4 +103,5 @@ class IntrosRedefsListArticle
 	var mentities: Array[MEntity]
 
 	redef fun is_hidden do return mentities.is_empty
+	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -54,7 +54,7 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mmodule_list(v: IntroRedefListPhase, doc: DocModel, mmodule: MModule) do
-		var section = new IntrosRedefsSection("article:{mentity.nitdoc_id}.intros_redefs", mentity)
+		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
 		var group = new PanelGroup("group:list", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
@@ -68,7 +68,7 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mclassdef_list(v: IntroRedefListPhase, doc: DocModel, mclassdef: MClassDef) do
-		var section = new IntrosRedefsSection("article:{mentity.nitdoc_id}.intros_redefs", mentity)
+		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
 		var group = new PanelGroup("group:list", "List")
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -54,7 +54,8 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mmodule_list(v: IntroRedefListPhase, doc: DocModel, mmodule: MModule) do
-		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
+		var section = new TabbedGroup("{mentity.nitdoc_id}.intros_redefs")
+		section.toc_title = "Intros / Redefs"
 		var group = new PanelGroup("list.group", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
@@ -68,7 +69,8 @@ redef class DefinitionArticle
 
 	# TODO this should move to MEntity?
 	private fun build_mclassdef_list(v: IntroRedefListPhase, doc: DocModel, mclassdef: MClassDef) do
-		var section = new IntrosRedefsSection("{mentity.nitdoc_id}.intros_redefs", mentity)
+		var section = new TabbedGroup("{mentity.nitdoc_id}.intros_redefs")
+		section.toc_title = "Intros / Redefs"
 		var group = new PanelGroup("list.group", "List")
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
@@ -81,13 +83,4 @@ redef class DefinitionArticle
 		section.add_child group
 		add_child(section)
 	end
-
-end
-
-# Section that contains the intros and redefs lists.
-class IntrosRedefsSection
-	super TabbedGroup
-	super MEntitySection
-
-	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -58,10 +58,10 @@ redef class DefinitionArticle
 		var group = new PanelGroup("list.group", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
 		var redefs = mmodule.redef_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
@@ -73,11 +73,11 @@ redef class DefinitionArticle
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
 		var redefs = mclassdef.collect_redef_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
@@ -95,10 +95,7 @@ end
 # FIXME diff hack
 # This can merged with InheritanceListArticle in a more generic class.
 class IntrosRedefsListArticle
-	super MEntityArticle
-
-	# Title displayed as header of the list.
-	var list_title: String
+	super DocArticle
 
 	# Intro mentities to list.
 	var mentities: Array[MEntity]

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -58,10 +58,10 @@ redef class DefinitionArticle
 		var group = new PanelGroup("list.group", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
+		group.add_child new MEntitiesListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
 		var redefs = mmodule.redef_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
+		group.add_child new MEntitiesListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
@@ -73,11 +73,11 @@ redef class DefinitionArticle
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
+		group.add_child new MEntitiesListArticle("{mentity.nitdoc_id}.intros", "Introduces", intros)
 		var redefs = mclassdef.collect_redef_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
+		group.add_child new MEntitiesListArticle("{mentity.nitdoc_id}.redefs", "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
@@ -89,19 +89,5 @@ class IntrosRedefsSection
 	super TabbedGroup
 	super MEntitySection
 
-	redef var is_toc_hidden = true
-end
-
-# An article that displays a list of introduced / refined mentities.
-#
-# FIXME diff hack
-# This can merged with InheritanceListArticle in a more generic class.
-class IntrosRedefsListArticle
-	super DocArticle
-
-	# Intro mentities to list.
-	var mentities: Array[MEntity]
-
-	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_intros_redefs.nit
+++ b/src/doc/doc_phases/doc_intros_redefs.nit
@@ -58,10 +58,10 @@ redef class DefinitionArticle
 		var group = new PanelGroup("group:list", "List")
 		var intros = mmodule.intro_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(intros)
-		group.add_child new IntrosRedefsListArticle("article:Introduces_{mentity.nitdoc_id}.intros_redefs", mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", mentity, "Introduces", intros)
 		var redefs = mmodule.redef_mclassdefs(v.ctx.min_visibility).to_a
 		doc.mainmodule.linearize_mclassdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("article:Redefines_{mentity.nitdoc_id}.intros_redefs", mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", mentity, "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end
@@ -73,11 +73,11 @@ redef class DefinitionArticle
 		var intros = mclassdef.collect_intro_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(intros)
-		group.add_child new IntrosRedefsListArticle("article:Introduces_{mentity.nitdoc_id}.intros_redefs", mentity, "Introduces", intros)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.intros", mentity, "Introduces", intros)
 		var redefs = mclassdef.collect_redef_mpropdefs(v.ctx.min_visibility).to_a
 		# FIXME avoid diff changes
 		# v.ctx.mainmodule.linearize_mpropdefs(redefs)
-		group.add_child new IntrosRedefsListArticle("article:Redefines_{mentity.nitdoc_id}.intros_redefs", mentity, "Redefines", redefs)
+		group.add_child new IntrosRedefsListArticle("{mentity.nitdoc_id}.redefs", mentity, "Redefines", redefs)
 		section.add_child group
 		add_child(section)
 	end

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -99,4 +99,5 @@ class DefinitionLinArticle
 	var mentities: Array[MEntity]
 
 	redef var toc_title = "Linearization"
+	redef fun is_hidden do return mentities.is_empty
 end

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -97,4 +97,6 @@ class DefinitionLinArticle
 
 	# The linearized list to display.
 	var mentities: Array[MEntity]
+
+	redef var toc_title = "Linearization"
 end

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -73,7 +73,7 @@ redef class DefinitionArticle
 		var lin = all_defs.to_a
 		doc.mainmodule.linearize_mpropdefs(lin)
 		if lin.length > 1 then
-			add_child new DefinitionLinArticle("{mentity.nitdoc_id}.lin", mentity, lin)
+			add_child new DefinitionLinArticle("{mentity.nitdoc_id}.lin", "Linearization", lin)
 		end
 	end
 
@@ -93,12 +93,11 @@ end
 
 # Display a linearized list of definitions.
 class DefinitionLinArticle
-	super MEntityArticle
+	super DocArticle
 
 	# The linearized list to display.
 	var mentities: Array[MEntity]
 
-	redef var toc_title = "Linearization"
 	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -73,7 +73,7 @@ redef class DefinitionArticle
 		var lin = all_defs.to_a
 		doc.mainmodule.linearize_mpropdefs(lin)
 		if lin.length > 1 then
-			add_child new DefinitionLinArticle("article:{mentity.nitdoc_id}.lin", mentity, lin)
+			add_child new DefinitionLinArticle("{mentity.nitdoc_id}.lin", mentity, lin)
 		end
 	end
 

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -73,7 +73,7 @@ redef class DefinitionArticle
 		var lin = all_defs.to_a
 		doc.mainmodule.linearize_mpropdefs(lin)
 		if lin.length > 1 then
-			add_child new DefinitionLinArticle(mentity, lin)
+			add_child new DefinitionLinArticle("article:{mentity.nitdoc_id}.lin", mentity, lin)
 		end
 	end
 

--- a/src/doc/doc_phases/doc_lin.nit
+++ b/src/doc/doc_phases/doc_lin.nit
@@ -100,4 +100,5 @@ class DefinitionLinArticle
 
 	redef var toc_title = "Linearization"
 	redef fun is_hidden do return mentities.is_empty
+	redef var is_toc_hidden = true
 end

--- a/src/doc/doc_phases/doc_poset.nit
+++ b/src/doc/doc_phases/doc_poset.nit
@@ -46,7 +46,7 @@ redef class MModulePage
 	# Imported modules that should appear in the documentation.
 	var imports = new HashSet[MModule]
 
-	# Clients modules that shjould appear in the documentation.
+	# Clients modules that should appear in the documentation.
 	var clients = new HashSet[MModule]
 
 	redef fun build_poset(v, doc) do

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -47,7 +47,7 @@ end
 
 redef class OverviewPage
 	redef fun apply_structure(v, doc) do
-		var article = new HomeArticle("article:home")
+		var article = new HomeArticle("home.article")
 		root.add_child article
 		# Projects list
 		var mprojects = doc.model.mprojects.to_a
@@ -55,7 +55,7 @@ redef class OverviewPage
 		sorter.sort mprojects
 		var section = new ProjectsSection("projects.section")
 		for mproject in mprojects do
-			section.add_child new DefinitionArticle("article:{mproject.nitdoc_id}.definition", mproject)
+			section.add_child new DefinitionArticle("{mproject.nitdoc_id}.definition", mproject)
 		end
 		article.add_child section
 	end
@@ -69,7 +69,7 @@ redef class SearchPage
 		v.name_sorter.sort(mclasses)
 		var mprops = doc.mproperties.to_a
 		v.name_sorter.sort(mprops)
-		root.add_child new IndexArticle("article:index", mmodules, mclasses, mprops)
+		root.add_child new IndexArticle("index.article", mmodules, mclasses, mprops)
 	end
 end
 
@@ -78,9 +78,9 @@ redef class MGroupPage
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		if mentity.is_root then
-			section.add_child new IntroArticle("article:{mentity.mproject.nitdoc_id}.intro", mentity.mproject)
+			section.add_child new IntroArticle("{mentity.mproject.nitdoc_id}.intro", mentity.mproject)
 		else
-			section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
+			section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
 		end
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
@@ -90,11 +90,11 @@ redef class MGroupPage
 		concerns.sort_with(v.concerns_sorter)
 		mentity.mproject.booster_rank = 0
 		mentity.booster_rank = 0
-		section.add_child new ConcernsArticle("article:{mentity.nitdoc_id}.concerns", mentity, concerns)
+		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
 			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
 			if mentity isa MModule then
-				ssection.add_child new DefinitionArticle("article:{mentity.nitdoc_id}.definition", mentity)
+				ssection.add_child new DefinitionArticle("{mentity.nitdoc_id}.definition", mentity)
 			end
 			section.add_child ssection
 		end
@@ -105,7 +105,7 @@ redef class MModulePage
 	redef fun apply_structure(v, doc) do
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
-		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
+		section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
 		# FIXME avoid diff
@@ -116,7 +116,7 @@ redef class MModulePage
 		mentity.mgroup.mproject.booster_rank = 0
 		mentity.mgroup.booster_rank = 0
 		mentity.booster_rank = 0
-		section.add_child new ConcernsArticle("article:{mentity.nitdoc_id}.concerns", mentity, concerns)
+		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		# reference list
 		for mentity in concerns do
 			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
@@ -125,16 +125,16 @@ redef class MModulePage
 				v.name_sorter.sort(mclasses)
 				for mclass in mclasses do
 					var article = new DefinitionListArticle(
-						"article:{mclass.intro.nitdoc_id}.definition-list", mclass)
+						"{mclass.intro.nitdoc_id}.definition-list", mclass)
 					var mclassdefs = mclassdefs_for(mclass).to_a
 					if not mclassdefs.has(mclass.intro) then
 						article.add_child(new DefinitionArticle(
-							"article:{mclass.intro.nitdoc_id}.definition", mclass.intro))
+							"{mclass.intro.nitdoc_id}.definition", mclass.intro))
 					end
 					doc.mainmodule.linearize_mclassdefs(mclassdefs)
 					for mclassdef in mclassdefs do
 						article.add_child(new DefinitionArticle(
-							"article:{mclassdef.nitdoc_id}.definition", mclassdef))
+							"{mclassdef.nitdoc_id}.definition", mclassdef))
 					end
 					ssection.add_child article
 				end
@@ -170,7 +170,7 @@ redef class MClassPage
 	redef fun apply_structure(v, doc) do
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
-		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
+		section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
 		# FIXME diff hack
@@ -182,13 +182,13 @@ redef class MClassPage
 		mentity.intro_mmodule.mgroup.booster_rank = 0
 		mentity.intro_mmodule.booster_rank = 0
 		var constructors = new ConstructorsSection(
-			"article:{mentity.nitdoc_id}.constructors", mentity)
+			"{mentity.nitdoc_id}.constructors", mentity)
 		var minit = mentity.root_init
 		if minit != null then
-			constructors.add_child new DefinitionArticle("article:{minit.nitdoc_id}.definition", minit)
+			constructors.add_child new DefinitionArticle("{minit.nitdoc_id}.definition", minit)
 		end
 		section.add_child constructors
-		section.add_child new ConcernsArticle("article:{mentity.nitdoc_id}.concerns", mentity, concerns)
+		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
 			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
 			if mentity isa MModule then
@@ -201,10 +201,10 @@ redef class MClassPage
 							if mpropdef isa MMethodDef and mpropdef.mproperty.is_init then
 								if mpropdef == minit then continue
 								constructors.add_child new DefinitionArticle(
-									"article:{mpropdef.nitdoc_id}.definition", mpropdef)
+									"{mpropdef.nitdoc_id}.definition", mpropdef)
 							else
 								ssection.add_child new DefinitionArticle(
-									"article:{mpropdef.nitdoc_id}.definition", mpropdef)
+									"{mpropdef.nitdoc_id}.definition", mpropdef)
 							end
 						end
 					end
@@ -246,7 +246,7 @@ redef class MPropertyPage
 	redef fun apply_structure(v, doc) do
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
-		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
+		section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
 		# FIXME diff hack
@@ -257,7 +257,7 @@ redef class MPropertyPage
 		mentity.intro.mclassdef.mmodule.mgroup.mproject.booster_rank = 0
 		mentity.intro.mclassdef.mmodule.mgroup.booster_rank = 0
 		mentity.intro.mclassdef.mmodule.booster_rank = 0
-		section.add_child new ConcernsArticle("article:{mentity.nitdoc_id}.concerns", mentity, concerns)
+		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
 			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
 			if mentity isa MModule then
@@ -266,7 +266,7 @@ redef class MPropertyPage
 				v.name_sorter.sort(mpropdefs)
 				for mpropdef in mpropdefs do
 					ssection.add_child new DefinitionArticle(
-						"article:{mpropdef.nitdoc_id}.definition", mpropdef)
+						"{mpropdef.nitdoc_id}.definition", mpropdef)
 				end
 			end
 			section.add_child ssection

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -318,6 +318,8 @@ end
 class ConcernSection
 	super MEntityComposite
 	super DocSection
+
+	redef fun is_toc_hidden do return is_hidden
 end
 
 # An article about a Mentity.
@@ -344,6 +346,7 @@ class IntroArticle
 	super DocArticle
 
 	redef var is_hidden = false
+	redef var is_toc_hidden = true
 end
 
 # An article that display a ConcernsTreee as a list.

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -181,8 +181,7 @@ redef class MClassPage
 		mentity.intro_mmodule.mgroup.mproject.booster_rank = 0
 		mentity.intro_mmodule.mgroup.booster_rank = 0
 		mentity.intro_mmodule.booster_rank = 0
-		var constructors = new ConstructorsSection(
-			"{mentity.nitdoc_id}.constructors", mentity)
+		var constructors = new DocSection("{mentity.nitdoc_id}.constructors", "Constructors")
 		var minit = mentity.root_init
 		if minit != null then
 			constructors.add_child new DefinitionArticle("{minit.nitdoc_id}.definition", minit)
@@ -305,11 +304,6 @@ class MEntityComposite
 
 	# MEntity documented by this page element.
 	var mentity: MEntity
-end
-
-# A list of constructors.
-class ConstructorsSection
-	super MEntitySection
 end
 
 # A Section about a Concern.

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -364,7 +364,7 @@ class ConcernsArticle
 	redef fun is_hidden do return concerns.is_empty
 end
 
-# An article that displaus a list of definition belonging to a MEntity.
+# An article that displays a list of definition belonging to a MEntity.
 class DefinitionListArticle
 	super TabbedGroup
 	super MEntityArticle

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -92,7 +92,7 @@ redef class MGroupPage
 		mentity.booster_rank = 0
 		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
-			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
+			var ssection = new ConcernSection("{mentity.nitdoc_id}.concern", mentity)
 			if mentity isa MModule then
 				ssection.add_child new DefinitionArticle("{mentity.nitdoc_id}.definition", mentity)
 			end
@@ -119,7 +119,7 @@ redef class MModulePage
 		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		# reference list
 		for mentity in concerns do
-			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
+			var ssection = new ConcernSection("{mentity.nitdoc_id}.concern", mentity)
 			if mentity isa MModule then
 				var mclasses = mclasses_for_mmodule(mentity).to_a
 				v.name_sorter.sort(mclasses)
@@ -190,7 +190,7 @@ redef class MClassPage
 		section.add_child constructors
 		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
-			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
+			var ssection = new ConcernSection("{mentity.nitdoc_id}.concern", mentity)
 			if mentity isa MModule then
 				var mprops = mproperties_for(mentity)
 				var by_kind = new PropertiesByKind.with_elements(mprops)
@@ -259,7 +259,7 @@ redef class MPropertyPage
 		mentity.intro.mclassdef.mmodule.booster_rank = 0
 		section.add_child new ConcernsArticle("{mentity.nitdoc_id}.concerns", mentity, concerns)
 		for mentity in concerns do
-			var ssection = new ConcernSection("concern:{mentity.nitdoc_id}", mentity)
+			var ssection = new ConcernSection("{mentity.nitdoc_id}.concern", mentity)
 			if mentity isa MModule then
 				# Add mproperties
 				var mpropdefs = mpropdefs_for(mentity).to_a

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -53,7 +53,7 @@ redef class OverviewPage
 		var mprojects = doc.model.mprojects.to_a
 		var sorter = new MConcernRankSorter
 		sorter.sort mprojects
-		var section = new ProjectsSection("section:projects")
+		var section = new ProjectsSection("projects.section")
 		for mproject in mprojects do
 			section.add_child new DefinitionArticle("article:{mproject.nitdoc_id}.definition", mproject)
 		end
@@ -75,7 +75,7 @@ end
 
 redef class MGroupPage
 	redef fun apply_structure(v, doc) do
-		var section = new MEntitySection("section:{mentity.nitdoc_name}", mentity)
+		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		if mentity.is_root then
 			section.add_child new IntroArticle("article:{mentity.mproject.nitdoc_id}.intro", mentity.mproject)
@@ -103,7 +103,7 @@ end
 
 redef class MModulePage
 	redef fun apply_structure(v, doc) do
-		var section = new MEntitySection("section:{mentity.nitdoc_name}", mentity)
+		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns
@@ -168,7 +168,7 @@ end
 
 redef class MClassPage
 	redef fun apply_structure(v, doc) do
-		var section = new MEntitySection("section:{mentity.nitdoc_name}", mentity)
+		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns
@@ -244,7 +244,7 @@ end
 
 redef class MPropertyPage
 	redef fun apply_structure(v, doc) do
-		var section = new MEntitySection("section:{mentity.nitdoc_name}", mentity)
+		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		section.add_child new IntroArticle("article:{mentity.nitdoc_id}.intro", mentity)
 		var concerns = self.concerns

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -47,13 +47,13 @@ end
 
 redef class OverviewPage
 	redef fun apply_structure(v, doc) do
-		var article = new HomeArticle("home.article")
+		var article = new HomeArticle("home.article", "Home")
 		root.add_child article
 		# Projects list
 		var mprojects = doc.model.mprojects.to_a
 		var sorter = new MConcernRankSorter
 		sorter.sort mprojects
-		var section = new ProjectsSection("projects.section")
+		var section = new ProjectsSection("projects.section", "Projects")
 		for mproject in mprojects do
 			section.add_child new DefinitionArticle("{mproject.nitdoc_id}.definition", mproject)
 		end
@@ -295,14 +295,13 @@ end
 # A group of sections that can be displayed together in a tab panel.
 class PanelGroup
 	super DocSection
-
-	# The title of this group.
-	var group_title: String
 end
 
 # A DocComposite element about a MEntity.
 class MEntityComposite
 	super DocComposite
+
+	redef fun title do return mentity.nitdoc_name
 
 	# MEntity documented by this page element.
 	var mentity: MEntity

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -342,6 +342,8 @@ end
 class IntroArticle
 	super MEntityComposite
 	super DocArticle
+
+	redef var is_hidden = false
 end
 
 # An article that display a ConcernsTreee as a list.
@@ -350,6 +352,8 @@ class ConcernsArticle
 
 	# Concerns to list in this article.
 	var concerns: ConcernsTree
+
+	redef fun is_hidden do return concerns.is_empty
 end
 
 # An article that displaus a list of definition belonging to a MEntity.
@@ -361,6 +365,8 @@ end
 # An article that display the definition text of a MEntity.
 class DefinitionArticle
 	super MEntityArticle
+
+	redef var is_hidden = false
 end
 
 # The main project article.
@@ -385,4 +391,8 @@ class IndexArticle
 
 	# List of mproperties to display.
 	var mprops: Array[MProperty]
+
+	redef fun is_hidden do
+		return mmodules.is_empty and mclasses.is_empty and mprops.is_empty
+	end
 end

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -53,7 +53,7 @@ redef class OverviewPage
 		var mprojects = doc.model.mprojects.to_a
 		var sorter = new MConcernRankSorter
 		sorter.sort mprojects
-		var section = new ProjectsSection("projects.section", "Projects")
+		var section = new DocSection("projects.section", "Projects")
 		for mproject in mprojects do
 			section.add_child new DefinitionArticle("{mproject.nitdoc_id}.definition", mproject)
 		end
@@ -385,11 +385,6 @@ end
 
 # The main project article.
 class HomeArticle
-	super DocArticle
-end
-
-# The project list.
-class ProjectsSection
 	super DocArticle
 end
 

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -330,6 +330,17 @@ abstract class MEntityArticle
 	super DocArticle
 end
 
+# An article that displays a list of mentities.
+class MEntitiesListArticle
+	super DocArticle
+
+	# MEntities to display.
+	var mentities: Array[MEntity]
+
+	redef fun is_hidden do return mentities.is_empty
+end
+
+
 # A section about a Mentity.
 #
 # Used to regroup content about a MEntity.

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -686,7 +686,7 @@ redef class MConcern
 	private fun html_concern_item: ListItem do
 		var lnk = html_link
 		var tpl = new Template
-		tpl.add new Link.with_title("#concern:{nitdoc_id}", lnk.text, lnk.title)
+		tpl.add new Link.with_title("#{nitdoc_id}.concern", lnk.text, lnk.title)
 		var comment = html_short_comment
 		if comment != null then
 			tpl.add ": "

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -247,7 +247,7 @@ redef class DocComposite
 	super Template
 
 	# HTML anchor id
-	var html_id: String is noinit, writable
+	var html_id: String is writable, lazy do return id
 
 	# Title to display if any.
 	#
@@ -366,14 +366,12 @@ redef class TabbedGroup
 end
 
 redef class PanelGroup
-	redef var html_id is lazy do return "group:{group_title.to_lower.to_snake_case}"
 	redef var html_title = null
 	redef var toc_title is lazy do return group_title
 	redef var is_toc_hidden = true
 end
 
 redef class HomeArticle
-	redef var html_id = "article:home"
 	redef var html_title = "Overview"
 
 	# HTML content to display on the home page.
@@ -389,7 +387,6 @@ redef class HomeArticle
 end
 
 redef class IndexArticle
-	redef var html_id = "article:index"
 	redef var html_title = "Index"
 	redef fun is_empty do
 		return mmodules.is_empty and mclasses.is_empty and mprops.is_empty
@@ -429,46 +426,38 @@ redef class IndexArticle
 end
 
 redef class ProjectsSection
-	redef var html_id = "section:projects"
 	redef var html_title = "Projects"
 end
 
 redef class MEntityComposite
-	redef var html_id is lazy do return mentity.nitdoc_id
 	redef var html_title is lazy do return mentity.nitdoc_name
 end
 
 redef class MEntitySection
-	redef var html_id is lazy do return "section:{mentity.nitdoc_name}"
 	redef var html_title is lazy do return mentity.html_name
 	redef var html_subtitle is lazy do return mentity.html_declaration
 end
 
 redef class ConstructorsSection
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.constructors"
 	redef var html_title = "Constructors"
 	redef var html_subtitle = null
 	redef fun is_toc_hidden do return is_empty
 end
 
 redef class ConcernSection
-	redef var html_id is lazy do return "concern:{mentity.nitdoc_id}"
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"
 	redef fun is_toc_hidden do return is_empty
 end
 
 redef class ImportationListSection
-	redef var html_id is lazy do return "section:{mentity.nitdoc_id}.importation"
 	redef var html_title is lazy do return "Dependencies"
 end
 
 redef class InheritanceListSection
-	redef var html_id is lazy do return "section:{mentity.nitdoc_id}.inheritance"
 	redef var html_title is lazy do return "Inheritance"
 end
 
 redef class IntroArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.intro"
 	redef var html_title = null
 	redef var is_hidden = false
 	redef var is_toc_hidden = true
@@ -495,15 +484,12 @@ redef class IntroArticle
 end
 
 redef class ConcernsArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.concerns"
 	redef var html_title = "Concerns"
 	redef fun is_hidden do return concerns.is_empty
 	redef fun render_body do add concerns.html_list
 end
 
 redef class DefinitionListArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.definition-list"
-
 	redef var html_title is lazy do
 		var title = new Template
 		title.add mentity.html_icon
@@ -516,7 +502,6 @@ redef class DefinitionListArticle
 end
 
 redef class DefinitionArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.definition"
 	redef var html_title is lazy do return mentity.html_name
 	redef var html_subtitle is lazy do return mentity.html_declaration
 	redef var is_hidden = false
@@ -560,7 +545,6 @@ redef class DefinitionArticle
 end
 
 redef class HierarchyListArticle
-	redef var html_id is lazy do return "article:{list_title}_{mentity.nitdoc_id}.hierarchy"
 	redef var html_title is lazy do return list_title
 	redef fun is_empty do return mentities.is_empty
 	redef var is_toc_hidden = true
@@ -576,7 +560,6 @@ redef class HierarchyListArticle
 end
 
 redef class IntrosRedefsSection
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.intros_redefs"
 	redef var toc_title do return "Intros / Redefs"
 	redef var html_title = null
 	redef var html_subtitle = null
@@ -584,7 +567,6 @@ redef class IntrosRedefsSection
 end
 
 redef class IntrosRedefsListArticle
-	redef var html_id is lazy do return "article:{list_title}_{mentity.nitdoc_id}.intros_redefs"
 	redef var html_title is lazy do return list_title
 	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
@@ -600,7 +582,6 @@ redef class IntrosRedefsListArticle
 end
 
 redef class DefinitionLinArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.lin"
 	redef var html_title is lazy do return "Linearization"
 	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
@@ -626,7 +607,6 @@ redef class DefinitionLinArticle
 end
 
 redef class GraphArticle
-	redef var html_id is lazy do return "article:{mentity.nitdoc_id}.graph"
 	redef var html_title = null
 	redef var toc_title do return "Graph"
 	redef var is_hidden = false
@@ -639,7 +619,7 @@ redef class GraphArticle
 
 	redef fun render_body do
 		addn "<div class=\"text-center\">"
-		addn " <img src='{id}.png' usemap='#{id}' style='margin:auto'"
+		addn " <img src='{graph_id}.png' usemap='#{graph_id}' style='margin:auto'"
 		addn "  alt='{graph_title}'/>"
 		add map
 		addn "</div>"

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -436,10 +436,6 @@ redef class ConcernSection
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"
 end
 
-redef class ImportationListSection
-	redef var html_title is lazy do return "Dependencies"
-end
-
 redef class IntroArticle
 	redef var html_title = null
 

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -423,10 +423,6 @@ redef class IndexArticle
 	end
 end
 
-redef class ProjectsSection
-	redef var html_title = "Projects"
-end
-
 redef class MEntityComposite
 	redef var html_title is lazy do return mentity.nitdoc_name
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -432,11 +432,6 @@ redef class MEntitySection
 	redef var html_subtitle is lazy do return mentity.html_declaration
 end
 
-redef class ConstructorsSection
-	redef var html_title = "Constructors"
-	redef var html_subtitle = null
-end
-
 redef class ConcernSection
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"
 end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -440,10 +440,6 @@ redef class ImportationListSection
 	redef var html_title is lazy do return "Dependencies"
 end
 
-redef class InheritanceListSection
-	redef var html_title is lazy do return "Inheritance"
-end
-
 redef class IntroArticle
 	redef var html_title = null
 

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -294,12 +294,9 @@ redef class DocComposite
 		return html_title.write_to_string
 	end
 
-	# Is `self` hidden in the table of content?
-	var is_toc_hidden = false is writable
-
 	# Render this element in a table of contents.
 	private fun render_toc_item(lst: UnorderedList) do
-		if is_toc_hidden then return
+		if is_toc_hidden or html_toc_title == null then return
 
 		var content = new Template
 		content.add new Link("#{html_id}", html_toc_title.to_s)
@@ -442,12 +439,10 @@ end
 redef class ConstructorsSection
 	redef var html_title = "Constructors"
 	redef var html_subtitle = null
-	redef fun is_toc_hidden do return is_hidden
 end
 
 redef class ConcernSection
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"
-	redef fun is_toc_hidden do return is_hidden
 end
 
 redef class ImportationListSection
@@ -460,7 +455,6 @@ end
 
 redef class IntroArticle
 	redef var html_title = null
-	redef var is_toc_hidden = true
 
 	# Link to source to display if any.
 	var html_source_link: nullable Writable is noinit, writable
@@ -545,8 +539,6 @@ redef class DefinitionArticle
 end
 
 redef class HierarchyListArticle
-	redef var is_toc_hidden = true
-
 	redef fun render_body do
 		var lst = new UnorderedList
 		lst.css_classes.add "list-unstyled list-definition"
@@ -561,12 +553,9 @@ redef class IntrosRedefsSection
 	redef var toc_title do return "Intros / Redefs"
 	redef var html_title = null
 	redef var html_subtitle = null
-	redef var is_toc_hidden = true
 end
 
 redef class IntrosRedefsListArticle
-	redef var is_toc_hidden = true
-
 	redef fun render_body do
 		var lst = new UnorderedList
 		lst.css_classes.add "list-unstyled list-labeled"
@@ -579,7 +568,6 @@ end
 
 redef class DefinitionLinArticle
 	redef var html_title is lazy do return "Linearization"
-	redef var is_toc_hidden = true
 
 	redef fun render_body do
 		var lst = new UnorderedList
@@ -603,7 +591,6 @@ end
 
 redef class GraphArticle
 	redef var html_title = null
-	redef var is_toc_hidden = true
 
 	# HTML map used to display link.
 	#

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -286,11 +286,6 @@ redef class DocComposite
 	# Level <hX> for HTML heading.
 	private fun hlvl: Int do return depth
 
-	# Is `self` not displayed in the page.
-	#
-	# By default, empty elements are hidden.
-	fun is_hidden: Bool do return is_empty
-
 	# A short, undecorated title that goes in the table of contents.
 	#
 	# By default, returns `html_title.to_s`, subclasses should redefine it.
@@ -397,9 +392,6 @@ end
 
 redef class IndexArticle
 	redef var html_title = "Index"
-	redef fun is_empty do
-		return mmodules.is_empty and mclasses.is_empty and mprops.is_empty
-	end
 
 	redef fun render_body do
 		addn "<div class='container-fluid'>"
@@ -450,12 +442,12 @@ end
 redef class ConstructorsSection
 	redef var html_title = "Constructors"
 	redef var html_subtitle = null
-	redef fun is_toc_hidden do return is_empty
+	redef fun is_toc_hidden do return is_hidden
 end
 
 redef class ConcernSection
 	redef var html_title is lazy do return "in {mentity.nitdoc_name}"
-	redef fun is_toc_hidden do return is_empty
+	redef fun is_toc_hidden do return is_hidden
 end
 
 redef class ImportationListSection
@@ -468,7 +460,6 @@ end
 
 redef class IntroArticle
 	redef var html_title = null
-	redef var is_hidden = false
 	redef var is_toc_hidden = true
 
 	# Link to source to display if any.
@@ -495,7 +486,6 @@ end
 
 redef class ConcernsArticle
 	redef var html_title = "Concerns"
-	redef fun is_hidden do return concerns.is_empty
 	redef fun render_body do add concerns.html_list
 end
 
@@ -514,7 +504,6 @@ end
 redef class DefinitionArticle
 	redef var html_title is lazy do return mentity.html_name
 	redef var html_subtitle is lazy do return mentity.html_declaration
-	redef var is_hidden = false
 
 	# Does `self` display only it's title and no body?
 	#
@@ -556,7 +545,6 @@ redef class DefinitionArticle
 end
 
 redef class HierarchyListArticle
-	redef fun is_empty do return mentities.is_empty
 	redef var is_toc_hidden = true
 
 	redef fun render_body do
@@ -577,7 +565,6 @@ redef class IntrosRedefsSection
 end
 
 redef class IntrosRedefsListArticle
-	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
 
 	redef fun render_body do
@@ -592,7 +579,6 @@ end
 
 redef class DefinitionLinArticle
 	redef var html_title is lazy do return "Linearization"
-	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
 
 	redef fun render_body do
@@ -617,7 +603,6 @@ end
 
 redef class GraphArticle
 	redef var html_title = null
-	redef var is_hidden = false
 	redef var is_toc_hidden = true
 
 	# HTML map used to display link.

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -529,12 +529,6 @@ redef class DefinitionArticle
 	end
 end
 
-redef class IntrosRedefsSection
-	redef var toc_title do return "Intros / Redefs"
-	redef var html_title = null
-	redef var html_subtitle = null
-end
-
 redef class MEntitiesListArticle
 	redef fun render_body do
 		var lst = new UnorderedList

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -533,8 +533,6 @@ redef class MEntitiesListArticle
 end
 
 redef class DefinitionLinArticle
-	redef var html_title is lazy do return "Linearization"
-
 	redef fun render_body do
 		var lst = new UnorderedList
 		lst.css_classes.add "list-unstyled list-labeled"

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -538,27 +538,16 @@ redef class DefinitionArticle
 	end
 end
 
-redef class HierarchyListArticle
-	redef fun render_body do
-		var lst = new UnorderedList
-		lst.css_classes.add "list-unstyled list-definition"
-		for mentity in mentities do
-			lst.add_li mentity.html_list_item
-		end
-		addn lst
-	end
-end
-
 redef class IntrosRedefsSection
 	redef var toc_title do return "Intros / Redefs"
 	redef var html_title = null
 	redef var html_subtitle = null
 end
 
-redef class IntrosRedefsListArticle
+redef class MEntitiesListArticle
 	redef fun render_body do
 		var lst = new UnorderedList
-		lst.css_classes.add "list-unstyled list-labeled"
+		lst.css_classes.add "list-unstyled list-definition"
 		for mentity in mentities do
 			lst.add_li mentity.html_list_item
 		end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -252,7 +252,7 @@ redef class DocComposite
 	# Title to display if any.
 	#
 	# This title can be decorated with HTML.
-	var html_title: nullable Writable is noinit, writable
+	var html_title: nullable Writable is writable, lazy do return title
 
 	# Subtitle to display if any.
 	var html_subtitle: nullable Writable is noinit, writable
@@ -327,6 +327,12 @@ redef class DocComposite
 	end
 end
 
+redef class DocRoot
+	redef fun rendering do
+		for child in children do addn child.write_to_string
+	end
+end
+
 redef class DocSection
 	super BSComponent
 
@@ -367,7 +373,7 @@ end
 
 redef class PanelGroup
 	redef var html_title = null
-	redef var toc_title is lazy do return group_title
+	redef var toc_title is lazy do return title or else ""
 	redef var is_toc_hidden = true
 end
 
@@ -545,7 +551,6 @@ redef class DefinitionArticle
 end
 
 redef class HierarchyListArticle
-	redef var html_title is lazy do return list_title
 	redef fun is_empty do return mentities.is_empty
 	redef var is_toc_hidden = true
 
@@ -567,7 +572,6 @@ redef class IntrosRedefsSection
 end
 
 redef class IntrosRedefsListArticle
-	redef var html_title is lazy do return list_title
 	redef fun is_hidden do return mentities.is_empty
 	redef var is_toc_hidden = true
 
@@ -620,7 +624,7 @@ redef class GraphArticle
 	redef fun render_body do
 		addn "<div class=\"text-center\">"
 		addn " <img src='{graph_id}.png' usemap='#{graph_id}' style='margin:auto'"
-		addn "  alt='{graph_title}'/>"
+		addn "  alt='{title or else ""}'/>"
 		add map
 		addn "</div>"
 	end

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -294,7 +294,10 @@ redef class DocComposite
 	# A short, undecorated title that goes in the table of contents.
 	#
 	# By default, returns `html_title.to_s`, subclasses should redefine it.
-	var toc_title: String is lazy, writable do return html_title.to_s
+	var html_toc_title: nullable String is lazy, writable do
+		if html_title == null then return toc_title
+		return html_title.write_to_string
+	end
 
 	# Is `self` hidden in the table of content?
 	var is_toc_hidden = false is writable
@@ -304,8 +307,7 @@ redef class DocComposite
 		if is_toc_hidden then return
 
 		var content = new Template
-		content.add new Link("#{html_id}", toc_title)
-
+		content.add new Link("#{html_id}", html_toc_title.to_s)
 		if not children.is_empty then
 			var sublst = new UnorderedList
 			sublst.css_classes.add "nav"
@@ -365,7 +367,8 @@ redef class TabbedGroup
 		var tabs = new DocTabs("{html_id}.tabs", "")
 		for child in children do
 			if child.is_hidden then continue
-			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+			var title = child.html_toc_title or else child.toc_title or else ""
+			tabs.add_panel new DocTabPanel(child.html_tab_id, title, child)
 		end
 		addn tabs
 	end
@@ -479,7 +482,8 @@ redef class IntroArticle
 		end
 		for child in children do
 			if child.is_hidden then continue
-			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+			var title = child.html_toc_title or else child.toc_title or else ""
+			tabs.add_panel new DocTabPanel(child.html_tab_id, title, child)
 		end
 		var lnk = html_source_link
 		if lnk != null then
@@ -504,7 +508,7 @@ redef class DefinitionListArticle
 	end
 
 	redef var html_subtitle is lazy do return mentity.html_namespace
-	redef var toc_title is lazy do return mentity.html_name
+	redef var html_toc_title is lazy do return mentity.html_name
 end
 
 redef class DefinitionArticle
@@ -540,7 +544,8 @@ redef class DefinitionArticle
 		end
 		for child in children do
 			if child.is_hidden then continue
-			tabs.add_panel new DocTabPanel(child.html_tab_id, child.toc_title, child)
+			var title = child.html_toc_title or else child.toc_title or else ""
+			tabs.add_panel new DocTabPanel(child.html_tab_id, title, child)
 		end
 		var lnk = html_source_link
 		if lnk != null then
@@ -612,7 +617,6 @@ end
 
 redef class GraphArticle
 	redef var html_title = null
-	redef var toc_title do return "Graph"
 	redef var is_hidden = false
 	redef var is_toc_hidden = true
 


### PR DESCRIPTION
Now that nitx and nitdoc are fully merged with the same structure and services, we can start the refactoring to limit the differences between both tools.

Note that the first four commits are from #1401.

Demos from [Jenkins::CI-nitdoc](http://gresil.org/jenkins/job/CI-nitdoc):
* [Standard library](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/index.html)
* [Nit compilers and tools](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/nitc/index.html)