### PR TITLE
Remove `char*` alias to NativeString

### DIFF
--- a/lib/standard/text/native.nit
+++ b/lib/standard/text/native.nit
@@ -14,7 +14,7 @@ module native
 import kernel
 
 # Native strings are simple C char *
-extern class NativeString `{ char* `}
+extern class NativeString
 	# Creates a new NativeString with a capacity of `length`
 	new(length: Int) is intern
 


### PR DESCRIPTION
Since this was a superfluous information, I figured it was better if we left it off the definition of the class