### PR TITLE
Opportunity: Adds total number of participants to a meetup

### DIFF
--- a/contrib/opportunity/src/templates/meetup.nit
+++ b/contrib/opportunity/src/templates/meetup.nit
@@ -356,7 +356,7 @@ redef class Meetup
 		end
 		t.add """
 <tr id="total">
-	<th>Total</th>
+	<th>Total ({{{participants(db).length}}})</th>
 		"""
 		for i in answers(db) do
 			t.add """<th id="total{{{i.id}}}"><center>{{{i.count(db)}}}"""


### PR DESCRIPTION
As requested in #1431, this PR adds the total number of participants in a Meetup, as a number aside from the Total, like:

`Total(nb)`

Closes #1431