### PR TITLE
nitdoc: Use wikilinks on README files

### DIFF
--- a/lib/github/README.md
+++ b/lib/github/README.md
@@ -1,0 +1,71 @@
+# Nit wrapper for Github API
+
+This module provides a Nit object oriented interface to access the Github api.
+
+## Accessing the API
+
+[[doc: GithubAPI]]
+
+### Authentification
+
+[[doc: GithubAPI::auth]]
+
+Token can also be recovered from user config with `get_github_oauth`.
+
+[[doc: get_github_oauth]]
+
+### Retrieving user data
+
+[[doc: load_user]]
+[[doc: User]]
+[[list: User]]
+
+### Retrieving repo data
+
+[[doc: load_repo]]
+[[doc: Repo]]
+[[list: Repo]]
+
+### Other data
+
+[[list: api]]
+
+### Advanced uses
+
+#### Caching
+
+[[doc: cache]]
+
+#### Custom requests
+
+[[doc: GithubAPI::get]]
+
+#### Change the user agent
+
+[[doc: GithubAPI::user_agent]]
+
+#### Debugging
+
+[[doc: verbose_lvl]]
+
+#### Using with GitLab
+
+If URL scheme of GitLab API follows the one of Github API, it may be possible to
+configure this wrapper to use a custom URL.
+
+[[doc: api_url]]
+
+## Creating hooks
+
+Using this API you can create Github hooks able to respond to actions performed
+on a repository.
+
+[[doc: hooks]]
+
+## Dealing with events
+
+GithubAPI can trigger different events depending on the hook configuration.
+
+[[doc: GithubEvent]]
+
+[[list: github::events]]

--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Nit object oriented interface to Github api.
+# Nit object oriented interface to [Github api](https://developer.github.com/v3/).
 #
 # This modules reifies Github API elements as Nit classes.
 #
@@ -21,11 +21,9 @@ module api
 
 import github_curl
 
-# Interface to Github REST API.
+# Client to Github API
 #
-# Used by all `GithubEntity` to perform requests.
-#
-# Usage:
+# To access the API you need an instance of a `GithubAPI` client.
 #
 # ~~~
 # # Get Github authentification token.
@@ -36,7 +34,7 @@ import github_curl
 # var api = new GithubAPI(token)
 # ~~~
 #
-# The API client allows to get Github API entities:
+# The API client allows you to get Github API entities.
 #
 # ~~~
 # var repo = api.load_repo("privat/nit")
@@ -49,9 +47,16 @@ import github_curl
 # ~~~
 class GithubAPI
 
-	# Github API OAuth token.
+	# Github API OAuth token
 	#
-	# This token is used to authenticate the application on Github API.
+	# To access your private ressources, you must
+	# [authenticate](https://developer.github.com/guides/basics-of-authentication/).
+	#
+	# For client applications, Github recommands to use the
+	# [OAuth tokens](https://developer.github.com/v3/oauth/) authentification method.
+	#
+	#
+	#
 	# Be aware that there is [rate limits](https://developer.github.com/v3/rate_limit/)
 	# associated to the key.
 	var auth: String
@@ -140,9 +145,9 @@ class GithubAPI
 		return res.as(JsonObject)
 	end
 
-	# Get the Github user with `login`.
+	# Get the Github user with `login`
 	#
-	# Returns `null` if the user cannot be found.
+	# Loads the `User` from the API or returns `null` if the user cannot be found.
 	#
 	#     var api = new GithubAPI(get_github_oauth)
 	#     var user = api.load_user("Morriar")
@@ -154,7 +159,7 @@ class GithubAPI
 
 	# Get the Github repo with `full_name`.
 	#
-	# Returns `null` if the repo cannot be found.
+	# Loads the `Repo` from the API or returns `null` if the repo cannot be found.
 	#
 	#     var api = new GithubAPI(get_github_oauth)
 	#     var repo = api.load_repo("privat/nit")
@@ -349,11 +354,10 @@ abstract class GithubEntity
 	fun html_url: String do return json["html_url"].to_s
 end
 
-# A Github user.
+# A Github user
 #
+# Provides access to [Github user data](https://developer.github.com/v3/users/).
 # Should be accessed from `GithubAPI::load_user`.
-#
-# See <https://developer.github.com/v3/users/>.
 class User
 	super GithubEntity
 
@@ -374,9 +378,8 @@ end
 
 # A Github repository.
 #
+# Provides access to [Github repo data](https://developer.github.com/v3/repos/).
 # Should be accessed from `GithubAPI::load_repo`.
-#
-# See <https://developer.github.com/v3/repos/>.
 class Repo
 	super GithubEntity
 

--- a/lib/github/github.nit
+++ b/lib/github/github.nit
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Github API related features.
+# Nit wrapper for Github API
+#
+# This module provides a Nit object oriented interface to access the
+# [Github api](https://developer.github.com/v3/).
 module github
 
 import cache

--- a/lib/github/github_curl.nit
+++ b/lib/github/github_curl.nit
@@ -131,8 +131,10 @@ class GithubError
 	redef fun to_s do return "[{name}] {super}"
 end
 
+# Gets the Github token from `git` configuration
+#
 # Return the value of `git config --get github.oauthtoken`
-# return "" if no such a key
+# or `""` if no key exists.
 fun get_github_oauth: String
 do
 	var p = new ProcessReader("git", "config", "--get", "github.oauthtoken")

--- a/lib/markdown/test_markdown.nit
+++ b/lib/markdown/test_markdown.nit
@@ -2770,6 +2770,26 @@ class TestTokenLocation
 			"TokenLink at 4,1--4,1"]
 		(new TestTokenProcessor(stack)).process(string)
 	end
+
+	fun test_token_location4 do
+		var string = "**Hello**\n\n`World`"
+		var stack =  [
+			"TokenStrongStar at 1,1--1,1",
+			"TokenStrongStar at 1,8--1,8",
+			"TokenCodeSingle at 3,1--3,1",
+			"TokenCodeSingle at 3,7--3,7"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location5 do
+		var string = "# *Title1*\n\n# *Title2*"
+		var stack =  [
+			"TokenEmStar at 1,3--1,3",
+			"TokenEmStar at 1,10--1,10",
+			"TokenEmStar at 3,3--3,3",
+			"TokenEmStar at 3,10--3,10"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
 end
 
 class TestTokenProcessor
@@ -2781,8 +2801,10 @@ class TestTokenProcessor
 		var token = super
 		if token isa TokenNone then return token
 		var res = "{token.class_name} at {token.location}"
-		print res
 		var exp = test_stack.shift
+		print ""
+		print "EXP {exp}"
+		print "RES {res}"
 		assert exp == res
 		return token
 	end
@@ -2819,6 +2841,15 @@ some code
 
 1. li1
 1. li2"""
+		proc.emitter.decorator = new TestBlockDecorator(stack)
+		proc.process(string)
+	end
+
+	fun test_block_location3 do
+		var stack = [
+			"BlockHeadline: 1,1--1,8",
+			"BlockHeadline: 3,1--3,10"]
+		var string ="""# Title\n\n## Title 2"""
 		proc.emitter.decorator = new TestBlockDecorator(stack)
 		proc.process(string)
 	end

--- a/lib/markdown/test_wikilinks.nit
+++ b/lib/markdown/test_wikilinks.nit
@@ -1,0 +1,73 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test suites for module `markdown`
+module test_wikilinks is test_suite
+
+import test_markdown
+import wikilinks
+
+class TestTokenWikilink
+	super TestSuite
+
+	fun test_token_location1 do
+		var string = "[[wikilink]]"
+		var stack =  ["TokenWikiLink at 1,1--1,1"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location2 do
+		var string = "Hello [[World]]"
+		var stack =  ["TokenWikiLink at 1,7--1,7"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location3 do
+		var string = "\nHello\nworld [[wikilink]] !"
+		var stack =  ["TokenWikiLink at 3,7--3,7"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location4 do
+		var string = "[[link1]]\n\n[[link2]]"
+		var stack =  [
+			"TokenWikiLink at 1,1--1,1",
+			"TokenWikiLink at 3,1--3,1"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location5 do
+		var string = "[[link1]]\n[[link2]]"
+		var stack =  [
+			"TokenWikiLink at 1,1--1,1",
+			"TokenWikiLink at 2,1--2,1"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+
+	fun test_token_location6 do
+		var string = """
+[[doc: github]]
+
+[[loollll]]
+
+## Accessing the API
+
+[[doc: GithubAPI]]"""
+		var stack =  [
+			"TokenWikiLink at 1,1--1,1",
+			"TokenWikiLink at 3,1--3,1",
+			"TokenWikiLink at 7,1--7,1"]
+		(new TestTokenProcessor(stack)).process(string)
+	end
+end

--- a/lib/markdown/wikilinks.nit
+++ b/lib/markdown/wikilinks.nit
@@ -41,11 +41,11 @@ end
 redef class Decorator
 
 	# Renders a `[[wikilink]]` item.
-	fun add_wikilink(v: EMITTER, link: Text, name, comment: nullable Text) do
-		if name != null then
-			v.add "[[{name}|{link}]]"
+	fun add_wikilink(v: EMITTER, token: TokenWikiLink) do
+		if token.name != null then
+			v.add "[[{token.name.to_s}|{token.link.to_s}]]"
 		else
-			v.add "[[{link}]]"
+			v.add "[[{token.link.to_s}]]"
 		end
 	end
 end
@@ -67,7 +67,7 @@ class TokenWikiLink
 	super TokenLink
 
 	redef fun emit_hyper(v) do
-		v.decorator.add_wikilink(v, link.as(not null), name, comment)
+		v.decorator.add_wikilink(v, self)
 	end
 
 	redef fun check_link(v, out, start, token) do

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -111,7 +111,7 @@ abstract class DocComposite
 	var id: String is writable
 
 	# Item title if any.
-	var title: nullable String
+	var title: nullable String is writable
 
 	# Does `self` have a `parent`?
 	fun is_root: Bool do return parent == null

--- a/src/doc/doc_commands.nit
+++ b/src/doc/doc_commands.nit
@@ -45,6 +45,8 @@ interface DocCommand
 			return new ArticleCommand(command_string)
 		else if command_string.has_prefix("comment:") then
 			return new CommentCommand(command_string)
+		else if command_string.has_prefix("list:") then
+			return new ListCommand(command_string)
 		else if command_string.has_prefix("param:") then
 			return new ParamCommand(command_string)
 		else if command_string.has_prefix("return:") then
@@ -104,6 +106,13 @@ end
 #
 # Syntax: `comment: MEntity::name`.
 class CommentCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes a list of something.
+#
+# Syntax: `list:kind: <arg>`.
+class ListCommand
 	super AbstractDocCommand
 end
 

--- a/src/doc/doc_commands.nit
+++ b/src/doc/doc_commands.nit
@@ -1,0 +1,146 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Parsing of commands understood by documentation tools.
+#
+# This can be through:
+# * `nitx` commands like `code: MEntity::name`
+# * `nitdoc` wikilinks like `[[doc: MEntity::name]]`
+module doc_commands
+
+import doc_base
+
+# A command aimed at a documentation tool like `nitdoc` or `nitx`.
+#
+# `DocCommand` are generally of the form `command: args`.
+interface DocCommand
+
+	# Original command string.
+	fun string: String is abstract
+
+	# Command name.
+	fun name: String is abstract
+
+	# Command arguments.
+	#
+	# FIXME: define a syntax
+	fun args: Array[String] is abstract
+
+	# Command factory.
+	#
+	# Returns a concrete instance of `DocCommand` depending on the string.
+	new(command_string: String) do
+		if command_string.has_prefix("doc:") then
+			return new ArticleCommand(command_string)
+		else if command_string.has_prefix("comment:") then
+			return new CommentCommand(command_string)
+		else if command_string.has_prefix("param:") then
+			return new ParamCommand(command_string)
+		else if command_string.has_prefix("return:") then
+			return new ReturnCommand(command_string)
+		else if command_string.has_prefix("new:") then
+			return new NewCommand(command_string)
+		else if command_string.has_prefix("call:") then
+			return new CallCommand(command_string)
+		else if command_string.has_prefix("code:") then
+			return new CodeCommand(command_string)
+		end
+		return new UnknownCommand(command_string)
+	end
+
+	redef fun to_s do return string
+end
+
+# Used to factorize initialization of DocCommands.
+abstract class AbstractDocCommand
+	super DocCommand
+
+	redef var string
+	redef var name is noinit
+	redef var args = new Array[String]
+
+	init do
+		# parse command
+		var str = new FlatBuffer
+		var i = 0
+		while i < string.length do
+			var c = string[i]
+			i += 1
+			if c == ':' then break
+			str.add c
+		end
+		name = str.write_to_string
+		# parse args
+		args.add string.substring_from(i).trim
+	end
+end
+
+# A `DocCommand` not recognized by documentation tools.
+#
+# Used to provide warnings or any other behavior for unexisting commands.
+class UnknownCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the documentation article of a `MEntity`.
+#
+# Syntax: `doc: MEntity::name`.
+class ArticleCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the MDoc of a `MEntity`.
+#
+# Syntax: `comment: MEntity::name`.
+class CommentCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the list of methods tanking a `MType` as parameter.
+#
+# Syntax: `param: MType`.
+class ParamCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the list of methods returning a `MType` as parameter.
+#
+# Syntax: `param: MType`.
+class ReturnCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the list of methods creating new instances of a specific `MType`
+#
+# Syntax: `new: MType`.
+class NewCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the list of methods calling a specific `MProperty`.
+#
+# Syntax: `call: MEntity::name`.
+class CallCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that includes the source code of a `MEntity`.
+#
+# Syntax:
+# * `code: MEntity::name`
+# * `./src/file.nit` to include source code from a file.
+# * `./src/file.nit:1,2--3,4` to select code between positions.
+class CodeCommand
+	super AbstractDocCommand
+end

--- a/src/doc/doc_down.nit
+++ b/src/doc/doc_down.nit
@@ -185,7 +185,7 @@ end
 
 redef class Model
 	# Get a markdown processor for Nitdoc comments.
-	private var nitdoc_md_processor: MarkdownProcessor is lazy do
+	var nitdoc_md_processor: MarkdownProcessor is lazy do
 		var proc = new MarkdownProcessor
 		proc.emitter.decorator = new NitdocDecorator
 		return proc
@@ -194,7 +194,7 @@ redef class Model
 	# Get a markdown inline processor for Nitdoc comments.
 	#
 	# This processor is specificaly designed to inlinable doc elements like synopsys.
-	private var nitdoc_inline_processor: MarkdownProcessor is lazy do
+	var nitdoc_inline_processor: MarkdownProcessor is lazy do
 		var proc = new MarkdownProcessor
 		proc.emitter.decorator = new InlineDecorator
 		return proc

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -375,7 +375,7 @@ redef class MClassPage
 			var def_url = "{cls_url}#{mprop.nitdoc_id}.definition"
 			var lnk = new Link(def_url, mprop.html_name)
 			var mdoc = mprop.intro.mdoc_or_fallback
-			if mdoc != null then lnk.title = mdoc.short_comment
+			if mdoc != null then lnk.title = mdoc.synopsis
 			var item = new Template
 			item.add new DocHTMLLabel.with_classes(classes)
 			item.add lnk

--- a/src/doc/doc_phases/doc_pages.nit
+++ b/src/doc/doc_phases/doc_pages.nit
@@ -26,6 +26,7 @@ class MakePagePhase
 		doc.add_page new OverviewPage("overview", "Overview")
 		doc.add_page new SearchPage("search", "Index")
 		for mgroup in doc.mgroups do
+			doc.add_page new ReadmePage(mgroup)
 			doc.add_page new MGroupPage(mgroup)
 		end
 		for mmodule in doc.mmodules do
@@ -63,6 +64,14 @@ class MEntityPage
 
 	redef var id is lazy do return mentity.nitdoc_id
 	redef var title is lazy do return mentity.nitdoc_name
+end
+
+# A page that displays a `MGroup` README.
+class ReadmePage
+	super MEntityPage
+
+	redef type MENTITY: MGroup
+	redef var id is lazy do return "readme_{mentity.nitdoc_id}"
 end
 
 # A documentation page about a MGroup.

--- a/src/doc/doc_phases/doc_readme.nit
+++ b/src/doc/doc_phases/doc_readme.nit
@@ -1,0 +1,314 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This phase parses README files.
+module doc_readme
+
+import markdown::decorators
+intrude import markdown::wikilinks
+import doc_commands
+import doc_down
+import doc_intros_redefs
+
+# Generate content of `ReadmePage`.
+#
+# This phase extracts the structure of a `ReadmePage` from the markdown content
+# of the README file.
+# It also resolves Wikilinks and commands.
+class ReadmePhase
+	super DocPhase
+
+	redef fun apply do
+		for page in doc.pages.values do page.build_content(self, doc)
+	end
+
+	# Display a warning about something wrong in the readme file.
+	fun warning(location: nullable MDLocation, page: ReadmePage, message: String) do
+		var loc = null
+		if location != null then
+			loc = location.to_location(page.mentity.mdoc.location.file)
+		end
+		ctx.warning(loc, "readme-warning", message)
+	end
+end
+
+redef class DocPage
+	# Build content of `ReadmePage` based on the content of the readme file.
+	private fun build_content(v: ReadmePhase, doc: DocModel) do end
+end
+
+redef class ReadmePage
+	redef fun build_content(v, doc) do
+		if mentity.mdoc == null then
+			v.warning(null, self, "Empty README for group `{mentity}`")
+			return
+		end
+		var proc = new MarkdownProcessor
+		proc.emitter = new ReadmeMdEmitter(proc, self, v)
+		proc.emitter.decorator = new ReadmeDecorator
+		var md = mentity.mdoc.content.join("\n")
+		proc.process(md)
+	end
+end
+
+# Markdown emitter used to produce the `ReadmeArticle`.
+class ReadmeMdEmitter
+	super MarkdownEmitter
+
+	# Readme page being decorated.
+	var page: ReadmePage
+
+	# Phase used to access doc model and toolcontext.
+	var phase: ReadmePhase
+
+	init do open_article
+
+	# Push the article template on top of the buffer stack.
+	#
+	# Subsequent markdown writting will be done in the article template.
+	#
+	# See `ReadmeArticle::md`.
+	private fun push_article(article: ReadmeArticle) do
+		buffer_stack.add article.md
+	end
+
+	private var context = new Array[DocComposite]
+
+	# Creates a new ReadmeSection in `self.toc.page`.
+	#
+	# Called from `add_headline`.
+	private fun open_section(lvl: Int, title: String) do
+		var section = new ReadmeSection(title.escape_to_c, title, lvl, processor)
+		if current_section == null then
+			page.root.add_child(section)
+		else
+			current_section.add_child(section)
+		end
+		current_section = section
+		context.add section
+	end
+	private var current_section: nullable ReadmeSection is noinit
+
+	# Close the current section.
+	#
+	# Ensure `context.last isa ReadmeSection`.
+	private fun close_section do
+		assert context.last isa ReadmeSection
+		context.pop
+		if context.is_empty then
+			current_section = null
+		else
+			current_section = context.last.as(ReadmeSection)
+		end
+	end
+
+	# Add an article at current location.
+	#
+	# This closes the current article, inserts `article` then opens a new article.
+	private fun add_article(article: DocArticle) do
+		close_article
+		if current_section == null then
+			page.root.add_child(article)
+		else
+			current_section.add_child(article)
+		end
+		open_article
+	end
+
+	# Creates a new ReadmeArticle in `self.toc.page`.
+	#
+	# Called from `add_headline`.
+	private fun open_article do
+		var section: DocComposite = page.root
+		if current_section != null then section = current_section.as(not null)
+		var article = new ReadmeArticle("mdarticle-{section.children.length}", null, processor)
+		section.add_child(article)
+		context.add article
+		push_article article
+	end
+
+	# Close the current article.
+	#
+	# Ensure `context.last isa ReadmeArticle`.
+	fun close_article do
+		assert context.last isa ReadmeArticle
+		context.pop
+		pop_buffer
+	end
+end
+
+# MarkdownDecorator used to decorated the Readme file with links between doc entities.
+class ReadmeDecorator
+	super MdDecorator
+
+	redef type EMITTER: ReadmeMdEmitter
+
+	redef fun add_headline(v, block) do
+		var txt = block.block.first_line.value
+		var lvl = block.depth
+		if not v.context.is_empty then
+			v.close_article
+			while v.current_section != null do
+				if v.current_section.depth < lvl then break
+				v.close_section
+			end
+		end
+		v.open_section(lvl, txt)
+		v.open_article
+	end
+
+	redef fun add_wikilink(v, token) do
+		var link = token.link.to_s
+		var cmd = new DocCommand(link)
+		if cmd isa UnknownCommand then
+			# search MEntities by name
+			var res = v.phase.doc.mentities_by_name(link.to_s)
+			# no match, print warning and display wikilink as is
+			if res.is_empty then
+				v.phase.warning(token.location, v.page, "Link to unknown entity `{link}`")
+				super
+			else
+				add_mentity_link(v, res.first, token.name, token.comment)
+			end
+			return
+		end
+		cmd.render(v, token)
+	end
+
+	# Renders a link to a mentity.
+	private fun add_mentity_link(v: EMITTER, mentity: MEntity, name, comment: nullable Text) do
+		# TODO real link
+		var link = mentity.full_name
+		if name == null then name = mentity.name
+		if comment == null and mentity.mdoc != null then
+			comment = mentity.mdoc.synopsis
+		end
+		add_link(v, link, name, comment)
+	end
+end
+
+redef interface DocCommand
+
+	# Render the content of the doc command.
+	fun render(v: ReadmeMdEmitter, token: TokenWikiLink) is abstract
+
+	# Search `doc` model for mentities match `string`.
+	fun search_model(doc: DocModel, string: String): Array[MEntity] do
+		var res
+		if string.has("::") then
+			res = doc.mentities_by_namespace(string).to_a
+		else
+			res = doc.mentities_by_name(string).to_a
+		end
+		return res
+	end
+end
+
+redef class ArticleCommand
+	redef fun render(v, token) do
+		var string = args.first
+		var res = search_model(v.phase.doc, string)
+		res = filter_results(res)
+		if res.is_empty then
+			v.phase.warning(
+				token.location, v.page,
+				"Try to include documentation of unknown entity `{args.first}`")
+			return
+		end
+		if res.length > 1 then
+			v.phase.warning(token.location, v.page, "conflicting article for `{args.first}` (choices : {res.join(", ")})")
+		end
+		v.add_article new DocumentationArticle("readme", "Readme", res.first)
+	end
+
+	private fun filter_results(res: Array[MEntity]): Array[MEntity] do
+		var out = new Array[MEntity]
+		for e in res do
+			if e isa MProject then continue
+			if e isa MGroup then continue
+			out.add e
+		end
+		return out
+	end
+end
+
+redef class ListCommand
+	redef fun render(v, token) do
+		var string = args.first
+		var res = search_model(v.phase.doc, string)
+		if res.is_empty then
+			v.phase.warning(token.location, v.page, "include article for unknown entity `{args.first}`")
+			return
+		end
+		if res.length > 1 then
+			v.phase.warning(token.location, v.page, "conflicting article for `{args.first}` (choices : {res.join(", ")})")
+		end
+		var mentity = res.first
+		if mentity isa MModule then
+			v.add_article new MEntitiesListArticle("Classes", mentity.mclassdefs)
+		else if mentity isa MClass then
+			var mprops = mentity.collect_intro_mproperties(public_visibility)
+			v.add_article new MEntitiesListArticle("Methods", mprops.to_a)
+		else if mentity isa MClassDef then
+			v.add_article new MEntitiesListArticle("Methods", mentity.mpropdefs)
+		end
+	end
+end
+
+
+# A section found in a README.
+#
+# Produced by markdown headlines like `## Section 1.1`.
+class ReadmeSection
+	super DocSection
+
+	# The depth is based on the markdown headline depth.
+	redef var depth
+
+	# Markdown processor used to process the section title.
+	var markdown_processor: MarkdownProcessor
+
+	redef var is_hidden = false
+end
+
+# An article found in a README file.
+#
+# Basically, everything found in a README that is not a headline.
+class ReadmeArticle
+	super DocArticle
+
+	# Markdown processor used to process the article content.
+	var markdown_processor: MarkdownProcessor
+
+	# Markdown content of this article extracted from the README file.
+	var md = new FlatBuffer
+
+	redef fun is_hidden do return super and md.trim.is_empty
+end
+
+# Documentation Article to introduce from the directive `doc: Something`.
+#
+# TODO merge with DefinitionArticle once the html is simplified
+class DocumentationArticle
+	super MEntityArticle
+
+	redef var is_hidden = false
+end
+
+redef class MDLocation
+	# Translate a Markdown location in Nit location.
+	private fun to_location(file: nullable SourceFile): Location do
+		return new Location(file, line_start, line_end, column_start, column_end)
+	end
+end

--- a/src/doc/html_templates/html_model.nit
+++ b/src/doc/html_templates/html_model.nit
@@ -44,7 +44,7 @@ redef class MEntity
 		var tpl = new Link(nitdoc_url, html_name)
 		var mdoc = mdoc_or_fallback
 		if mdoc != null then
-			tpl.title = mdoc.short_comment
+			tpl.title = mdoc.synopsis
 		end
 		return tpl
 	end
@@ -56,7 +56,7 @@ redef class MEntity
 		var tpl = new Link("#{nitdoc_id}", html_name)
 		var mdoc = mdoc_or_fallback
 		if mdoc != null then
-			tpl.title = mdoc.short_comment
+			tpl.title = mdoc.synopsis
 		end
 		return tpl
 	end
@@ -94,18 +94,25 @@ redef class MEntity
 	# * MPropdef: `mclassdef:mpropdef`
 	fun html_namespace: Template is abstract
 
-	# Returns the comment of this MEntity formatted as HTML.
+	# Returns the synopsis and the comment of this MEntity formatted as HTML.
+	var html_documentation: nullable Writable is lazy do
+		var mdoc = mdoc_or_fallback
+		if mdoc == null then return null
+		return mdoc.html_documentation
+	end
+
+	# Returns the synopsis of this MEntity formatted as HTML.
+	var html_synopsis: nullable Writable is lazy do
+		var mdoc = mdoc_or_fallback
+		if mdoc == null then return null
+		return mdoc.html_synopsis
+	end
+
+	# Returns the the comment without the synopsis formatted as HTML.
 	var html_comment: nullable Writable is lazy do
 		var mdoc = mdoc_or_fallback
 		if mdoc == null then return null
-		return mdoc.tpl_comment
-	end
-
-	# Returns the comment of this MEntity formatted as HTML.
-	var html_short_comment: nullable Writable is lazy do
-		var mdoc = mdoc_or_fallback
-		if mdoc == null then return null
-		return mdoc.tpl_short_comment
+		return mdoc.html_comment
 	end
 
 	# Icon that will be displayed before the title
@@ -125,7 +132,7 @@ redef class MEntity
 		var tpl = new Template
 		tpl.add new DocHTMLLabel.with_classes(css_classes)
 		tpl.add html_link
-		var comment = html_short_comment
+		var comment = html_synopsis
 		if comment != null then
 			tpl.add ": "
 			tpl.add comment
@@ -688,7 +695,7 @@ redef class MConcern
 		var lnk = html_link
 		var tpl = new Template
 		tpl.add new Link.with_title("#{nitdoc_id}.concern", lnk.text, lnk.title)
-		var comment = html_short_comment
+		var comment = html_synopsis
 		if comment != null then
 			tpl.add ": "
 			tpl.add comment

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -446,7 +446,7 @@ redef class IntroArticle
 
 	redef fun render_body do
 		var tabs = new DocTabs("{html_id}.tabs", "")
-		var comment = mentity.html_comment
+		var comment = mentity.html_documentation
 		if comment != null then
 			tabs.add_panel new DocTabPanel("{html_tab_id}-comment", "Comment", comment)
 		end
@@ -502,9 +502,9 @@ redef class DefinitionArticle
 		if not is_no_body then
 			var comment
 			if is_short_comment then
-				comment = mentity.html_short_comment
+				comment = mentity.html_synopsis
 			else
-				comment = mentity.html_comment
+				comment = mentity.html_documentation
 			end
 			if comment != null then
 				tabs.add_panel new DocTabPanel("{html_tab_id}-comment", "Comment", comment)
@@ -542,7 +542,7 @@ redef class DefinitionLinArticle
 			if not mentity isa MPropDef then continue # TODO handle all mentities
 			var tpl = new Template
 			tpl.add mentity.mclassdef.html_namespace
-			var comment = mentity.mclassdef.html_short_comment
+			var comment = mentity.mclassdef.html_synopsis
 			if comment != null then
 				tpl.add ": "
 				tpl.add comment

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -265,7 +265,6 @@ redef class DocComposite
 		if html_title != null then
 		var header = new Header(hlvl, html_title.write_to_string)
 		header.css_classes.add "signature"
-		if hlvl == 2 then header.css_classes.add "well well-sm"
 		addn header
 		end
 		if html_subtitle != null then

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -479,11 +479,21 @@ redef class ModelBuilder
 	# Load a markdown file as a documentation object
 	fun load_markdown(filepath: String): MDoc
 	do
-		var mdoc = new MDoc(new Location(new SourceFile.from_string(filepath, ""),0,0,0,0))
 		var s = new FileReader.open(filepath)
+		var lines = new Array[String]
+		var line_starts = new Array[Int]
+		var len = 1
 		while not s.eof do
-			mdoc.content.add(s.read_line)
+			var line = s.read_line
+			lines.add(line)
+			line_starts.add(len)
+			len += line.length + 1
 		end
+		s.close
+		var source = new SourceFile.from_string(filepath, lines.join("\n"))
+		source.line_starts.add_all line_starts
+		var mdoc = new MDoc(new Location(source, 1, lines.length, 0, 0))
+		mdoc.content.add_all(lines)
 		return mdoc
 	end
 

--- a/src/location.nit
+++ b/src/location.nit
@@ -42,7 +42,9 @@ class SourceFile
 		line_starts[0] = 0
 	end
 
-	# Position of each line start
+	# Offset of each line start in the content `string`.
+	#
+	# Used for fast access to each line when rendering parts of the `string`.
 	var line_starts = new Array[Int]
 end
 

--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -51,7 +51,8 @@ private class Nitdoc
 			new InheritanceListsPhase(toolcontext, doc),
 			new IntroRedefListPhase(toolcontext, doc),
 			new LinListPhase(toolcontext, doc),
-			new GraphPhase(toolcontext, doc): DocPhase]
+			new GraphPhase(toolcontext, doc),
+			new ReadmePhase(toolcontext, doc): DocPhase]
 
 		if not toolcontext.opt_test.value then
 			phases.add new RenderHTMLPhase(toolcontext, doc)

--- a/tests/sav/nitdoc_args1.res
+++ b/tests/sav/nitdoc_args1.res
@@ -1,3 +1,6 @@
+Empty README for group `module_1` (readme-warning)
+Empty README for group `module_0` (readme-warning)
+Errors: 0. Warnings: 2.
 class_module_95d0-__Int.html
 class_module_95d0-__Object.html
 class_module_95d0-__Sys.html

--- a/tests/sav/nitdoc_args2.res
+++ b/tests/sav/nitdoc_args2.res
@@ -1,3 +1,5 @@
+Empty README for group `base_attr_nullable` (readme-warning)
+Errors: 0. Warnings: 1.
 class_base_attr_nullable-__Bar.html
 class_base_attr_nullable-__Bool.html
 class_base_attr_nullable-__Foo.html

--- a/tests/sav/nitdoc_args3.res
+++ b/tests/sav/nitdoc_args3.res
@@ -1,3 +1,5 @@
+Empty README for group `base_attr_nullable` (readme-warning)
+Errors: 0. Warnings: 1.
 class_base_attr_nullable-__Bar.html
 class_base_attr_nullable-__Bool.html
 class_base_attr_nullable-__Foo.html

--- a/tests/sav/nitdoc_args4.res
+++ b/tests/sav/nitdoc_args4.res
@@ -3,6 +3,18 @@ OverviewPage Overview
 		## projects.section
 			### test_prog.definition
 
+ReadmePage test_prog
+	# mdarticle-0
+
+ReadmePage game
+	# mdarticle-0
+
+ReadmePage platform
+	# mdarticle-0
+
+ReadmePage rpg
+	# mdarticle-0
+
 SearchPage Index
 	# index.article
 
@@ -940,14 +952,15 @@ MModulePage rpg
 				#### test_prog__rpg__rpg.imports
 				#### test_prog__rpg__rpg.clients
 
-Generated 81 pages
+Generated 85 pages
  list:
-  MPropertyPage: 47 (58.02%)
-  MClassPage: 20 (24.69%)
-  MModulePage: 8 (9.87%)
-  MGroupPage: 4 (4.93%)
-  SearchPage: 1 (1.23%)
-  OverviewPage: 1 (1.23%)
+  MPropertyPage: 47 (55.29%)
+  MClassPage: 20 (23.52%)
+  MModulePage: 8 (9.41%)
+  MGroupPage: 4 (4.70%)
+  ReadmePage: 4 (4.70%)
+  SearchPage: 1 (1.17%)
+  OverviewPage: 1 (1.17%)
 Found 160 mentities
  list:
   MMethodDef: 57 (35.62%)

--- a/tests/sav/nitunit_args6.res
+++ b/tests/sav/nitunit_args6.res
@@ -1,5 +1,5 @@
-test_nitunit3/README.md: Error: there is a block of invalid Nit code, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,2--4: Syntax Error: unexpected malformed character '\]..
-test_nitunit3/README.md: ERROR: nitunit.test_nitunit3.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
+test_nitunit3/README.md:1,0--13,0: Error: there is a block of invalid Nit code, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,2--4: Syntax Error: unexpected malformed character '\]..
+test_nitunit3/README.md:1,0--13,0: ERROR: nitunit.test_nitunit3.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
 
 DocUnits:
 Entities: 2; Documented ones: 2; With nitunits: 3; Failures: 2
@@ -7,7 +7,7 @@ Entities: 2; Documented ones: 2; With nitunits: 3; Failures: 2
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_nitunit3"><testcase classname="nitunit.test_nitunit3" name="&lt;group&gt;"><failure message="test_nitunit3&#47;README.md: Invalid block of code. At 1,2--4: Syntax Error: unexpected malformed character &#39;\].."></failure><system-err></system-err><system-out>assert false
+<testsuites><testsuite package="test_nitunit3"><testcase classname="nitunit.test_nitunit3" name="&lt;group&gt;"><failure message="test_nitunit3&#47;README.md:1,0--13,0: Invalid block of code. At 1,2--4: Syntax Error: unexpected malformed character &#39;\].."></failure><system-err></system-err><system-out>assert false
 assert true
 </system-out><error message="Runtime error: Assert failed (.nitunit&#47;test_nitunit3-0.nit:7)
 "></error></testcase></testsuite><testsuite package="test_nitunit3"><testcase classname="nitunit.test_nitunit3.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true

--- a/tests/sav/nitunit_args7.res
+++ b/tests/sav/nitunit_args7.res
@@ -1,4 +1,4 @@
-test_nitunit_md.md: ERROR: nitunit.<file>.test_nitunit_md.md (in .nitunit/file-0.nit): Runtime error: Assert failed (.nitunit/file-0.nit:8)
+test_nitunit_md.md:1,0--15,0: ERROR: nitunit.<file>.test_nitunit_md.md:1,0--15,0 (in .nitunit/file-0.nit): Runtime error: Assert failed (.nitunit/file-0.nit:8)
 
 DocUnits:
 Entities: 1; Documented ones: 1; With nitunits: 1; Failures: 1
@@ -6,7 +6,7 @@ Entities: 1; Documented ones: 1; With nitunits: 1; Failures: 1
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_nitunit_md.md"><testcase classname="nitunit.&lt;file&gt;" name="test_nitunit_md.md"><system-err></system-err><system-out>var a = 1
+<testsuites><testsuite package="test_nitunit_md.md:1,0--15,0"><testcase classname="nitunit.&lt;file&gt;" name="test_nitunit_md.md:1,0--15,0"><system-err></system-err><system-out>var a = 1
 assert 1 == 1
 assert false
 </system-out><error message="Runtime error: Assert failed (.nitunit&#47;file-0.nit:8)


### PR DESCRIPTION
This PR introduce the use of wikilinks in README files.

It's mainly a request for comments on what you want, what you need and what you like from Nitdoc and README writting.

0f6ff78 gives an example of README file written using wikilinks. The processed result by nitdoc is visible [here](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/group_github.html).

Supported commands for now:

* `[[doc:MEntity]]`: include the documentation article or an MEntity
* `[[list:MEntity]]`: list classes or methods from than MEntity

Old API pages still available, there are prefixed with `api_`.

Demos from [Jenkins::CI-nitdoc](http://gresil.org/jenkins/job/CI-nitdoc):
* [Standard library](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/index.html)
* [Nit compilers and tools](http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/nitc/index.html)

Some question still need to be answered:
* What to do with old API page (http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/api_group_github.html)
* What comment to display in API page (http://gresil.org/jenkins/job/CI-nitdoc/ws/doc/stdlib/api_group_github.html)
* What commands should be supported by wikilinks directive?
