### PR TITLE
Kill big vararg in parser

### DIFF
--- a/src/parser/parser.nit
+++ b/src/parser/parser.nit
@@ -9,1124 +9,1124 @@ private import tables
 redef class Parser
 	redef fun build_reduce_table
 	do
-		_reduce_table = new Array[ReduceAction].with_items(
-			new ReduceAction0(0),
-			new ReduceAction1(0),
-			new ReduceAction2(0),
-			new ReduceAction3(0),
-			new ReduceAction4(0),
-			new ReduceAction5(0),
-			new ReduceAction6(0),
-			new ReduceAction7(0),
-			new ReduceAction8(0),
-			new ReduceAction9(0),
-			new ReduceAction10(0),
-			new ReduceAction11(0),
-			new ReduceAction12(0),
-			new ReduceAction13(0),
-			new ReduceAction14(0),
-			new ReduceAction15(0),
-			new ReduceAction16(1),
-			new ReduceAction17(2),
-			new ReduceAction18(2),
-			new ReduceAction19(3),
-			new ReduceAction20(3),
-			new ReduceAction21(4),
-			new ReduceAction22(4),
-			new ReduceAction23(4),
-			new ReduceAction24(5),
-			new ReduceAction24(5),
-			new ReduceAction26(6),
-			new ReduceAction27(6),
-			new ReduceAction28(6),
-			new ReduceAction29(6),
-			new ReduceAction22(7),
-			new ReduceAction31(7),
-			new ReduceAction32(8),
-			new ReduceAction33(8),
-			new ReduceAction34(8),
-			new ReduceAction35(8),
-			new ReduceAction36(8),
-			new ReduceAction37(9),
-			new ReduceAction38(9),
-			new ReduceAction39(9),
-			new ReduceAction40(10),
-			new ReduceAction41(11),
-			new ReduceAction42(11),
-			new ReduceAction43(12),
-			new ReduceAction44(13),
-			new ReduceAction45(13),
-			new ReduceAction46(13),
-			new ReduceAction47(14),
-			new ReduceAction48(15),
-			new ReduceAction49(15),
-			new ReduceAction50(15),
-			new ReduceAction51(15),
-			new ReduceAction52(15),
-			new ReduceAction53(15),
-			new ReduceAction54(15),
-			new ReduceAction55(15),
-			new ReduceAction56(15),
-			new ReduceAction57(15),
-			new ReduceAction58(15),
-			new ReduceAction59(15),
-			new ReduceAction60(15),
-			new ReduceAction61(15),
-			new ReduceAction62(15),
-			new ReduceAction63(15),
-			new ReduceAction64(15),
-			new ReduceAction65(15),
-			new ReduceAction66(15),
-			new ReduceAction67(15),
-			new ReduceAction68(15),
-			new ReduceAction69(15),
-			new ReduceAction70(15),
-			new ReduceAction71(15),
-			new ReduceAction72(15),
-			new ReduceAction73(15),
-			new ReduceAction74(15),
-			new ReduceAction74(15),
-			new ReduceAction76(16),
-			new ReduceAction77(16),
-			new ReduceAction22(16),
-			new ReduceAction76(17),
-			new ReduceAction80(17),
-			new ReduceAction81(18),
-			new ReduceAction82(18),
-			new ReduceAction83(18),
-			new ReduceAction84(18),
-			new ReduceAction85(18),
-			new ReduceAction86(19),
-			new ReduceAction87(19),
-			new ReduceAction88(19),
-			new ReduceAction89(19),
-			new ReduceAction90(19),
-			new ReduceAction91(19),
-			new ReduceAction92(19),
-			new ReduceAction93(19),
-			new ReduceAction94(19),
-			new ReduceAction95(19),
-			new ReduceAction96(19),
-			new ReduceAction97(19),
-			new ReduceAction98(19),
-			new ReduceAction99(19),
-			new ReduceAction100(19),
-			new ReduceAction101(19),
-			new ReduceAction102(19),
-			new ReduceAction103(19),
-			new ReduceAction104(19),
-			new ReduceAction105(19),
-			new ReduceAction106(19),
-			new ReduceAction107(19),
-			new ReduceAction108(19),
-			new ReduceAction109(20),
-			new ReduceAction110(20),
-			new ReduceAction111(20),
-			new ReduceAction112(20),
-			new ReduceAction113(21),
-			new ReduceAction114(21),
-			new ReduceAction39(21),
-			new ReduceAction116(22),
-			new ReduceAction117(23),
-			new ReduceAction118(23),
-			new ReduceAction119(23),
-			new ReduceAction120(23),
-			new ReduceAction121(23),
-			new ReduceAction122(24),
-			new ReduceAction123(24),
-			new ReduceAction22(24),
-			new ReduceAction125(25),
-			new ReduceAction126(26),
-			new ReduceAction126(26),
-			new ReduceAction128(26),
-			new ReduceAction129(27),
-			new ReduceAction130(27),
-			new ReduceAction131(27),
-			new ReduceAction132(28),
-			new ReduceAction133(28),
-			new ReduceAction134(28),
-			new ReduceAction135(28),
-			new ReduceAction136(28),
-			new ReduceAction137(28),
-			new ReduceAction22(29),
-			new ReduceAction139(29),
-			new ReduceAction140(30),
-			new ReduceAction141(31),
-			new ReduceAction142(31),
-			new ReduceAction143(32),
-			new ReduceAction22(32),
-			new ReduceAction145(33),
-			new ReduceAction146(34),
-			new ReduceAction147(34),
-			new ReduceAction148(34),
-			new ReduceAction149(34),
-			new ReduceAction150(35),
-			new ReduceAction151(35),
-			new ReduceAction152(36),
-			new ReduceAction152(37),
-			new ReduceAction152(38),
-			new ReduceAction22(38),
-			new ReduceAction156(39),
-			new ReduceAction157(39),
-			new ReduceAction158(39),
-			new ReduceAction159(39),
-			new ReduceAction160(40),
-			new ReduceAction161(40),
-			new ReduceAction162(41),
-			new ReduceAction163(41),
-			new ReduceAction164(42),
-			new ReduceAction165(42),
-			new ReduceAction156(43),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction169(44),
-			new ReduceAction170(44),
-			new ReduceAction171(44),
-			new ReduceAction172(44),
-			new ReduceAction173(44),
-			new ReduceAction174(44),
-			new ReduceAction175(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction159(44),
-			new ReduceAction183(44),
-			new ReduceAction184(44),
-			new ReduceAction185(44),
-			new ReduceAction184(44),
-			new ReduceAction187(44),
-			new ReduceAction188(44),
-			new ReduceAction189(44),
-			new ReduceAction188(44),
-			new ReduceAction191(44),
-			new ReduceAction192(44),
-			new ReduceAction193(44),
-			new ReduceAction194(44),
-			new ReduceAction195(44),
-			new ReduceAction194(44),
-			new ReduceAction197(44),
-			new ReduceAction198(44),
-			new ReduceAction197(44),
-			new ReduceAction200(44),
-			new ReduceAction201(45),
-			new ReduceAction202(45),
-			new ReduceAction203(46),
-			new ReduceAction204(46),
-			new ReduceAction205(46),
-			new ReduceAction206(46),
-			new ReduceAction207(47),
-			new ReduceAction208(47),
-			new ReduceAction209(47),
-			new ReduceAction210(47),
-			new ReduceAction211(47),
-			new ReduceAction212(47),
-			new ReduceAction213(47),
-			new ReduceAction214(47),
-			new ReduceAction211(47),
-			new ReduceAction212(47),
-			new ReduceAction217(47),
-			new ReduceAction218(47),
-			new ReduceAction219(47),
-			new ReduceAction220(47),
-			new ReduceAction221(47),
-			new ReduceAction222(47),
-			new ReduceAction219(47),
-			new ReduceAction220(47),
-			new ReduceAction225(47),
-			new ReduceAction226(47),
-			new ReduceAction227(47),
-			new ReduceAction228(47),
-			new ReduceAction229(47),
-			new ReduceAction230(47),
-			new ReduceAction231(47),
-			new ReduceAction232(47),
-			new ReduceAction233(47),
-			new ReduceAction230(47),
-			new ReduceAction231(47),
-			new ReduceAction236(47),
-			new ReduceAction237(47),
-			new ReduceAction238(47),
-			new ReduceAction239(47),
-			new ReduceAction240(47),
-			new ReduceAction241(47),
-			new ReduceAction238(47),
-			new ReduceAction239(47),
-			new ReduceAction244(47),
-			new ReduceAction245(48),
-			new ReduceAction246(48),
-			new ReduceAction247(48),
-			new ReduceAction248(48),
-			new ReduceAction249(48),
-			new ReduceAction250(48),
-			new ReduceAction251(48),
-			new ReduceAction252(48),
-			new ReduceAction253(48),
-			new ReduceAction254(48),
-			new ReduceAction255(48),
-			new ReduceAction256(49),
-			new ReduceAction257(49),
-			new ReduceAction258(50),
-			new ReduceAction259(50),
-			new ReduceAction260(50),
-			new ReduceAction261(50),
-			new ReduceAction262(50),
-			new ReduceAction263(50),
-			new ReduceAction264(50),
-			new ReduceAction265(50),
-			new ReduceAction158(51),
-			new ReduceAction267(52),
-			new ReduceAction268(52),
-			new ReduceAction269(53),
-			new ReduceAction270(53),
-			new ReduceAction271(54),
-			new ReduceAction272(54),
-			new ReduceAction273(55),
-			new ReduceAction274(55),
-			new ReduceAction275(56),
-			new ReduceAction276(56),
-			new ReduceAction159(56),
-			new ReduceAction278(57),
-			new ReduceAction279(57),
-			new ReduceAction280(57),
-			new ReduceAction281(57),
-			new ReduceAction282(58),
-			new ReduceAction159(59),
-			new ReduceAction284(59),
-			new ReduceAction159(60),
-			new ReduceAction286(60),
-			new ReduceAction287(60),
-			new ReduceAction288(60),
-			new ReduceAction289(60),
-			new ReduceAction159(61),
-			new ReduceAction291(61),
-			new ReduceAction159(62),
-			new ReduceAction293(62),
-			new ReduceAction294(62),
-			new ReduceAction295(62),
-			new ReduceAction296(62),
-			new ReduceAction297(62),
-			new ReduceAction298(62),
-			new ReduceAction299(62),
-			new ReduceAction300(62),
-			new ReduceAction159(63),
-			new ReduceAction302(63),
-			new ReduceAction159(64),
-			new ReduceAction304(64),
-			new ReduceAction159(65),
-			new ReduceAction306(65),
-			new ReduceAction159(66),
-			new ReduceAction308(66),
-			new ReduceAction309(66),
-			new ReduceAction159(67),
-			new ReduceAction311(67),
-			new ReduceAction312(67),
-			new ReduceAction159(68),
-			new ReduceAction314(68),
-			new ReduceAction315(68),
-			new ReduceAction316(68),
-			new ReduceAction159(69),
-			new ReduceAction318(69),
-			new ReduceAction159(70),
-			new ReduceAction320(70),
-			new ReduceAction321(70),
-			new ReduceAction322(70),
-			new ReduceAction323(70),
-			new ReduceAction159(71),
-			new ReduceAction325(71),
-			new ReduceAction326(71),
-			new ReduceAction327(71),
-			new ReduceAction328(71),
-			new ReduceAction159(72),
-			new ReduceAction330(72),
-			new ReduceAction331(72),
-			new ReduceAction183(72),
-			new ReduceAction333(72),
-			new ReduceAction184(72),
-			new ReduceAction335(72),
-			new ReduceAction185(72),
-			new ReduceAction337(72),
-			new ReduceAction184(72),
-			new ReduceAction335(72),
-			new ReduceAction187(72),
-			new ReduceAction341(72),
-			new ReduceAction188(72),
-			new ReduceAction343(72),
-			new ReduceAction189(72),
-			new ReduceAction345(72),
-			new ReduceAction188(72),
-			new ReduceAction343(72),
-			new ReduceAction191(72),
-			new ReduceAction349(72),
-			new ReduceAction192(72),
-			new ReduceAction351(72),
-			new ReduceAction193(72),
-			new ReduceAction353(72),
-			new ReduceAction354(72),
-			new ReduceAction355(72),
-			new ReduceAction356(72),
-			new ReduceAction357(72),
-			new ReduceAction358(72),
-			new ReduceAction359(72),
-			new ReduceAction360(72),
-			new ReduceAction357(72),
-			new ReduceAction358(72),
-			new ReduceAction363(72),
-			new ReduceAction364(72),
-			new ReduceAction365(72),
-			new ReduceAction159(73),
-			new ReduceAction367(73),
-			new ReduceAction368(73),
-			new ReduceAction369(74),
-			new ReduceAction370(74),
-			new ReduceAction371(74),
-			new ReduceAction372(74),
-			new ReduceAction373(74),
-			new ReduceAction374(74),
-			new ReduceAction375(74),
-			new ReduceAction376(74),
-			new ReduceAction377(74),
-			new ReduceAction378(74),
-			new ReduceAction379(74),
-			new ReduceAction380(74),
-			new ReduceAction381(74),
-			new ReduceAction382(74),
-			new ReduceAction383(74),
-			new ReduceAction159(74),
-			new ReduceAction159(74),
-			new ReduceAction386(74),
-			new ReduceAction387(74),
-			new ReduceAction388(74),
-			new ReduceAction389(75),
-			new ReduceAction389(75),
-			new ReduceAction391(76),
-			new ReduceAction392(77),
-			new ReduceAction393(78),
-			new ReduceAction394(78),
-			new ReduceAction392(79),
-			new ReduceAction396(80),
-			new ReduceAction272(80),
-			new ReduceAction398(80),
-			new ReduceAction399(81),
-			new ReduceAction400(81),
-			new ReduceAction401(82),
-			new ReduceAction402(82),
-			new ReduceAction403(83),
-			new ReduceAction401(84),
-			new ReduceAction402(84),
-			new ReduceAction406(85),
-			new ReduceAction407(86),
-			new ReduceAction408(87),
-			new ReduceAction409(87),
-			new ReduceAction410(88),
-			new ReduceAction22(88),
-			new ReduceAction412(89),
-			new ReduceAction413(89),
-			new ReduceAction414(90),
-			new ReduceAction415(90),
-			new ReduceAction412(91),
-			new ReduceAction413(91),
-			new ReduceAction418(91),
-			new ReduceAction159(92),
-			new ReduceAction420(93),
-			new ReduceAction421(94),
-			new ReduceAction422(94),
-			new ReduceAction423(94),
-			new ReduceAction424(94),
-			new ReduceAction425(94),
-			new ReduceAction426(95),
-			new ReduceAction427(95),
-			new ReduceAction428(95),
-			new ReduceAction429(95),
-			new ReduceAction430(95),
-			new ReduceAction393(96),
-			new ReduceAction394(96),
-			new ReduceAction392(97),
-			new ReduceAction434(98),
-			new ReduceAction159(98),
-			new ReduceAction159(98),
-			new ReduceAction437(98),
-			new ReduceAction438(98),
-			new ReduceAction439(98),
-			new ReduceAction440(99),
-			new ReduceAction441(99),
-			new ReduceAction442(99),
-			new ReduceAction443(100),
-			new ReduceAction444(100),
-			new ReduceAction443(101),
-			new ReduceAction446(101),
-			new ReduceAction444(101),
-			new ReduceAction448(101),
-			new ReduceAction449(102),
-			new ReduceAction402(103),
-			new ReduceAction451(103),
-			new ReduceAction452(104),
-			new ReduceAction453(105),
-			new ReduceAction454(105),
-			new ReduceAction455(106),
-			new ReduceAction456(106),
-			new ReduceAction457(107),
-			new ReduceAction458(107),
-			new ReduceAction459(107),
-			new ReduceAction460(107),
-			new ReduceAction461(108),
-			new ReduceAction462(108),
-			new ReduceAction463(108),
-			new ReduceAction22(108),
-			new ReduceAction465(109),
-			new ReduceAction466(109),
-			new ReduceAction467(109),
-			new ReduceAction466(109),
-			new ReduceAction469(110),
-			new ReduceAction470(110),
-			new ReduceAction471(110),
-			new ReduceAction470(110),
-			new ReduceAction473(111),
-			new ReduceAction474(112),
-			new ReduceAction22(113),
-			new ReduceAction476(113),
-			new ReduceAction477(114),
-			new ReduceAction477(114),
-			new ReduceAction477(114),
-			new ReduceAction480(115),
-			new ReduceAction481(115),
-			new ReduceAction23(115),
-			new ReduceAction23(115),
-			new ReduceAction484(115),
-			new ReduceAction484(115),
-			new ReduceAction486(115),
-			new ReduceAction487(115),
-			new ReduceAction488(115),
-			new ReduceAction488(115),
-			new ReduceAction490(115),
-			new ReduceAction22(116),
-			new ReduceAction492(116),
-			new ReduceAction493(117),
-			new ReduceAction477(117),
-			new ReduceAction477(118),
-			new ReduceAction496(118),
-			new ReduceAction48(119),
-			new ReduceAction49(119),
-			new ReduceAction50(119),
-			new ReduceAction57(119),
-			new ReduceAction58(119),
-			new ReduceAction76(120),
-			new ReduceAction77(120),
-			new ReduceAction86(121),
-			new ReduceAction87(121),
-			new ReduceAction88(121),
-			new ReduceAction89(121),
-			new ReduceAction90(121),
-			new ReduceAction91(121),
-			new ReduceAction92(121),
-			new ReduceAction93(121),
-			new ReduceAction94(121),
-			new ReduceAction95(121),
-			new ReduceAction96(121),
-			new ReduceAction97(121),
-			new ReduceAction98(121),
-			new ReduceAction99(121),
-			new ReduceAction100(121),
-			new ReduceAction101(121),
-			new ReduceAction102(121),
-			new ReduceAction103(121),
-			new ReduceAction104(121),
-			new ReduceAction105(121),
-			new ReduceAction106(121),
-			new ReduceAction107(121),
-			new ReduceAction469(122),
-			new ReduceAction470(122),
-			new ReduceAction471(122),
-			new ReduceAction470(122),
-			new ReduceAction146(123),
-			new ReduceAction147(123),
-			new ReduceAction159(124),
-			new ReduceAction284(124),
-			new ReduceAction159(125),
-			new ReduceAction286(125),
-			new ReduceAction287(125),
-			new ReduceAction288(125),
-			new ReduceAction289(125),
-			new ReduceAction159(126),
-			new ReduceAction291(126),
-			new ReduceAction159(127),
-			new ReduceAction293(127),
-			new ReduceAction294(127),
-			new ReduceAction295(127),
-			new ReduceAction296(127),
-			new ReduceAction297(127),
-			new ReduceAction298(127),
-			new ReduceAction299(127),
-			new ReduceAction300(127),
-			new ReduceAction159(128),
-			new ReduceAction302(128),
-			new ReduceAction159(129),
-			new ReduceAction304(129),
-			new ReduceAction159(130),
-			new ReduceAction306(130),
-			new ReduceAction159(131),
-			new ReduceAction308(131),
-			new ReduceAction309(131),
-			new ReduceAction159(132),
-			new ReduceAction311(132),
-			new ReduceAction312(132),
-			new ReduceAction159(133),
-			new ReduceAction314(133),
-			new ReduceAction315(133),
-			new ReduceAction316(133),
-			new ReduceAction159(134),
-			new ReduceAction318(134),
-			new ReduceAction159(135),
-			new ReduceAction320(135),
-			new ReduceAction321(135),
-			new ReduceAction322(135),
-			new ReduceAction323(135),
-			new ReduceAction159(136),
-			new ReduceAction325(136),
-			new ReduceAction326(136),
-			new ReduceAction327(136),
-			new ReduceAction328(136),
-			new ReduceAction159(137),
-			new ReduceAction330(137),
-			new ReduceAction331(137),
-			new ReduceAction183(137),
-			new ReduceAction187(137),
-			new ReduceAction333(137),
-			new ReduceAction341(137),
-			new ReduceAction184(137),
-			new ReduceAction188(137),
-			new ReduceAction335(137),
-			new ReduceAction343(137),
-			new ReduceAction185(137),
-			new ReduceAction189(137),
-			new ReduceAction337(137),
-			new ReduceAction345(137),
-			new ReduceAction184(137),
-			new ReduceAction188(137),
-			new ReduceAction335(137),
-			new ReduceAction343(137),
-			new ReduceAction191(137),
-			new ReduceAction349(137),
-			new ReduceAction192(137),
-			new ReduceAction193(137),
-			new ReduceAction351(137),
-			new ReduceAction353(137),
-			new ReduceAction355(137),
-			new ReduceAction356(137),
-			new ReduceAction357(137),
-			new ReduceAction358(137),
-			new ReduceAction359(137),
-			new ReduceAction360(137),
-			new ReduceAction357(137),
-			new ReduceAction358(137),
-			new ReduceAction363(137),
-			new ReduceAction364(137),
-			new ReduceAction365(137),
-			new ReduceAction159(138),
-			new ReduceAction367(138),
-			new ReduceAction368(138),
-			new ReduceAction369(139),
-			new ReduceAction370(139),
-			new ReduceAction371(139),
-			new ReduceAction372(139),
-			new ReduceAction373(139),
-			new ReduceAction374(139),
-			new ReduceAction375(139),
-			new ReduceAction376(139),
-			new ReduceAction377(139),
-			new ReduceAction378(139),
-			new ReduceAction379(139),
-			new ReduceAction380(139),
-			new ReduceAction381(139),
-			new ReduceAction382(139),
-			new ReduceAction383(139),
-			new ReduceAction159(139),
-			new ReduceAction159(139),
-			new ReduceAction146(140),
-			new ReduceAction147(140),
-			new ReduceAction148(140),
-			new ReduceAction149(140),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction169(141),
-			new ReduceAction170(141),
-			new ReduceAction171(141),
-			new ReduceAction172(141),
-			new ReduceAction173(141),
-			new ReduceAction174(141),
-			new ReduceAction175(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction159(141),
-			new ReduceAction183(141),
-			new ReduceAction184(141),
-			new ReduceAction185(141),
-			new ReduceAction184(141),
-			new ReduceAction187(141),
-			new ReduceAction188(141),
-			new ReduceAction189(141),
-			new ReduceAction188(141),
-			new ReduceAction191(141),
-			new ReduceAction192(141),
-			new ReduceAction193(141),
-			new ReduceAction194(141),
-			new ReduceAction195(141),
-			new ReduceAction194(141),
-			new ReduceAction197(141),
-			new ReduceAction198(141),
-			new ReduceAction197(141),
-			new ReduceAction200(141),
-			new ReduceAction207(142),
-			new ReduceAction208(142),
-			new ReduceAction209(142),
-			new ReduceAction210(142),
-			new ReduceAction211(142),
-			new ReduceAction212(142),
-			new ReduceAction213(142),
-			new ReduceAction214(142),
-			new ReduceAction211(142),
-			new ReduceAction212(142),
-			new ReduceAction217(142),
-			new ReduceAction218(142),
-			new ReduceAction219(142),
-			new ReduceAction220(142),
-			new ReduceAction221(142),
-			new ReduceAction222(142),
-			new ReduceAction219(142),
-			new ReduceAction220(142),
-			new ReduceAction225(142),
-			new ReduceAction226(142),
-			new ReduceAction227(142),
-			new ReduceAction228(142),
-			new ReduceAction229(142),
-			new ReduceAction230(142),
-			new ReduceAction231(142),
-			new ReduceAction232(142),
-			new ReduceAction233(142),
-			new ReduceAction230(142),
-			new ReduceAction231(142),
-			new ReduceAction236(142),
-			new ReduceAction237(142),
-			new ReduceAction238(142),
-			new ReduceAction239(142),
-			new ReduceAction240(142),
-			new ReduceAction241(142),
-			new ReduceAction238(142),
-			new ReduceAction239(142),
-			new ReduceAction244(142),
-			new ReduceAction159(143),
-			new ReduceAction284(143),
-			new ReduceAction159(144),
-			new ReduceAction286(144),
-			new ReduceAction287(144),
-			new ReduceAction288(144),
-			new ReduceAction289(144),
-			new ReduceAction159(145),
-			new ReduceAction291(145),
-			new ReduceAction159(146),
-			new ReduceAction293(146),
-			new ReduceAction294(146),
-			new ReduceAction295(146),
-			new ReduceAction296(146),
-			new ReduceAction297(146),
-			new ReduceAction298(146),
-			new ReduceAction299(146),
-			new ReduceAction300(146),
-			new ReduceAction159(147),
-			new ReduceAction302(147),
-			new ReduceAction159(148),
-			new ReduceAction304(148),
-			new ReduceAction159(149),
-			new ReduceAction306(149),
-			new ReduceAction159(150),
-			new ReduceAction308(150),
-			new ReduceAction309(150),
-			new ReduceAction159(151),
-			new ReduceAction311(151),
-			new ReduceAction312(151),
-			new ReduceAction159(152),
-			new ReduceAction314(152),
-			new ReduceAction315(152),
-			new ReduceAction316(152),
-			new ReduceAction159(153),
-			new ReduceAction318(153),
-			new ReduceAction159(154),
-			new ReduceAction320(154),
-			new ReduceAction321(154),
-			new ReduceAction322(154),
-			new ReduceAction323(154),
-			new ReduceAction159(155),
-			new ReduceAction325(155),
-			new ReduceAction326(155),
-			new ReduceAction327(155),
-			new ReduceAction328(155),
-			new ReduceAction159(156),
-			new ReduceAction330(156),
-			new ReduceAction331(156),
-			new ReduceAction183(156),
-			new ReduceAction333(156),
-			new ReduceAction184(156),
-			new ReduceAction335(156),
-			new ReduceAction185(156),
-			new ReduceAction337(156),
-			new ReduceAction184(156),
-			new ReduceAction335(156),
-			new ReduceAction187(156),
-			new ReduceAction341(156),
-			new ReduceAction188(156),
-			new ReduceAction343(156),
-			new ReduceAction189(156),
-			new ReduceAction345(156),
-			new ReduceAction188(156),
-			new ReduceAction343(156),
-			new ReduceAction191(156),
-			new ReduceAction349(156),
-			new ReduceAction192(156),
-			new ReduceAction351(156),
-			new ReduceAction193(156),
-			new ReduceAction353(156),
-			new ReduceAction354(156),
-			new ReduceAction355(156),
-			new ReduceAction356(156),
-			new ReduceAction357(156),
-			new ReduceAction358(156),
-			new ReduceAction359(156),
-			new ReduceAction360(156),
-			new ReduceAction357(156),
-			new ReduceAction358(156),
-			new ReduceAction363(156),
-			new ReduceAction364(156),
-			new ReduceAction365(156),
-			new ReduceAction159(157),
-			new ReduceAction367(157),
-			new ReduceAction368(157),
-			new ReduceAction369(158),
-			new ReduceAction370(158),
-			new ReduceAction371(158),
-			new ReduceAction372(158),
-			new ReduceAction373(158),
-			new ReduceAction374(158),
-			new ReduceAction375(158),
-			new ReduceAction376(158),
-			new ReduceAction377(158),
-			new ReduceAction378(158),
-			new ReduceAction379(158),
-			new ReduceAction380(158),
-			new ReduceAction381(158),
-			new ReduceAction382(158),
-			new ReduceAction383(158),
-			new ReduceAction159(158),
-			new ReduceAction408(159),
-			new ReduceAction409(159),
-			new ReduceAction410(160),
-			new ReduceAction22(160),
-			new ReduceAction412(161),
-			new ReduceAction412(162),
-			new ReduceAction393(163),
-			new ReduceAction394(163),
-			new ReduceAction434(164),
-			new ReduceAction159(164),
-			new ReduceAction159(164),
-			new ReduceAction437(164),
-			new ReduceAction438(164),
-			new ReduceAction146(165),
-			new ReduceAction147(165),
-			new ReduceAction159(166),
-			new ReduceAction284(166),
-			new ReduceAction159(167),
-			new ReduceAction286(167),
-			new ReduceAction287(167),
-			new ReduceAction288(167),
-			new ReduceAction289(167),
-			new ReduceAction159(168),
-			new ReduceAction291(168),
-			new ReduceAction159(169),
-			new ReduceAction293(169),
-			new ReduceAction294(169),
-			new ReduceAction295(169),
-			new ReduceAction296(169),
-			new ReduceAction297(169),
-			new ReduceAction298(169),
-			new ReduceAction299(169),
-			new ReduceAction300(169),
-			new ReduceAction159(170),
-			new ReduceAction302(170),
-			new ReduceAction159(171),
-			new ReduceAction304(171),
-			new ReduceAction159(172),
-			new ReduceAction306(172),
-			new ReduceAction159(173),
-			new ReduceAction308(173),
-			new ReduceAction309(173),
-			new ReduceAction159(174),
-			new ReduceAction311(174),
-			new ReduceAction312(174),
-			new ReduceAction159(175),
-			new ReduceAction314(175),
-			new ReduceAction315(175),
-			new ReduceAction316(175),
-			new ReduceAction159(176),
-			new ReduceAction318(176),
-			new ReduceAction159(177),
-			new ReduceAction320(177),
-			new ReduceAction321(177),
-			new ReduceAction322(177),
-			new ReduceAction323(177),
-			new ReduceAction159(178),
-			new ReduceAction325(178),
-			new ReduceAction326(178),
-			new ReduceAction871(178),
-			new ReduceAction159(179),
-			new ReduceAction873(179),
-			new ReduceAction874(179),
-			new ReduceAction875(179),
-			new ReduceAction876(179),
-			new ReduceAction877(179),
-			new ReduceAction183(179),
-			new ReduceAction333(179),
-			new ReduceAction876(179),
-			new ReduceAction877(179),
-			new ReduceAction191(179),
-			new ReduceAction349(179),
-			new ReduceAction884(179),
-			new ReduceAction885(179),
-			new ReduceAction355(179),
-			new ReduceAction356(179),
-			new ReduceAction357(179),
-			new ReduceAction358(179),
-			new ReduceAction359(179),
-			new ReduceAction360(179),
-			new ReduceAction357(179),
-			new ReduceAction358(179),
-			new ReduceAction363(179),
-			new ReduceAction364(179),
-			new ReduceAction365(179),
-			new ReduceAction159(180),
-			new ReduceAction367(180),
-			new ReduceAction368(180),
-			new ReduceAction369(181),
-			new ReduceAction370(181),
-			new ReduceAction371(181),
-			new ReduceAction372(181),
-			new ReduceAction373(181),
-			new ReduceAction374(181),
-			new ReduceAction375(181),
-			new ReduceAction376(181),
-			new ReduceAction377(181),
-			new ReduceAction378(181),
-			new ReduceAction379(181),
-			new ReduceAction380(181),
-			new ReduceAction381(181),
-			new ReduceAction382(181),
-			new ReduceAction383(181),
-			new ReduceAction159(181),
-			new ReduceAction916(182),
-			new ReduceAction917(182),
-			new ReduceAction156(183),
-			new ReduceAction157(183),
-			new ReduceAction158(183),
-			new ReduceAction159(183),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction169(184),
-			new ReduceAction170(184),
-			new ReduceAction171(184),
-			new ReduceAction172(184),
-			new ReduceAction173(184),
-			new ReduceAction174(184),
-			new ReduceAction175(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction159(184),
-			new ReduceAction183(184),
-			new ReduceAction184(184),
-			new ReduceAction185(184),
-			new ReduceAction184(184),
-			new ReduceAction187(184),
-			new ReduceAction188(184),
-			new ReduceAction189(184),
-			new ReduceAction188(184),
-			new ReduceAction191(184),
-			new ReduceAction192(184),
-			new ReduceAction193(184),
-			new ReduceAction194(184),
-			new ReduceAction195(184),
-			new ReduceAction194(184),
-			new ReduceAction197(184),
-			new ReduceAction198(184),
-			new ReduceAction197(184),
-			new ReduceAction200(184),
-			new ReduceAction256(185),
-			new ReduceAction257(185),
-			new ReduceAction258(186),
-			new ReduceAction267(187),
-			new ReduceAction268(187),
-			new ReduceAction269(188),
-			new ReduceAction270(188),
-			new ReduceAction271(189),
-			new ReduceAction272(189),
-			new ReduceAction273(190),
-			new ReduceAction274(190),
-			new ReduceAction278(191),
-			new ReduceAction279(191),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction169(192),
-			new ReduceAction170(192),
-			new ReduceAction171(192),
-			new ReduceAction172(192),
-			new ReduceAction173(192),
-			new ReduceAction174(192),
-			new ReduceAction175(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction159(192),
-			new ReduceAction183(192),
-			new ReduceAction184(192),
-			new ReduceAction185(192),
-			new ReduceAction184(192),
-			new ReduceAction187(192),
-			new ReduceAction188(192),
-			new ReduceAction189(192),
-			new ReduceAction188(192),
-			new ReduceAction191(192),
-			new ReduceAction192(192),
-			new ReduceAction193(192),
-			new ReduceAction194(192),
-			new ReduceAction195(192),
-			new ReduceAction194(192),
-			new ReduceAction197(192),
-			new ReduceAction198(192),
-			new ReduceAction197(192),
-			new ReduceAction200(192),
-			new ReduceAction156(193),
-			new ReduceAction157(193),
-			new ReduceAction158(193),
-			new ReduceAction156(194),
-			new ReduceAction157(194),
-			new ReduceAction158(194),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction169(195),
-			new ReduceAction170(195),
-			new ReduceAction171(195),
-			new ReduceAction172(195),
-			new ReduceAction173(195),
-			new ReduceAction174(195),
-			new ReduceAction175(195),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction159(195),
-			new ReduceAction200(195),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction169(196),
-			new ReduceAction170(196),
-			new ReduceAction171(196),
-			new ReduceAction172(196),
-			new ReduceAction173(196),
-			new ReduceAction174(196),
-			new ReduceAction175(196),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction159(196),
-			new ReduceAction200(196),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction169(197),
-			new ReduceAction170(197),
-			new ReduceAction171(197),
-			new ReduceAction172(197),
-			new ReduceAction173(197),
-			new ReduceAction174(197),
-			new ReduceAction175(197),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction159(197),
-			new ReduceAction200(197),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction169(198),
-			new ReduceAction170(198),
-			new ReduceAction171(198),
-			new ReduceAction172(198),
-			new ReduceAction173(198),
-			new ReduceAction174(198),
-			new ReduceAction175(198),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction159(198),
-			new ReduceAction200(198),
-			new ReduceAction440(199),
-			new ReduceAction442(199),
-			new ReduceAction480(200),
-			new ReduceAction481(200),
-			new ReduceAction23(200),
-			new ReduceAction1078(201),
-			new ReduceAction1079(201),
-			new ReduceAction1080(202),
-			new ReduceAction1081(202),
-			new ReduceAction1082(203),
-			new ReduceAction1083(203),
-			new ReduceAction37(204),
-			new ReduceAction1085(204),
-			new ReduceAction45(205),
-			new ReduceAction1087(205),
-			new ReduceAction414(206),
-			new ReduceAction1089(206),
-			new ReduceAction1090(207),
-			new ReduceAction1091(207),
-			new ReduceAction1092(208),
-			new ReduceAction1093(208),
-			new ReduceAction150(209),
-			new ReduceAction1095(209),
-			new ReduceAction393(210),
-			new ReduceAction1097(210),
-			new ReduceAction393(211),
-			new ReduceAction1097(211),
-			new ReduceAction393(212),
-			new ReduceAction1097(212),
-			new ReduceAction454(213),
-			new ReduceAction1103(213),
-			new ReduceAction414(214),
-			new ReduceAction1089(214),
-			new ReduceAction393(215),
-			new ReduceAction1097(215),
-			new ReduceAction393(216),
-			new ReduceAction1097(216),
-			new ReduceAction455(217),
-			new ReduceAction1111(217),
-			new ReduceAction1112(218),
-			new ReduceAction1113(218),
-			new ReduceAction477(219),
-			new ReduceAction496(219)
-		)
+		var reduce_table = new Array[ReduceAction].with_capacity(1116)
+		self.reduce_table = reduce_table
+		reduce_table.add new ReduceAction0(0)
+		reduce_table.add new ReduceAction1(0)
+		reduce_table.add new ReduceAction2(0)
+		reduce_table.add new ReduceAction3(0)
+		reduce_table.add new ReduceAction4(0)
+		reduce_table.add new ReduceAction5(0)
+		reduce_table.add new ReduceAction6(0)
+		reduce_table.add new ReduceAction7(0)
+		reduce_table.add new ReduceAction8(0)
+		reduce_table.add new ReduceAction9(0)
+		reduce_table.add new ReduceAction10(0)
+		reduce_table.add new ReduceAction11(0)
+		reduce_table.add new ReduceAction12(0)
+		reduce_table.add new ReduceAction13(0)
+		reduce_table.add new ReduceAction14(0)
+		reduce_table.add new ReduceAction15(0)
+		reduce_table.add new ReduceAction16(1)
+		reduce_table.add new ReduceAction17(2)
+		reduce_table.add new ReduceAction18(2)
+		reduce_table.add new ReduceAction19(3)
+		reduce_table.add new ReduceAction20(3)
+		reduce_table.add new ReduceAction21(4)
+		reduce_table.add new ReduceAction22(4)
+		reduce_table.add new ReduceAction23(4)
+		reduce_table.add new ReduceAction24(5)
+		reduce_table.add new ReduceAction24(5)
+		reduce_table.add new ReduceAction26(6)
+		reduce_table.add new ReduceAction27(6)
+		reduce_table.add new ReduceAction28(6)
+		reduce_table.add new ReduceAction29(6)
+		reduce_table.add new ReduceAction22(7)
+		reduce_table.add new ReduceAction31(7)
+		reduce_table.add new ReduceAction32(8)
+		reduce_table.add new ReduceAction33(8)
+		reduce_table.add new ReduceAction34(8)
+		reduce_table.add new ReduceAction35(8)
+		reduce_table.add new ReduceAction36(8)
+		reduce_table.add new ReduceAction37(9)
+		reduce_table.add new ReduceAction38(9)
+		reduce_table.add new ReduceAction39(9)
+		reduce_table.add new ReduceAction40(10)
+		reduce_table.add new ReduceAction41(11)
+		reduce_table.add new ReduceAction42(11)
+		reduce_table.add new ReduceAction43(12)
+		reduce_table.add new ReduceAction44(13)
+		reduce_table.add new ReduceAction45(13)
+		reduce_table.add new ReduceAction46(13)
+		reduce_table.add new ReduceAction47(14)
+		reduce_table.add new ReduceAction48(15)
+		reduce_table.add new ReduceAction49(15)
+		reduce_table.add new ReduceAction50(15)
+		reduce_table.add new ReduceAction51(15)
+		reduce_table.add new ReduceAction52(15)
+		reduce_table.add new ReduceAction53(15)
+		reduce_table.add new ReduceAction54(15)
+		reduce_table.add new ReduceAction55(15)
+		reduce_table.add new ReduceAction56(15)
+		reduce_table.add new ReduceAction57(15)
+		reduce_table.add new ReduceAction58(15)
+		reduce_table.add new ReduceAction59(15)
+		reduce_table.add new ReduceAction60(15)
+		reduce_table.add new ReduceAction61(15)
+		reduce_table.add new ReduceAction62(15)
+		reduce_table.add new ReduceAction63(15)
+		reduce_table.add new ReduceAction64(15)
+		reduce_table.add new ReduceAction65(15)
+		reduce_table.add new ReduceAction66(15)
+		reduce_table.add new ReduceAction67(15)
+		reduce_table.add new ReduceAction68(15)
+		reduce_table.add new ReduceAction69(15)
+		reduce_table.add new ReduceAction70(15)
+		reduce_table.add new ReduceAction71(15)
+		reduce_table.add new ReduceAction72(15)
+		reduce_table.add new ReduceAction73(15)
+		reduce_table.add new ReduceAction74(15)
+		reduce_table.add new ReduceAction74(15)
+		reduce_table.add new ReduceAction76(16)
+		reduce_table.add new ReduceAction77(16)
+		reduce_table.add new ReduceAction22(16)
+		reduce_table.add new ReduceAction76(17)
+		reduce_table.add new ReduceAction80(17)
+		reduce_table.add new ReduceAction81(18)
+		reduce_table.add new ReduceAction82(18)
+		reduce_table.add new ReduceAction83(18)
+		reduce_table.add new ReduceAction84(18)
+		reduce_table.add new ReduceAction85(18)
+		reduce_table.add new ReduceAction86(19)
+		reduce_table.add new ReduceAction87(19)
+		reduce_table.add new ReduceAction88(19)
+		reduce_table.add new ReduceAction89(19)
+		reduce_table.add new ReduceAction90(19)
+		reduce_table.add new ReduceAction91(19)
+		reduce_table.add new ReduceAction92(19)
+		reduce_table.add new ReduceAction93(19)
+		reduce_table.add new ReduceAction94(19)
+		reduce_table.add new ReduceAction95(19)
+		reduce_table.add new ReduceAction96(19)
+		reduce_table.add new ReduceAction97(19)
+		reduce_table.add new ReduceAction98(19)
+		reduce_table.add new ReduceAction99(19)
+		reduce_table.add new ReduceAction100(19)
+		reduce_table.add new ReduceAction101(19)
+		reduce_table.add new ReduceAction102(19)
+		reduce_table.add new ReduceAction103(19)
+		reduce_table.add new ReduceAction104(19)
+		reduce_table.add new ReduceAction105(19)
+		reduce_table.add new ReduceAction106(19)
+		reduce_table.add new ReduceAction107(19)
+		reduce_table.add new ReduceAction108(19)
+		reduce_table.add new ReduceAction109(20)
+		reduce_table.add new ReduceAction110(20)
+		reduce_table.add new ReduceAction111(20)
+		reduce_table.add new ReduceAction112(20)
+		reduce_table.add new ReduceAction113(21)
+		reduce_table.add new ReduceAction114(21)
+		reduce_table.add new ReduceAction39(21)
+		reduce_table.add new ReduceAction116(22)
+		reduce_table.add new ReduceAction117(23)
+		reduce_table.add new ReduceAction118(23)
+		reduce_table.add new ReduceAction119(23)
+		reduce_table.add new ReduceAction120(23)
+		reduce_table.add new ReduceAction121(23)
+		reduce_table.add new ReduceAction122(24)
+		reduce_table.add new ReduceAction123(24)
+		reduce_table.add new ReduceAction22(24)
+		reduce_table.add new ReduceAction125(25)
+		reduce_table.add new ReduceAction126(26)
+		reduce_table.add new ReduceAction126(26)
+		reduce_table.add new ReduceAction128(26)
+		reduce_table.add new ReduceAction129(27)
+		reduce_table.add new ReduceAction130(27)
+		reduce_table.add new ReduceAction131(27)
+		reduce_table.add new ReduceAction132(28)
+		reduce_table.add new ReduceAction133(28)
+		reduce_table.add new ReduceAction134(28)
+		reduce_table.add new ReduceAction135(28)
+		reduce_table.add new ReduceAction136(28)
+		reduce_table.add new ReduceAction137(28)
+		reduce_table.add new ReduceAction22(29)
+		reduce_table.add new ReduceAction139(29)
+		reduce_table.add new ReduceAction140(30)
+		reduce_table.add new ReduceAction141(31)
+		reduce_table.add new ReduceAction142(31)
+		reduce_table.add new ReduceAction143(32)
+		reduce_table.add new ReduceAction22(32)
+		reduce_table.add new ReduceAction145(33)
+		reduce_table.add new ReduceAction146(34)
+		reduce_table.add new ReduceAction147(34)
+		reduce_table.add new ReduceAction148(34)
+		reduce_table.add new ReduceAction149(34)
+		reduce_table.add new ReduceAction150(35)
+		reduce_table.add new ReduceAction151(35)
+		reduce_table.add new ReduceAction152(36)
+		reduce_table.add new ReduceAction152(37)
+		reduce_table.add new ReduceAction152(38)
+		reduce_table.add new ReduceAction22(38)
+		reduce_table.add new ReduceAction156(39)
+		reduce_table.add new ReduceAction157(39)
+		reduce_table.add new ReduceAction158(39)
+		reduce_table.add new ReduceAction159(39)
+		reduce_table.add new ReduceAction160(40)
+		reduce_table.add new ReduceAction161(40)
+		reduce_table.add new ReduceAction162(41)
+		reduce_table.add new ReduceAction163(41)
+		reduce_table.add new ReduceAction164(42)
+		reduce_table.add new ReduceAction165(42)
+		reduce_table.add new ReduceAction156(43)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction169(44)
+		reduce_table.add new ReduceAction170(44)
+		reduce_table.add new ReduceAction171(44)
+		reduce_table.add new ReduceAction172(44)
+		reduce_table.add new ReduceAction173(44)
+		reduce_table.add new ReduceAction174(44)
+		reduce_table.add new ReduceAction175(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction159(44)
+		reduce_table.add new ReduceAction183(44)
+		reduce_table.add new ReduceAction184(44)
+		reduce_table.add new ReduceAction185(44)
+		reduce_table.add new ReduceAction184(44)
+		reduce_table.add new ReduceAction187(44)
+		reduce_table.add new ReduceAction188(44)
+		reduce_table.add new ReduceAction189(44)
+		reduce_table.add new ReduceAction188(44)
+		reduce_table.add new ReduceAction191(44)
+		reduce_table.add new ReduceAction192(44)
+		reduce_table.add new ReduceAction193(44)
+		reduce_table.add new ReduceAction194(44)
+		reduce_table.add new ReduceAction195(44)
+		reduce_table.add new ReduceAction194(44)
+		reduce_table.add new ReduceAction197(44)
+		reduce_table.add new ReduceAction198(44)
+		reduce_table.add new ReduceAction197(44)
+		reduce_table.add new ReduceAction200(44)
+		reduce_table.add new ReduceAction201(45)
+		reduce_table.add new ReduceAction202(45)
+		reduce_table.add new ReduceAction203(46)
+		reduce_table.add new ReduceAction204(46)
+		reduce_table.add new ReduceAction205(46)
+		reduce_table.add new ReduceAction206(46)
+		reduce_table.add new ReduceAction207(47)
+		reduce_table.add new ReduceAction208(47)
+		reduce_table.add new ReduceAction209(47)
+		reduce_table.add new ReduceAction210(47)
+		reduce_table.add new ReduceAction211(47)
+		reduce_table.add new ReduceAction212(47)
+		reduce_table.add new ReduceAction213(47)
+		reduce_table.add new ReduceAction214(47)
+		reduce_table.add new ReduceAction211(47)
+		reduce_table.add new ReduceAction212(47)
+		reduce_table.add new ReduceAction217(47)
+		reduce_table.add new ReduceAction218(47)
+		reduce_table.add new ReduceAction219(47)
+		reduce_table.add new ReduceAction220(47)
+		reduce_table.add new ReduceAction221(47)
+		reduce_table.add new ReduceAction222(47)
+		reduce_table.add new ReduceAction219(47)
+		reduce_table.add new ReduceAction220(47)
+		reduce_table.add new ReduceAction225(47)
+		reduce_table.add new ReduceAction226(47)
+		reduce_table.add new ReduceAction227(47)
+		reduce_table.add new ReduceAction228(47)
+		reduce_table.add new ReduceAction229(47)
+		reduce_table.add new ReduceAction230(47)
+		reduce_table.add new ReduceAction231(47)
+		reduce_table.add new ReduceAction232(47)
+		reduce_table.add new ReduceAction233(47)
+		reduce_table.add new ReduceAction230(47)
+		reduce_table.add new ReduceAction231(47)
+		reduce_table.add new ReduceAction236(47)
+		reduce_table.add new ReduceAction237(47)
+		reduce_table.add new ReduceAction238(47)
+		reduce_table.add new ReduceAction239(47)
+		reduce_table.add new ReduceAction240(47)
+		reduce_table.add new ReduceAction241(47)
+		reduce_table.add new ReduceAction238(47)
+		reduce_table.add new ReduceAction239(47)
+		reduce_table.add new ReduceAction244(47)
+		reduce_table.add new ReduceAction245(48)
+		reduce_table.add new ReduceAction246(48)
+		reduce_table.add new ReduceAction247(48)
+		reduce_table.add new ReduceAction248(48)
+		reduce_table.add new ReduceAction249(48)
+		reduce_table.add new ReduceAction250(48)
+		reduce_table.add new ReduceAction251(48)
+		reduce_table.add new ReduceAction252(48)
+		reduce_table.add new ReduceAction253(48)
+		reduce_table.add new ReduceAction254(48)
+		reduce_table.add new ReduceAction255(48)
+		reduce_table.add new ReduceAction256(49)
+		reduce_table.add new ReduceAction257(49)
+		reduce_table.add new ReduceAction258(50)
+		reduce_table.add new ReduceAction259(50)
+		reduce_table.add new ReduceAction260(50)
+		reduce_table.add new ReduceAction261(50)
+		reduce_table.add new ReduceAction262(50)
+		reduce_table.add new ReduceAction263(50)
+		reduce_table.add new ReduceAction264(50)
+		reduce_table.add new ReduceAction265(50)
+		reduce_table.add new ReduceAction158(51)
+		reduce_table.add new ReduceAction267(52)
+		reduce_table.add new ReduceAction268(52)
+		reduce_table.add new ReduceAction269(53)
+		reduce_table.add new ReduceAction270(53)
+		reduce_table.add new ReduceAction271(54)
+		reduce_table.add new ReduceAction272(54)
+		reduce_table.add new ReduceAction273(55)
+		reduce_table.add new ReduceAction274(55)
+		reduce_table.add new ReduceAction275(56)
+		reduce_table.add new ReduceAction276(56)
+		reduce_table.add new ReduceAction159(56)
+		reduce_table.add new ReduceAction278(57)
+		reduce_table.add new ReduceAction279(57)
+		reduce_table.add new ReduceAction280(57)
+		reduce_table.add new ReduceAction281(57)
+		reduce_table.add new ReduceAction282(58)
+		reduce_table.add new ReduceAction159(59)
+		reduce_table.add new ReduceAction284(59)
+		reduce_table.add new ReduceAction159(60)
+		reduce_table.add new ReduceAction286(60)
+		reduce_table.add new ReduceAction287(60)
+		reduce_table.add new ReduceAction288(60)
+		reduce_table.add new ReduceAction289(60)
+		reduce_table.add new ReduceAction159(61)
+		reduce_table.add new ReduceAction291(61)
+		reduce_table.add new ReduceAction159(62)
+		reduce_table.add new ReduceAction293(62)
+		reduce_table.add new ReduceAction294(62)
+		reduce_table.add new ReduceAction295(62)
+		reduce_table.add new ReduceAction296(62)
+		reduce_table.add new ReduceAction297(62)
+		reduce_table.add new ReduceAction298(62)
+		reduce_table.add new ReduceAction299(62)
+		reduce_table.add new ReduceAction300(62)
+		reduce_table.add new ReduceAction159(63)
+		reduce_table.add new ReduceAction302(63)
+		reduce_table.add new ReduceAction159(64)
+		reduce_table.add new ReduceAction304(64)
+		reduce_table.add new ReduceAction159(65)
+		reduce_table.add new ReduceAction306(65)
+		reduce_table.add new ReduceAction159(66)
+		reduce_table.add new ReduceAction308(66)
+		reduce_table.add new ReduceAction309(66)
+		reduce_table.add new ReduceAction159(67)
+		reduce_table.add new ReduceAction311(67)
+		reduce_table.add new ReduceAction312(67)
+		reduce_table.add new ReduceAction159(68)
+		reduce_table.add new ReduceAction314(68)
+		reduce_table.add new ReduceAction315(68)
+		reduce_table.add new ReduceAction316(68)
+		reduce_table.add new ReduceAction159(69)
+		reduce_table.add new ReduceAction318(69)
+		reduce_table.add new ReduceAction159(70)
+		reduce_table.add new ReduceAction320(70)
+		reduce_table.add new ReduceAction321(70)
+		reduce_table.add new ReduceAction322(70)
+		reduce_table.add new ReduceAction323(70)
+		reduce_table.add new ReduceAction159(71)
+		reduce_table.add new ReduceAction325(71)
+		reduce_table.add new ReduceAction326(71)
+		reduce_table.add new ReduceAction327(71)
+		reduce_table.add new ReduceAction328(71)
+		reduce_table.add new ReduceAction159(72)
+		reduce_table.add new ReduceAction330(72)
+		reduce_table.add new ReduceAction331(72)
+		reduce_table.add new ReduceAction183(72)
+		reduce_table.add new ReduceAction333(72)
+		reduce_table.add new ReduceAction184(72)
+		reduce_table.add new ReduceAction335(72)
+		reduce_table.add new ReduceAction185(72)
+		reduce_table.add new ReduceAction337(72)
+		reduce_table.add new ReduceAction184(72)
+		reduce_table.add new ReduceAction335(72)
+		reduce_table.add new ReduceAction187(72)
+		reduce_table.add new ReduceAction341(72)
+		reduce_table.add new ReduceAction188(72)
+		reduce_table.add new ReduceAction343(72)
+		reduce_table.add new ReduceAction189(72)
+		reduce_table.add new ReduceAction345(72)
+		reduce_table.add new ReduceAction188(72)
+		reduce_table.add new ReduceAction343(72)
+		reduce_table.add new ReduceAction191(72)
+		reduce_table.add new ReduceAction349(72)
+		reduce_table.add new ReduceAction192(72)
+		reduce_table.add new ReduceAction351(72)
+		reduce_table.add new ReduceAction193(72)
+		reduce_table.add new ReduceAction353(72)
+		reduce_table.add new ReduceAction354(72)
+		reduce_table.add new ReduceAction355(72)
+		reduce_table.add new ReduceAction356(72)
+		reduce_table.add new ReduceAction357(72)
+		reduce_table.add new ReduceAction358(72)
+		reduce_table.add new ReduceAction359(72)
+		reduce_table.add new ReduceAction360(72)
+		reduce_table.add new ReduceAction357(72)
+		reduce_table.add new ReduceAction358(72)
+		reduce_table.add new ReduceAction363(72)
+		reduce_table.add new ReduceAction364(72)
+		reduce_table.add new ReduceAction365(72)
+		reduce_table.add new ReduceAction159(73)
+		reduce_table.add new ReduceAction367(73)
+		reduce_table.add new ReduceAction368(73)
+		reduce_table.add new ReduceAction369(74)
+		reduce_table.add new ReduceAction370(74)
+		reduce_table.add new ReduceAction371(74)
+		reduce_table.add new ReduceAction372(74)
+		reduce_table.add new ReduceAction373(74)
+		reduce_table.add new ReduceAction374(74)
+		reduce_table.add new ReduceAction375(74)
+		reduce_table.add new ReduceAction376(74)
+		reduce_table.add new ReduceAction377(74)
+		reduce_table.add new ReduceAction378(74)
+		reduce_table.add new ReduceAction379(74)
+		reduce_table.add new ReduceAction380(74)
+		reduce_table.add new ReduceAction381(74)
+		reduce_table.add new ReduceAction382(74)
+		reduce_table.add new ReduceAction383(74)
+		reduce_table.add new ReduceAction159(74)
+		reduce_table.add new ReduceAction159(74)
+		reduce_table.add new ReduceAction386(74)
+		reduce_table.add new ReduceAction387(74)
+		reduce_table.add new ReduceAction388(74)
+		reduce_table.add new ReduceAction389(75)
+		reduce_table.add new ReduceAction389(75)
+		reduce_table.add new ReduceAction391(76)
+		reduce_table.add new ReduceAction392(77)
+		reduce_table.add new ReduceAction393(78)
+		reduce_table.add new ReduceAction394(78)
+		reduce_table.add new ReduceAction392(79)
+		reduce_table.add new ReduceAction396(80)
+		reduce_table.add new ReduceAction272(80)
+		reduce_table.add new ReduceAction398(80)
+		reduce_table.add new ReduceAction399(81)
+		reduce_table.add new ReduceAction400(81)
+		reduce_table.add new ReduceAction401(82)
+		reduce_table.add new ReduceAction402(82)
+		reduce_table.add new ReduceAction403(83)
+		reduce_table.add new ReduceAction401(84)
+		reduce_table.add new ReduceAction402(84)
+		reduce_table.add new ReduceAction406(85)
+		reduce_table.add new ReduceAction407(86)
+		reduce_table.add new ReduceAction408(87)
+		reduce_table.add new ReduceAction409(87)
+		reduce_table.add new ReduceAction410(88)
+		reduce_table.add new ReduceAction22(88)
+		reduce_table.add new ReduceAction412(89)
+		reduce_table.add new ReduceAction413(89)
+		reduce_table.add new ReduceAction414(90)
+		reduce_table.add new ReduceAction415(90)
+		reduce_table.add new ReduceAction412(91)
+		reduce_table.add new ReduceAction413(91)
+		reduce_table.add new ReduceAction418(91)
+		reduce_table.add new ReduceAction159(92)
+		reduce_table.add new ReduceAction420(93)
+		reduce_table.add new ReduceAction421(94)
+		reduce_table.add new ReduceAction422(94)
+		reduce_table.add new ReduceAction423(94)
+		reduce_table.add new ReduceAction424(94)
+		reduce_table.add new ReduceAction425(94)
+		reduce_table.add new ReduceAction426(95)
+		reduce_table.add new ReduceAction427(95)
+		reduce_table.add new ReduceAction428(95)
+		reduce_table.add new ReduceAction429(95)
+		reduce_table.add new ReduceAction430(95)
+		reduce_table.add new ReduceAction393(96)
+		reduce_table.add new ReduceAction394(96)
+		reduce_table.add new ReduceAction392(97)
+		reduce_table.add new ReduceAction434(98)
+		reduce_table.add new ReduceAction159(98)
+		reduce_table.add new ReduceAction159(98)
+		reduce_table.add new ReduceAction437(98)
+		reduce_table.add new ReduceAction438(98)
+		reduce_table.add new ReduceAction439(98)
+		reduce_table.add new ReduceAction440(99)
+		reduce_table.add new ReduceAction441(99)
+		reduce_table.add new ReduceAction442(99)
+		reduce_table.add new ReduceAction443(100)
+		reduce_table.add new ReduceAction444(100)
+		reduce_table.add new ReduceAction443(101)
+		reduce_table.add new ReduceAction446(101)
+		reduce_table.add new ReduceAction444(101)
+		reduce_table.add new ReduceAction448(101)
+		reduce_table.add new ReduceAction449(102)
+		reduce_table.add new ReduceAction402(103)
+		reduce_table.add new ReduceAction451(103)
+		reduce_table.add new ReduceAction452(104)
+		reduce_table.add new ReduceAction453(105)
+		reduce_table.add new ReduceAction454(105)
+		reduce_table.add new ReduceAction455(106)
+		reduce_table.add new ReduceAction456(106)
+		reduce_table.add new ReduceAction457(107)
+		reduce_table.add new ReduceAction458(107)
+		reduce_table.add new ReduceAction459(107)
+		reduce_table.add new ReduceAction460(107)
+		reduce_table.add new ReduceAction461(108)
+		reduce_table.add new ReduceAction462(108)
+		reduce_table.add new ReduceAction463(108)
+		reduce_table.add new ReduceAction22(108)
+		reduce_table.add new ReduceAction465(109)
+		reduce_table.add new ReduceAction466(109)
+		reduce_table.add new ReduceAction467(109)
+		reduce_table.add new ReduceAction466(109)
+		reduce_table.add new ReduceAction469(110)
+		reduce_table.add new ReduceAction470(110)
+		reduce_table.add new ReduceAction471(110)
+		reduce_table.add new ReduceAction470(110)
+		reduce_table.add new ReduceAction473(111)
+		reduce_table.add new ReduceAction474(112)
+		reduce_table.add new ReduceAction22(113)
+		reduce_table.add new ReduceAction476(113)
+		reduce_table.add new ReduceAction477(114)
+		reduce_table.add new ReduceAction477(114)
+		reduce_table.add new ReduceAction477(114)
+		reduce_table.add new ReduceAction480(115)
+		reduce_table.add new ReduceAction481(115)
+		reduce_table.add new ReduceAction23(115)
+		reduce_table.add new ReduceAction23(115)
+		reduce_table.add new ReduceAction484(115)
+		reduce_table.add new ReduceAction484(115)
+		reduce_table.add new ReduceAction486(115)
+		reduce_table.add new ReduceAction487(115)
+		reduce_table.add new ReduceAction488(115)
+		reduce_table.add new ReduceAction488(115)
+		reduce_table.add new ReduceAction490(115)
+		reduce_table.add new ReduceAction22(116)
+		reduce_table.add new ReduceAction492(116)
+		reduce_table.add new ReduceAction493(117)
+		reduce_table.add new ReduceAction477(117)
+		reduce_table.add new ReduceAction477(118)
+		reduce_table.add new ReduceAction496(118)
+		reduce_table.add new ReduceAction48(119)
+		reduce_table.add new ReduceAction49(119)
+		reduce_table.add new ReduceAction50(119)
+		reduce_table.add new ReduceAction57(119)
+		reduce_table.add new ReduceAction58(119)
+		reduce_table.add new ReduceAction76(120)
+		reduce_table.add new ReduceAction77(120)
+		reduce_table.add new ReduceAction86(121)
+		reduce_table.add new ReduceAction87(121)
+		reduce_table.add new ReduceAction88(121)
+		reduce_table.add new ReduceAction89(121)
+		reduce_table.add new ReduceAction90(121)
+		reduce_table.add new ReduceAction91(121)
+		reduce_table.add new ReduceAction92(121)
+		reduce_table.add new ReduceAction93(121)
+		reduce_table.add new ReduceAction94(121)
+		reduce_table.add new ReduceAction95(121)
+		reduce_table.add new ReduceAction96(121)
+		reduce_table.add new ReduceAction97(121)
+		reduce_table.add new ReduceAction98(121)
+		reduce_table.add new ReduceAction99(121)
+		reduce_table.add new ReduceAction100(121)
+		reduce_table.add new ReduceAction101(121)
+		reduce_table.add new ReduceAction102(121)
+		reduce_table.add new ReduceAction103(121)
+		reduce_table.add new ReduceAction104(121)
+		reduce_table.add new ReduceAction105(121)
+		reduce_table.add new ReduceAction106(121)
+		reduce_table.add new ReduceAction107(121)
+		reduce_table.add new ReduceAction469(122)
+		reduce_table.add new ReduceAction470(122)
+		reduce_table.add new ReduceAction471(122)
+		reduce_table.add new ReduceAction470(122)
+		reduce_table.add new ReduceAction146(123)
+		reduce_table.add new ReduceAction147(123)
+		reduce_table.add new ReduceAction159(124)
+		reduce_table.add new ReduceAction284(124)
+		reduce_table.add new ReduceAction159(125)
+		reduce_table.add new ReduceAction286(125)
+		reduce_table.add new ReduceAction287(125)
+		reduce_table.add new ReduceAction288(125)
+		reduce_table.add new ReduceAction289(125)
+		reduce_table.add new ReduceAction159(126)
+		reduce_table.add new ReduceAction291(126)
+		reduce_table.add new ReduceAction159(127)
+		reduce_table.add new ReduceAction293(127)
+		reduce_table.add new ReduceAction294(127)
+		reduce_table.add new ReduceAction295(127)
+		reduce_table.add new ReduceAction296(127)
+		reduce_table.add new ReduceAction297(127)
+		reduce_table.add new ReduceAction298(127)
+		reduce_table.add new ReduceAction299(127)
+		reduce_table.add new ReduceAction300(127)
+		reduce_table.add new ReduceAction159(128)
+		reduce_table.add new ReduceAction302(128)
+		reduce_table.add new ReduceAction159(129)
+		reduce_table.add new ReduceAction304(129)
+		reduce_table.add new ReduceAction159(130)
+		reduce_table.add new ReduceAction306(130)
+		reduce_table.add new ReduceAction159(131)
+		reduce_table.add new ReduceAction308(131)
+		reduce_table.add new ReduceAction309(131)
+		reduce_table.add new ReduceAction159(132)
+		reduce_table.add new ReduceAction311(132)
+		reduce_table.add new ReduceAction312(132)
+		reduce_table.add new ReduceAction159(133)
+		reduce_table.add new ReduceAction314(133)
+		reduce_table.add new ReduceAction315(133)
+		reduce_table.add new ReduceAction316(133)
+		reduce_table.add new ReduceAction159(134)
+		reduce_table.add new ReduceAction318(134)
+		reduce_table.add new ReduceAction159(135)
+		reduce_table.add new ReduceAction320(135)
+		reduce_table.add new ReduceAction321(135)
+		reduce_table.add new ReduceAction322(135)
+		reduce_table.add new ReduceAction323(135)
+		reduce_table.add new ReduceAction159(136)
+		reduce_table.add new ReduceAction325(136)
+		reduce_table.add new ReduceAction326(136)
+		reduce_table.add new ReduceAction327(136)
+		reduce_table.add new ReduceAction328(136)
+		reduce_table.add new ReduceAction159(137)
+		reduce_table.add new ReduceAction330(137)
+		reduce_table.add new ReduceAction331(137)
+		reduce_table.add new ReduceAction183(137)
+		reduce_table.add new ReduceAction187(137)
+		reduce_table.add new ReduceAction333(137)
+		reduce_table.add new ReduceAction341(137)
+		reduce_table.add new ReduceAction184(137)
+		reduce_table.add new ReduceAction188(137)
+		reduce_table.add new ReduceAction335(137)
+		reduce_table.add new ReduceAction343(137)
+		reduce_table.add new ReduceAction185(137)
+		reduce_table.add new ReduceAction189(137)
+		reduce_table.add new ReduceAction337(137)
+		reduce_table.add new ReduceAction345(137)
+		reduce_table.add new ReduceAction184(137)
+		reduce_table.add new ReduceAction188(137)
+		reduce_table.add new ReduceAction335(137)
+		reduce_table.add new ReduceAction343(137)
+		reduce_table.add new ReduceAction191(137)
+		reduce_table.add new ReduceAction349(137)
+		reduce_table.add new ReduceAction192(137)
+		reduce_table.add new ReduceAction193(137)
+		reduce_table.add new ReduceAction351(137)
+		reduce_table.add new ReduceAction353(137)
+		reduce_table.add new ReduceAction355(137)
+		reduce_table.add new ReduceAction356(137)
+		reduce_table.add new ReduceAction357(137)
+		reduce_table.add new ReduceAction358(137)
+		reduce_table.add new ReduceAction359(137)
+		reduce_table.add new ReduceAction360(137)
+		reduce_table.add new ReduceAction357(137)
+		reduce_table.add new ReduceAction358(137)
+		reduce_table.add new ReduceAction363(137)
+		reduce_table.add new ReduceAction364(137)
+		reduce_table.add new ReduceAction365(137)
+		reduce_table.add new ReduceAction159(138)
+		reduce_table.add new ReduceAction367(138)
+		reduce_table.add new ReduceAction368(138)
+		reduce_table.add new ReduceAction369(139)
+		reduce_table.add new ReduceAction370(139)
+		reduce_table.add new ReduceAction371(139)
+		reduce_table.add new ReduceAction372(139)
+		reduce_table.add new ReduceAction373(139)
+		reduce_table.add new ReduceAction374(139)
+		reduce_table.add new ReduceAction375(139)
+		reduce_table.add new ReduceAction376(139)
+		reduce_table.add new ReduceAction377(139)
+		reduce_table.add new ReduceAction378(139)
+		reduce_table.add new ReduceAction379(139)
+		reduce_table.add new ReduceAction380(139)
+		reduce_table.add new ReduceAction381(139)
+		reduce_table.add new ReduceAction382(139)
+		reduce_table.add new ReduceAction383(139)
+		reduce_table.add new ReduceAction159(139)
+		reduce_table.add new ReduceAction159(139)
+		reduce_table.add new ReduceAction146(140)
+		reduce_table.add new ReduceAction147(140)
+		reduce_table.add new ReduceAction148(140)
+		reduce_table.add new ReduceAction149(140)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction169(141)
+		reduce_table.add new ReduceAction170(141)
+		reduce_table.add new ReduceAction171(141)
+		reduce_table.add new ReduceAction172(141)
+		reduce_table.add new ReduceAction173(141)
+		reduce_table.add new ReduceAction174(141)
+		reduce_table.add new ReduceAction175(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction159(141)
+		reduce_table.add new ReduceAction183(141)
+		reduce_table.add new ReduceAction184(141)
+		reduce_table.add new ReduceAction185(141)
+		reduce_table.add new ReduceAction184(141)
+		reduce_table.add new ReduceAction187(141)
+		reduce_table.add new ReduceAction188(141)
+		reduce_table.add new ReduceAction189(141)
+		reduce_table.add new ReduceAction188(141)
+		reduce_table.add new ReduceAction191(141)
+		reduce_table.add new ReduceAction192(141)
+		reduce_table.add new ReduceAction193(141)
+		reduce_table.add new ReduceAction194(141)
+		reduce_table.add new ReduceAction195(141)
+		reduce_table.add new ReduceAction194(141)
+		reduce_table.add new ReduceAction197(141)
+		reduce_table.add new ReduceAction198(141)
+		reduce_table.add new ReduceAction197(141)
+		reduce_table.add new ReduceAction200(141)
+		reduce_table.add new ReduceAction207(142)
+		reduce_table.add new ReduceAction208(142)
+		reduce_table.add new ReduceAction209(142)
+		reduce_table.add new ReduceAction210(142)
+		reduce_table.add new ReduceAction211(142)
+		reduce_table.add new ReduceAction212(142)
+		reduce_table.add new ReduceAction213(142)
+		reduce_table.add new ReduceAction214(142)
+		reduce_table.add new ReduceAction211(142)
+		reduce_table.add new ReduceAction212(142)
+		reduce_table.add new ReduceAction217(142)
+		reduce_table.add new ReduceAction218(142)
+		reduce_table.add new ReduceAction219(142)
+		reduce_table.add new ReduceAction220(142)
+		reduce_table.add new ReduceAction221(142)
+		reduce_table.add new ReduceAction222(142)
+		reduce_table.add new ReduceAction219(142)
+		reduce_table.add new ReduceAction220(142)
+		reduce_table.add new ReduceAction225(142)
+		reduce_table.add new ReduceAction226(142)
+		reduce_table.add new ReduceAction227(142)
+		reduce_table.add new ReduceAction228(142)
+		reduce_table.add new ReduceAction229(142)
+		reduce_table.add new ReduceAction230(142)
+		reduce_table.add new ReduceAction231(142)
+		reduce_table.add new ReduceAction232(142)
+		reduce_table.add new ReduceAction233(142)
+		reduce_table.add new ReduceAction230(142)
+		reduce_table.add new ReduceAction231(142)
+		reduce_table.add new ReduceAction236(142)
+		reduce_table.add new ReduceAction237(142)
+		reduce_table.add new ReduceAction238(142)
+		reduce_table.add new ReduceAction239(142)
+		reduce_table.add new ReduceAction240(142)
+		reduce_table.add new ReduceAction241(142)
+		reduce_table.add new ReduceAction238(142)
+		reduce_table.add new ReduceAction239(142)
+		reduce_table.add new ReduceAction244(142)
+		reduce_table.add new ReduceAction159(143)
+		reduce_table.add new ReduceAction284(143)
+		reduce_table.add new ReduceAction159(144)
+		reduce_table.add new ReduceAction286(144)
+		reduce_table.add new ReduceAction287(144)
+		reduce_table.add new ReduceAction288(144)
+		reduce_table.add new ReduceAction289(144)
+		reduce_table.add new ReduceAction159(145)
+		reduce_table.add new ReduceAction291(145)
+		reduce_table.add new ReduceAction159(146)
+		reduce_table.add new ReduceAction293(146)
+		reduce_table.add new ReduceAction294(146)
+		reduce_table.add new ReduceAction295(146)
+		reduce_table.add new ReduceAction296(146)
+		reduce_table.add new ReduceAction297(146)
+		reduce_table.add new ReduceAction298(146)
+		reduce_table.add new ReduceAction299(146)
+		reduce_table.add new ReduceAction300(146)
+		reduce_table.add new ReduceAction159(147)
+		reduce_table.add new ReduceAction302(147)
+		reduce_table.add new ReduceAction159(148)
+		reduce_table.add new ReduceAction304(148)
+		reduce_table.add new ReduceAction159(149)
+		reduce_table.add new ReduceAction306(149)
+		reduce_table.add new ReduceAction159(150)
+		reduce_table.add new ReduceAction308(150)
+		reduce_table.add new ReduceAction309(150)
+		reduce_table.add new ReduceAction159(151)
+		reduce_table.add new ReduceAction311(151)
+		reduce_table.add new ReduceAction312(151)
+		reduce_table.add new ReduceAction159(152)
+		reduce_table.add new ReduceAction314(152)
+		reduce_table.add new ReduceAction315(152)
+		reduce_table.add new ReduceAction316(152)
+		reduce_table.add new ReduceAction159(153)
+		reduce_table.add new ReduceAction318(153)
+		reduce_table.add new ReduceAction159(154)
+		reduce_table.add new ReduceAction320(154)
+		reduce_table.add new ReduceAction321(154)
+		reduce_table.add new ReduceAction322(154)
+		reduce_table.add new ReduceAction323(154)
+		reduce_table.add new ReduceAction159(155)
+		reduce_table.add new ReduceAction325(155)
+		reduce_table.add new ReduceAction326(155)
+		reduce_table.add new ReduceAction327(155)
+		reduce_table.add new ReduceAction328(155)
+		reduce_table.add new ReduceAction159(156)
+		reduce_table.add new ReduceAction330(156)
+		reduce_table.add new ReduceAction331(156)
+		reduce_table.add new ReduceAction183(156)
+		reduce_table.add new ReduceAction333(156)
+		reduce_table.add new ReduceAction184(156)
+		reduce_table.add new ReduceAction335(156)
+		reduce_table.add new ReduceAction185(156)
+		reduce_table.add new ReduceAction337(156)
+		reduce_table.add new ReduceAction184(156)
+		reduce_table.add new ReduceAction335(156)
+		reduce_table.add new ReduceAction187(156)
+		reduce_table.add new ReduceAction341(156)
+		reduce_table.add new ReduceAction188(156)
+		reduce_table.add new ReduceAction343(156)
+		reduce_table.add new ReduceAction189(156)
+		reduce_table.add new ReduceAction345(156)
+		reduce_table.add new ReduceAction188(156)
+		reduce_table.add new ReduceAction343(156)
+		reduce_table.add new ReduceAction191(156)
+		reduce_table.add new ReduceAction349(156)
+		reduce_table.add new ReduceAction192(156)
+		reduce_table.add new ReduceAction351(156)
+		reduce_table.add new ReduceAction193(156)
+		reduce_table.add new ReduceAction353(156)
+		reduce_table.add new ReduceAction354(156)
+		reduce_table.add new ReduceAction355(156)
+		reduce_table.add new ReduceAction356(156)
+		reduce_table.add new ReduceAction357(156)
+		reduce_table.add new ReduceAction358(156)
+		reduce_table.add new ReduceAction359(156)
+		reduce_table.add new ReduceAction360(156)
+		reduce_table.add new ReduceAction357(156)
+		reduce_table.add new ReduceAction358(156)
+		reduce_table.add new ReduceAction363(156)
+		reduce_table.add new ReduceAction364(156)
+		reduce_table.add new ReduceAction365(156)
+		reduce_table.add new ReduceAction159(157)
+		reduce_table.add new ReduceAction367(157)
+		reduce_table.add new ReduceAction368(157)
+		reduce_table.add new ReduceAction369(158)
+		reduce_table.add new ReduceAction370(158)
+		reduce_table.add new ReduceAction371(158)
+		reduce_table.add new ReduceAction372(158)
+		reduce_table.add new ReduceAction373(158)
+		reduce_table.add new ReduceAction374(158)
+		reduce_table.add new ReduceAction375(158)
+		reduce_table.add new ReduceAction376(158)
+		reduce_table.add new ReduceAction377(158)
+		reduce_table.add new ReduceAction378(158)
+		reduce_table.add new ReduceAction379(158)
+		reduce_table.add new ReduceAction380(158)
+		reduce_table.add new ReduceAction381(158)
+		reduce_table.add new ReduceAction382(158)
+		reduce_table.add new ReduceAction383(158)
+		reduce_table.add new ReduceAction159(158)
+		reduce_table.add new ReduceAction408(159)
+		reduce_table.add new ReduceAction409(159)
+		reduce_table.add new ReduceAction410(160)
+		reduce_table.add new ReduceAction22(160)
+		reduce_table.add new ReduceAction412(161)
+		reduce_table.add new ReduceAction412(162)
+		reduce_table.add new ReduceAction393(163)
+		reduce_table.add new ReduceAction394(163)
+		reduce_table.add new ReduceAction434(164)
+		reduce_table.add new ReduceAction159(164)
+		reduce_table.add new ReduceAction159(164)
+		reduce_table.add new ReduceAction437(164)
+		reduce_table.add new ReduceAction438(164)
+		reduce_table.add new ReduceAction146(165)
+		reduce_table.add new ReduceAction147(165)
+		reduce_table.add new ReduceAction159(166)
+		reduce_table.add new ReduceAction284(166)
+		reduce_table.add new ReduceAction159(167)
+		reduce_table.add new ReduceAction286(167)
+		reduce_table.add new ReduceAction287(167)
+		reduce_table.add new ReduceAction288(167)
+		reduce_table.add new ReduceAction289(167)
+		reduce_table.add new ReduceAction159(168)
+		reduce_table.add new ReduceAction291(168)
+		reduce_table.add new ReduceAction159(169)
+		reduce_table.add new ReduceAction293(169)
+		reduce_table.add new ReduceAction294(169)
+		reduce_table.add new ReduceAction295(169)
+		reduce_table.add new ReduceAction296(169)
+		reduce_table.add new ReduceAction297(169)
+		reduce_table.add new ReduceAction298(169)
+		reduce_table.add new ReduceAction299(169)
+		reduce_table.add new ReduceAction300(169)
+		reduce_table.add new ReduceAction159(170)
+		reduce_table.add new ReduceAction302(170)
+		reduce_table.add new ReduceAction159(171)
+		reduce_table.add new ReduceAction304(171)
+		reduce_table.add new ReduceAction159(172)
+		reduce_table.add new ReduceAction306(172)
+		reduce_table.add new ReduceAction159(173)
+		reduce_table.add new ReduceAction308(173)
+		reduce_table.add new ReduceAction309(173)
+		reduce_table.add new ReduceAction159(174)
+		reduce_table.add new ReduceAction311(174)
+		reduce_table.add new ReduceAction312(174)
+		reduce_table.add new ReduceAction159(175)
+		reduce_table.add new ReduceAction314(175)
+		reduce_table.add new ReduceAction315(175)
+		reduce_table.add new ReduceAction316(175)
+		reduce_table.add new ReduceAction159(176)
+		reduce_table.add new ReduceAction318(176)
+		reduce_table.add new ReduceAction159(177)
+		reduce_table.add new ReduceAction320(177)
+		reduce_table.add new ReduceAction321(177)
+		reduce_table.add new ReduceAction322(177)
+		reduce_table.add new ReduceAction323(177)
+		reduce_table.add new ReduceAction159(178)
+		reduce_table.add new ReduceAction325(178)
+		reduce_table.add new ReduceAction326(178)
+		reduce_table.add new ReduceAction871(178)
+		reduce_table.add new ReduceAction159(179)
+		reduce_table.add new ReduceAction873(179)
+		reduce_table.add new ReduceAction874(179)
+		reduce_table.add new ReduceAction875(179)
+		reduce_table.add new ReduceAction876(179)
+		reduce_table.add new ReduceAction877(179)
+		reduce_table.add new ReduceAction183(179)
+		reduce_table.add new ReduceAction333(179)
+		reduce_table.add new ReduceAction876(179)
+		reduce_table.add new ReduceAction877(179)
+		reduce_table.add new ReduceAction191(179)
+		reduce_table.add new ReduceAction349(179)
+		reduce_table.add new ReduceAction884(179)
+		reduce_table.add new ReduceAction885(179)
+		reduce_table.add new ReduceAction355(179)
+		reduce_table.add new ReduceAction356(179)
+		reduce_table.add new ReduceAction357(179)
+		reduce_table.add new ReduceAction358(179)
+		reduce_table.add new ReduceAction359(179)
+		reduce_table.add new ReduceAction360(179)
+		reduce_table.add new ReduceAction357(179)
+		reduce_table.add new ReduceAction358(179)
+		reduce_table.add new ReduceAction363(179)
+		reduce_table.add new ReduceAction364(179)
+		reduce_table.add new ReduceAction365(179)
+		reduce_table.add new ReduceAction159(180)
+		reduce_table.add new ReduceAction367(180)
+		reduce_table.add new ReduceAction368(180)
+		reduce_table.add new ReduceAction369(181)
+		reduce_table.add new ReduceAction370(181)
+		reduce_table.add new ReduceAction371(181)
+		reduce_table.add new ReduceAction372(181)
+		reduce_table.add new ReduceAction373(181)
+		reduce_table.add new ReduceAction374(181)
+		reduce_table.add new ReduceAction375(181)
+		reduce_table.add new ReduceAction376(181)
+		reduce_table.add new ReduceAction377(181)
+		reduce_table.add new ReduceAction378(181)
+		reduce_table.add new ReduceAction379(181)
+		reduce_table.add new ReduceAction380(181)
+		reduce_table.add new ReduceAction381(181)
+		reduce_table.add new ReduceAction382(181)
+		reduce_table.add new ReduceAction383(181)
+		reduce_table.add new ReduceAction159(181)
+		reduce_table.add new ReduceAction916(182)
+		reduce_table.add new ReduceAction917(182)
+		reduce_table.add new ReduceAction156(183)
+		reduce_table.add new ReduceAction157(183)
+		reduce_table.add new ReduceAction158(183)
+		reduce_table.add new ReduceAction159(183)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction169(184)
+		reduce_table.add new ReduceAction170(184)
+		reduce_table.add new ReduceAction171(184)
+		reduce_table.add new ReduceAction172(184)
+		reduce_table.add new ReduceAction173(184)
+		reduce_table.add new ReduceAction174(184)
+		reduce_table.add new ReduceAction175(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction159(184)
+		reduce_table.add new ReduceAction183(184)
+		reduce_table.add new ReduceAction184(184)
+		reduce_table.add new ReduceAction185(184)
+		reduce_table.add new ReduceAction184(184)
+		reduce_table.add new ReduceAction187(184)
+		reduce_table.add new ReduceAction188(184)
+		reduce_table.add new ReduceAction189(184)
+		reduce_table.add new ReduceAction188(184)
+		reduce_table.add new ReduceAction191(184)
+		reduce_table.add new ReduceAction192(184)
+		reduce_table.add new ReduceAction193(184)
+		reduce_table.add new ReduceAction194(184)
+		reduce_table.add new ReduceAction195(184)
+		reduce_table.add new ReduceAction194(184)
+		reduce_table.add new ReduceAction197(184)
+		reduce_table.add new ReduceAction198(184)
+		reduce_table.add new ReduceAction197(184)
+		reduce_table.add new ReduceAction200(184)
+		reduce_table.add new ReduceAction256(185)
+		reduce_table.add new ReduceAction257(185)
+		reduce_table.add new ReduceAction258(186)
+		reduce_table.add new ReduceAction267(187)
+		reduce_table.add new ReduceAction268(187)
+		reduce_table.add new ReduceAction269(188)
+		reduce_table.add new ReduceAction270(188)
+		reduce_table.add new ReduceAction271(189)
+		reduce_table.add new ReduceAction272(189)
+		reduce_table.add new ReduceAction273(190)
+		reduce_table.add new ReduceAction274(190)
+		reduce_table.add new ReduceAction278(191)
+		reduce_table.add new ReduceAction279(191)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction169(192)
+		reduce_table.add new ReduceAction170(192)
+		reduce_table.add new ReduceAction171(192)
+		reduce_table.add new ReduceAction172(192)
+		reduce_table.add new ReduceAction173(192)
+		reduce_table.add new ReduceAction174(192)
+		reduce_table.add new ReduceAction175(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction159(192)
+		reduce_table.add new ReduceAction183(192)
+		reduce_table.add new ReduceAction184(192)
+		reduce_table.add new ReduceAction185(192)
+		reduce_table.add new ReduceAction184(192)
+		reduce_table.add new ReduceAction187(192)
+		reduce_table.add new ReduceAction188(192)
+		reduce_table.add new ReduceAction189(192)
+		reduce_table.add new ReduceAction188(192)
+		reduce_table.add new ReduceAction191(192)
+		reduce_table.add new ReduceAction192(192)
+		reduce_table.add new ReduceAction193(192)
+		reduce_table.add new ReduceAction194(192)
+		reduce_table.add new ReduceAction195(192)
+		reduce_table.add new ReduceAction194(192)
+		reduce_table.add new ReduceAction197(192)
+		reduce_table.add new ReduceAction198(192)
+		reduce_table.add new ReduceAction197(192)
+		reduce_table.add new ReduceAction200(192)
+		reduce_table.add new ReduceAction156(193)
+		reduce_table.add new ReduceAction157(193)
+		reduce_table.add new ReduceAction158(193)
+		reduce_table.add new ReduceAction156(194)
+		reduce_table.add new ReduceAction157(194)
+		reduce_table.add new ReduceAction158(194)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction169(195)
+		reduce_table.add new ReduceAction170(195)
+		reduce_table.add new ReduceAction171(195)
+		reduce_table.add new ReduceAction172(195)
+		reduce_table.add new ReduceAction173(195)
+		reduce_table.add new ReduceAction174(195)
+		reduce_table.add new ReduceAction175(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction159(195)
+		reduce_table.add new ReduceAction200(195)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction169(196)
+		reduce_table.add new ReduceAction170(196)
+		reduce_table.add new ReduceAction171(196)
+		reduce_table.add new ReduceAction172(196)
+		reduce_table.add new ReduceAction173(196)
+		reduce_table.add new ReduceAction174(196)
+		reduce_table.add new ReduceAction175(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction159(196)
+		reduce_table.add new ReduceAction200(196)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction169(197)
+		reduce_table.add new ReduceAction170(197)
+		reduce_table.add new ReduceAction171(197)
+		reduce_table.add new ReduceAction172(197)
+		reduce_table.add new ReduceAction173(197)
+		reduce_table.add new ReduceAction174(197)
+		reduce_table.add new ReduceAction175(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction159(197)
+		reduce_table.add new ReduceAction200(197)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction169(198)
+		reduce_table.add new ReduceAction170(198)
+		reduce_table.add new ReduceAction171(198)
+		reduce_table.add new ReduceAction172(198)
+		reduce_table.add new ReduceAction173(198)
+		reduce_table.add new ReduceAction174(198)
+		reduce_table.add new ReduceAction175(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction159(198)
+		reduce_table.add new ReduceAction200(198)
+		reduce_table.add new ReduceAction440(199)
+		reduce_table.add new ReduceAction442(199)
+		reduce_table.add new ReduceAction480(200)
+		reduce_table.add new ReduceAction481(200)
+		reduce_table.add new ReduceAction23(200)
+		reduce_table.add new ReduceAction1078(201)
+		reduce_table.add new ReduceAction1079(201)
+		reduce_table.add new ReduceAction1080(202)
+		reduce_table.add new ReduceAction1081(202)
+		reduce_table.add new ReduceAction1082(203)
+		reduce_table.add new ReduceAction1083(203)
+		reduce_table.add new ReduceAction37(204)
+		reduce_table.add new ReduceAction1085(204)
+		reduce_table.add new ReduceAction45(205)
+		reduce_table.add new ReduceAction1087(205)
+		reduce_table.add new ReduceAction414(206)
+		reduce_table.add new ReduceAction1089(206)
+		reduce_table.add new ReduceAction1090(207)
+		reduce_table.add new ReduceAction1091(207)
+		reduce_table.add new ReduceAction1092(208)
+		reduce_table.add new ReduceAction1093(208)
+		reduce_table.add new ReduceAction150(209)
+		reduce_table.add new ReduceAction1095(209)
+		reduce_table.add new ReduceAction393(210)
+		reduce_table.add new ReduceAction1097(210)
+		reduce_table.add new ReduceAction393(211)
+		reduce_table.add new ReduceAction1097(211)
+		reduce_table.add new ReduceAction393(212)
+		reduce_table.add new ReduceAction1097(212)
+		reduce_table.add new ReduceAction454(213)
+		reduce_table.add new ReduceAction1103(213)
+		reduce_table.add new ReduceAction414(214)
+		reduce_table.add new ReduceAction1089(214)
+		reduce_table.add new ReduceAction393(215)
+		reduce_table.add new ReduceAction1097(215)
+		reduce_table.add new ReduceAction393(216)
+		reduce_table.add new ReduceAction1097(216)
+		reduce_table.add new ReduceAction455(217)
+		reduce_table.add new ReduceAction1111(217)
+		reduce_table.add new ReduceAction1112(218)
+		reduce_table.add new ReduceAction1113(218)
+		reduce_table.add new ReduceAction477(219)
+		reduce_table.add new ReduceAction496(219)
 	end
 end
 

--- a/src/parser/xss/parser.xss
+++ b/src/parser/xss/parser.xss
@@ -20,11 +20,11 @@ $ template make_parser()
 redef class Parser
 	redef fun build_reduce_table
 	do
-		_reduce_table = new Array[ReduceAction].with_items(
+		var reduce_table = new Array[ReduceAction].with_capacity(${count(rules/rule)})
+		self.reduce_table = reduce_table
 $ foreach {rules/rule}
-			new ReduceAction@index(@leftside)[-sep ','-]
+		reduce_table.add new ReduceAction@index(@leftside)
 $ end foreach
-		)
 	end
 end
 


### PR DESCRIPTION
In `parser::Parser::build_reduce_table` an array is allocated with `.with_items` that takes a vararg.

The vararg used is quite large (1116 elements) and this cause that the generated C code takes 30m to compile with clang-3.6 if -O2 is used; it is likely a regression in llvm since the same code takes appreciatively 1s with clang-3.5 (and with gcc).

Unfortunately, clang-3.6 is currently provided by Apple to MacOS X users.

The proposed solution is to allocate the array then use a sequence of `add`. The generated C code is more complex but clang-3.6 can compile it.

Close #1498 (once c_src is regenerated)