### PR TITLE
Love contrib

### DIFF
--- a/src/loader.nit
+++ b/src/loader.nit
@@ -52,6 +52,8 @@ redef class ModelBuilder
 		var nit_dir = toolcontext.nit_dir
 		var libname = nit_dir/"lib"
 		if libname.file_exists then paths.add(libname)
+		libname = nit_dir/"contrib"
+		if libname.file_exists then paths.add(libname)
 	end
 
 	# Load a bunch of modules.

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -50,7 +50,7 @@ redef class ModelBuilder
 		end
 
 		var nit_dir = toolcontext.nit_dir
-		var libname = "{nit_dir}/lib"
+		var libname = nit_dir/"lib"
 		if libname.file_exists then paths.add(libname)
 	end
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -224,6 +224,14 @@ redef class ModelBuilder
 				return res
 			end
 
+			# Fourth, try if the requested module is itself a group with a src
+			try_file = dirname + "/" + name + "/src/" + name + ".nit"
+			if try_file.file_exists then
+				var res = self.identify_file(try_file.simplify_path)
+				assert res != null
+				return res
+			end
+
 			c = c.parent
 		end
 
@@ -291,6 +299,19 @@ redef class ModelBuilder
 				end
 			end
 			try_file = (dirname + "/" + name + "/" + name + ".nit").simplify_path
+			if try_file.file_exists then
+				if candidate == null then
+					candidate = try_file
+				else if candidate != try_file then
+					# try to disambiguate conflicting modules
+					var abs_candidate = module_absolute_path(candidate)
+					var abs_try_file = module_absolute_path(try_file)
+					if abs_candidate != abs_try_file then
+						toolcontext.error(location, "Error: conflicting module file for `{name}`: `{candidate}` `{try_file}`")
+					end
+				end
+			end
+			try_file = (dirname + "/" + name + "/src/" + name + ".nit").simplify_path
 			if try_file.file_exists then
 				if candidate == null then
 					candidate = try_file

--- a/tests/sav/base_import_alt3.res
+++ b/tests/sav/base_import_alt3.res
@@ -1,1 +1,1 @@
-alt/base_import_alt3.nit:1,8--21: Error: cannot find module `fail` from `project1`. Tried: ., ../lib/standard, ../lib/standard/collection, alt, ../lib.
+alt/base_import_alt3.nit:1,8--21: Error: cannot find module `fail` from `project1`. Tried: ., ../lib/standard, ../lib/standard/collection, alt, ../lib, ../contrib.

--- a/tests/sav/error_mod_unk.res
+++ b/tests/sav/error_mod_unk.res
@@ -1,1 +1,1 @@
-error_mod_unk.nit:17,8--11: Error: cannot find module `dfgd` from `error_mod_unk`. Tried: ., ../lib/standard, ../lib/standard/collection, alt, ../lib.
+error_mod_unk.nit:17,8--11: Error: cannot find module `dfgd` from `error_mod_unk`. Tried: ., ../lib/standard, ../lib/standard/collection, alt, ../lib, ../contrib.

--- a/tests/sav/xymus_net.res
+++ b/tests/sav/xymus_net.res
@@ -1,3 +1,2 @@
-../examples/nitcorn/src/xymus_net.nit:24,8--14: Error: cannot find module `tnitter` from `nitcorn`. Tried: alt, ../lib, ../examples/nitcorn.
-../examples/nitcorn/src/xymus_net.nit:25,8--26: Error: cannot find module `benitlux_controller` from `nitcorn`. Tried: alt, ../lib, ../examples/nitcorn.
-../examples/nitcorn/src/xymus_net.nit:26,8--29: Error: cannot find module `opportunity_controller` from `nitcorn`. Tried: alt, ../lib, ../examples/nitcorn.
+../examples/nitcorn/src/xymus_net.nit:25,8--26: Error: cannot find module `benitlux_controller` from `nitcorn`. Tried: alt, ../lib, ../contrib, ../examples/nitcorn.
+../examples/nitcorn/src/xymus_net.nit:26,8--29: Error: cannot find module `opportunity_controller` from `nitcorn`. Tried: alt, ../lib, ../contrib, ../examples/nitcorn.


### PR DESCRIPTION
One day, a package manager will simplify the installation and the maintenance of third-party projects, libraries and programs in Nit, so that `import foo` will import the project `foo` if installed.

Noways, `contrib` is used as a placeholder for some independent projects that are not mainly a library (or borderline). However, the nature of the Nit language, especially the refinement of class blurry the difference between libraries and programs and make it conceivable to extends an existing program by refining it (or just reuse its base libraries).
However, `import foo` will not work if foo is in contrib, this issue has two current workarounds:

* the user use `-I` with some relative path location in the Makefile, that is not practical because it should be used on each tools thus broke basic manual commands (like nitc on the command line) and automatic commands (like vim+nitpick).
* the project just move itself to lib/ so that client can easily import it, but this is hard to conceptualize for some project like `nitiwiki`

The easy solution to solve this issue is to add `contrib` to the libpath.

Note: the loader still has to be rewritten to be less buggy, more simple and saner. cf #1250