### PR TITLE
Nitiwiki: relative links

### DIFF
--- a/contrib/nitiwiki/src/wiki_base.nit
+++ b/contrib/nitiwiki/src/wiki_base.nit
@@ -550,8 +550,10 @@ class WikiArticle
 	redef var src_full_path: nullable String = null
 
 	redef fun src_path do
+		var src_full_path = self.src_full_path
 		if src_full_path == null then return null
-		return src_full_path.substring_from(wiki.config.root_dir.length)
+		var res = wiki.config.root_dir.relpath(src_full_path)
+		return res
 	end
 
 	# The page markdown source content.

--- a/contrib/nitiwiki/src/wiki_base.nit
+++ b/contrib/nitiwiki/src/wiki_base.nit
@@ -194,9 +194,6 @@ class Nitiwiki
 		end
 		var file = expand_path(config.root_dir, config.templates_dir, name)
 		var tpl = new TemplateString.from_file(file)
-		if tpl.has_macro("ROOT_URL") then
-			tpl.replace("ROOT_URL", config.root_url)
-		end
 		if tpl.has_macro("TITLE") then
 			tpl.replace("TITLE", config.wiki_name)
 		end

--- a/contrib/nitiwiki/src/wiki_html.nit
+++ b/contrib/nitiwiki/src/wiki_html.nit
@@ -185,6 +185,12 @@ redef class WikiArticle
 	# Load a template and resolve page-related macros
 	fun load_template(template_file: String): TemplateString do
 		var tpl = wiki.load_template(template_file)
+		if tpl.has_macro("ROOT_URL") then
+			var root_dir = href.dirname.relpath("")
+			# Avoid issues if the macro is just followed by a `/` (as with url prefix)
+			if root_dir == "" then root_dir = "."
+			tpl.replace("ROOT_URL", root_dir)
+		end
 		return tpl
 	end
 

--- a/contrib/nitiwiki/src/wiki_html.nit
+++ b/contrib/nitiwiki/src/wiki_html.nit
@@ -133,15 +133,15 @@ redef class WikiSection
 	# </ul>
 	# ~~~
 	fun tpl_tree(limit: Int): Template do
-		return tpl_tree_intern(limit, 1)
+		return tpl_tree_intern(limit, 1, self)
 	end
 
 	# Build the template tree for this section recursively.
-	protected fun tpl_tree_intern(limit, count: Int): Template do
+	protected fun tpl_tree_intern(limit, count: Int, context: WikiEntry): Template do
 		var out = new Template
 		var index = index
 		out.add "<li>"
-		out.add tpl_link(self)
+		out.add tpl_link(context)
 		if (limit < 0 or count < limit) and
 		   (children.length > 1 or (children.length == 1)) then
 			out.add " <ul>"
@@ -149,10 +149,10 @@ redef class WikiSection
 				if child == index then continue
 				if child isa WikiArticle then
 					out.add "<li>"
-					out.add child.tpl_link(self)
+					out.add child.tpl_link(context)
 					out.add "</li>"
 				else if child isa WikiSection and not child.is_hidden then
-					out.add child.tpl_tree_intern(limit, count + 1)
+					out.add child.tpl_tree_intern(limit, count + 1, context)
 				end
 			end
 			out.add " </ul>"

--- a/contrib/nitiwiki/src/wiki_html.nit
+++ b/contrib/nitiwiki/src/wiki_html.nit
@@ -182,9 +182,15 @@ redef class WikiArticle
 	end
 
 
+	# Load a template and resolve page-related macros
+	fun load_template(template_file: String): TemplateString do
+		var tpl = wiki.load_template(template_file)
+		return tpl
+	end
+
 	# Replace macros in the template by wiki data.
 	private fun tpl_page: TemplateString do
-		var tpl = wiki.load_template(template_file)
+		var tpl = load_template(template_file)
 		if tpl.has_macro("TOP_MENU") then
 			tpl.replace("TOP_MENU", tpl_menu)
 		end
@@ -204,7 +210,7 @@ redef class WikiArticle
 	fun tpl_header: Writable do
 		var file = header_file
 		if not wiki.has_template(file) then return ""
-		return wiki.load_template(file)
+		return load_template(file)
 	end
 
 	# Generate the HTML page for this article.
@@ -262,7 +268,7 @@ redef class WikiArticle
 	fun tpl_menu: Writable do
 		var file = menu_file
 		if not wiki.has_template(file) then return ""
-		var tpl = wiki.load_template(file)
+		var tpl = load_template(file)
 		if tpl.has_macro("MENUS") then
 			var items = new Template
 			for child in wiki.root_section.children.values do
@@ -285,7 +291,7 @@ redef class WikiArticle
 	fun tpl_footer: Writable do
 		var file = footer_file
 		if not wiki.has_template(file) then return ""
-		var tpl = wiki.load_template(file)
+		var tpl = load_template(file)
 		var time = new Tm.gmtime
 		if tpl.has_macro("YEAR") then
 			tpl.replace("YEAR", (time.year + 1900).to_s)

--- a/contrib/nitiwiki/src/wiki_html.nit
+++ b/contrib/nitiwiki/src/wiki_html.nit
@@ -62,8 +62,8 @@ end
 
 redef class WikiEntry
 	# Get a `<a>` template link to `self`
-	fun tpl_link: Writable do
-		return "<a href=\"{url}\">{title}</a>"
+	fun tpl_link(context: WikiEntry): Writable do
+		return "<a href=\"{href_from(context)}\">{title}</a>"
 	end
 end
 
@@ -113,7 +113,7 @@ redef class WikiSection
 		end
 	end
 
-	redef fun tpl_link do return index.tpl_link
+	redef fun tpl_link(context) do return index.tpl_link(context)
 
 	# Render the section hierarchy as a html tree.
 	#
@@ -141,7 +141,7 @@ redef class WikiSection
 		var out = new Template
 		var index = index
 		out.add "<li>"
-		out.add tpl_link
+		out.add tpl_link(self)
 		if (limit < 0 or count < limit) and
 		   (children.length > 1 or (children.length == 1)) then
 			out.add " <ul>"
@@ -149,7 +149,7 @@ redef class WikiSection
 				if child == index then continue
 				if child isa WikiArticle then
 					out.add "<li>"
-					out.add child.tpl_link
+					out.add child.tpl_link(self)
 					out.add "</li>"
 				else if child isa WikiSection and not child.is_hidden then
 					out.add child.tpl_tree_intern(limit, count + 1)
@@ -279,7 +279,7 @@ redef class WikiArticle
 					items.add " class=\"active\""
 				end
 				items.add ">"
-				items.add child.tpl_link
+				items.add child.tpl_link(self)
 				items.add "</li>"
 			end
 			tpl.replace("MENUS", items)
@@ -430,7 +430,7 @@ class TplBreadcrumbs
 			else
 				if article.parent == entry and article.is_index then continue
 				add "<li>"
-				add entry.tpl_link
+				add entry.tpl_link(article)
 				add "</li>"
 			end
 		end

--- a/contrib/nitiwiki/src/wiki_links.nit
+++ b/contrib/nitiwiki/src/wiki_links.nit
@@ -90,8 +90,21 @@ end
 
 redef class WikiEntry
 
-	# Url to `self` once generated.
-	fun url: String do return wiki.config.root_url.join_path(breadcrumbs.join("/"))
+	# Absolute url to `self` once generated.
+	# If you use this, the generated files will hard-code `root_url`
+	fun url: String do return wiki.config.root_url / href
+
+	# Relative path to `self` from the target root_url
+	fun href: String do return breadcrumbs.join("/")
+
+	# A relative `href` to `self` from the page `context`.
+	#
+	# Should be used to navigate between documents.
+	fun href_from(context: WikiEntry): String
+	do
+		var res = context.href.dirname.relpath(href)
+		return res
+	end
 
 	redef fun render do
 		super
@@ -159,11 +172,11 @@ redef class WikiArticle
 	# Checks if `self.name == "index"`.
 	fun is_index: Bool do return name == "index"
 
-	redef fun url do
+	redef fun href do
 		if parent == null then
-			return wiki.config.root_url.join_path("{name}.html")
+			return "{name}.html"
 		else
-			return parent.url.join_path("{name}.html")
+			return parent.href.join_path("{name}.html")
 		end
 	end
 
@@ -184,7 +197,7 @@ class WikiSectionIndex
 
 	redef fun title do return section.title
 
-	redef fun url do return section.url
+	redef fun href do return section.href
 end
 
 # A MarkdownProcessor able to parse wiki links.

--- a/contrib/nitiwiki/src/wiki_links.nit
+++ b/contrib/nitiwiki/src/wiki_links.nit
@@ -248,7 +248,7 @@ private class NitiwikiDecorator
 			end
 			if target != null then
 				if name == null then name = target.title
-				link = target.url
+				link = target.href_from(context)
 			else
 				var loc = context.src_path or else context.name
 				wiki.message("Warning: unknown wikilink `{link}` (in {loc})", 0)

--- a/contrib/nitiwiki/tests/res/wiki1_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki1_nitiwiki_status.res
@@ -5,6 +5,6 @@ url: http://localhost/
 
 There is modified files:
  + pages
- + /pages/index.md
+ + pages/index.md
 
 Use nitiwiki --render to render modified files

--- a/contrib/nitiwiki/tests/res/wiki2_nitiwiki_render.res
+++ b/contrib/nitiwiki/tests/res/wiki2_nitiwiki_render.res
@@ -1,20 +1,20 @@
 Custom config for section sec2
 Render section out
-Warning: unknown wikilink `not found` (in /pages/index.md)
-Warning: unknown wikilink `Not Found` (in /pages/index.md)
-Warning: unknown wikilink `/not/found` (in /pages/index.md)
-Warning: unknown wikilink `not/found` (in /pages/index.md)
-Warning: unknown wikilink `not found` (in /pages/index.md)
-Warning: unknown wikilink `not found` (in /pages/index.md)
-Warning: unknown wikilink `not found` (in /pages/index.md)
+Warning: unknown wikilink `not found` (in pages/index.md)
+Warning: unknown wikilink `Not Found` (in pages/index.md)
+Warning: unknown wikilink `/not/found` (in pages/index.md)
+Warning: unknown wikilink `not/found` (in pages/index.md)
+Warning: unknown wikilink `not found` (in pages/index.md)
+Warning: unknown wikilink `not found` (in pages/index.md)
+Warning: unknown wikilink `not found` (in pages/index.md)
 Render section out/sec1
 Render section out/sec2
-Warning: unknown wikilink `not found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `Not Found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `/not/found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `not/found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `not found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `not found` (in /pages/sec2/index.md)
-Warning: unknown wikilink `not found` (in /pages/sec2/index.md)
+Warning: unknown wikilink `not found` (in pages/sec2/index.md)
+Warning: unknown wikilink `Not Found` (in pages/sec2/index.md)
+Warning: unknown wikilink `/not/found` (in pages/sec2/index.md)
+Warning: unknown wikilink `not/found` (in pages/sec2/index.md)
+Warning: unknown wikilink `not found` (in pages/sec2/index.md)
+Warning: unknown wikilink `not found` (in pages/sec2/index.md)
+Warning: unknown wikilink `not found` (in pages/sec2/index.md)
 Render section out/sec2/sub-sec21
 Render section out/sec2/sub-sec22

--- a/contrib/nitiwiki/tests/res/wiki2_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki2_nitiwiki_status.res
@@ -5,17 +5,17 @@ url: http://localhost/
 
 There is modified files:
  + pages
- + /pages/contact.md
- + /pages/index.md
- + /pages/other_page.md
+ + pages/contact.md
+ + pages/index.md
+ + pages/other_page.md
  + pages/sec1
- + /pages/sec1/index.md
+ + pages/sec1/index.md
  + pages/sec2
- + /pages/sec2/index.md
+ + pages/sec2/index.md
  + pages/sec2/sub-sec21
- + /pages/sec2/sub-sec21/index.md
+ + pages/sec2/sub-sec21/index.md
  + pages/sec2/sub-sec22
- + /pages/sec2/sub-sec22/index.md
- + /pages/sec2/sub-sec22/other.md
+ + pages/sec2/sub-sec22/index.md
+ + pages/sec2/sub-sec22/other.md
 
 Use nitiwiki --render to render modified files

--- a/contrib/nitiwiki/tests/res/wiki3_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki3_nitiwiki_status.res
@@ -5,8 +5,8 @@ url: http://localhost/
 
 There is modified files:
  + pages
- + /pages/contact.mdwn
- + /pages/index.mdwn
- + /pages/other_page.mdwn
+ + pages/contact.mdwn
+ + pages/index.mdwn
+ + pages/other_page.mdwn
 
 Use nitiwiki --render to render modified files

--- a/tests/sav/nitiwiki_args1.res
+++ b/tests/sav/nitiwiki_args1.res
@@ -5,6 +5,6 @@ url: http://localhost/
 
 There is modified files:
  + pages
- + /pages/index.md
+ + pages/index.md
 
 Use nitiwiki --render to render modified files


### PR DESCRIPTION
Use relative links in generated documents to avoid hard_coding `root_url`.

Demo: http://nitlanguage.org/beta/