### PR TITLE
Nitunit fails bad code

### DIFF
--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -41,33 +41,39 @@ class MarkdownProcessor
 	#
 	#   In normal markdown the following:
 	#
-	#		This is a paragraph
-	#		* and this is not a list
+	# ~~~md
+	# This is a paragraph
+	# * and this is not a list
+	# ~~~
 	#
 	#   Will produce:
 	#
-	#		<p>This is a paragraph
-	#		* and this is not a list</p>
+	# ~~~html
+	# <p>This is a paragraph
+	# * and this is not a list</p>
+	# ~~~
 	#
-	#	When using extended mode this changes to:
+	#   When using extended mode this changes to:
 	#
-	#		<p>This is a paragraph</p>
-	#		<ul>
-	#		<li>and this is not a list</li>
-	#		</ul>
+	# ~~~html
+	# <p>This is a paragraph</p>
+	# <ul>
+	# <li>and this is not a list</li>
+	# </ul>
+	# ~~~
 	#
 	# * Fences code blocks
 	#
 	#   If you don't want to indent your all your code with 4 spaces,
 	#   you can wrap your code in ``` ``` ``` or `~~~`.
 	#
-	#	Here's an example:
+	#   Here's an example:
 	#
-	#		```
-	#		fun test do
-	#			print "Hello World!"
-	#		end
-	#		```
+	# ~~~md
+	# fun test do
+	#    print "Hello World!"
+	# end
+	# ~~~
 	#
 	# * Code blocks meta
 	#
@@ -76,43 +82,55 @@ class MarkdownProcessor
 	#   You can add an optional language identifier after the fence declaration to output
 	#   it in the HTML render.
 	#
-	#		```nit
-	#		import markdown
+	# ```nit
+	# import markdown
 	#
-	#		print "# Hello World!".md_to_html
-	#		```
+	# print "# Hello World!".md_to_html
+	# ```
 	#
 	#   Becomes
 	#
-	#		<pre class="nit"><code>import markdown
+	# ~~~html
+	# <pre class="nit"><code>import markdown
 	#
-	#		print "Hello World!".md_to_html
-	#		</code></pre>
+	# print "Hello World!".md_to_html
+	# </code></pre>
+	# ~~~
 	#
 	# * Underscores (Emphasis)
 	#
 	#   Underscores in the middle of a word like:
 	#
-	#		Con_cat_this
+	# ~~~md
+	# Con_cat_this
+	# ~~~
 	#
-	#	normally produces this:
+	#   normally produces this:
 	#
-	#		<p>Con<em>cat</em>this</p>
+	# ~~~html
+	# <p>Con<em>cat</em>this</p>
+	# ~~~
 	#
 	#   With extended mode they don't result in emphasis.
 	#
-	#		<p>Con_cat_this</p>
+	# ~~~html
+	# <p>Con_cat_this</p>
+	# ~~~
 	#
 	# * Strikethrough
 	#
 	#   Like in [GFM](https://help.github.com/articles/github-flavored-markdown),
 	#   strikethrought span is marked with `~~`.
 	#
-	#		~~Mistaken text.~~
+	# ~~~md
+	# ~~Mistaken text.~~
+	# ~~~
 	#
 	#   becomes
 	#
-	#		<del>Mistaken text.</del>
+	# ~~~html
+	# <del>Mistaken text.</del>
+	# ~~~
 	var ext_mode = true
 
 	init do self.emitter = new MarkdownEmitter(self)
@@ -250,8 +268,10 @@ class MarkdownProcessor
 	#
 	# Markdown allows link refs to be defined over two lines:
 	#
-	#	[id]: http://example.com/longish/path/to/resource/here
-	#		"Optional Title Here"
+	# ~~~md
+	# [id]: http://example.com/longish/path/to/resource/here
+	#	"Optional Title Here"
+	# ~~~
 	#
 	private var last_link_ref: nullable LinkRef = null
 

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -68,7 +68,6 @@ class NitUnitExecutor
 
 		# Populate `blocks` from the markdown decorator
 		mdproc.process(mdoc.content.join("\n"))
-		if blocks.is_empty then return
 
 		toolcontext.check_errors
 
@@ -82,6 +81,7 @@ class NitUnitExecutor
 			if blocks.is_empty then testsuite.add(tc)
 		end
 
+		if blocks.is_empty then return
 		for block in blocks do
 			docunits.add new DocUnit(mdoc, tc, block.write_to_string)
 		end

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -76,6 +76,7 @@ class NitUnitExecutor
 				var ne = new HTMLTag("failure")
 				ne.attr("message", msg)
 				tc.add ne
+				toolcontext.modelbuilder.unit_entities += 1
 				toolcontext.modelbuilder.failed_entities += 1
 			end
 			if blocks.is_empty then testsuite.add(tc)

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -5,3 +5,4 @@ test_nitunit2.nit -o $WRITE
 test_doc2.nit --no-color -o $WRITE
 test_nitunit3 --no-color -o $WRITE
 test_nitunit_md.md --no-color -o $WRITE
+test_doc3.nit --no-color -o $WRITE

--- a/tests/sav/nitunit_args6.res
+++ b/tests/sav/nitunit_args6.res
@@ -2,7 +2,7 @@ test_nitunit3/README.md: Error: there is a block of invalid Nit code, thus not c
 test_nitunit3/README.md: ERROR: nitunit.test_nitunit3.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
 
 DocUnits:
-Entities: 2; Documented ones: 2; With nitunits: 2; Failures: 2
+Entities: 2; Documented ones: 2; With nitunits: 3; Failures: 2
 
 TestSuites:
 No test cases found

--- a/tests/sav/nitunit_args8.res
+++ b/tests/sav/nitunit_args8.res
@@ -1,0 +1,10 @@
+test_doc3.nit:15,1--18,0: Error: there is a block of invalid Nit code, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,3--9: Syntax Error: unexpected identifier 'garbage'..
+test_doc3.nit:20,1--25,0: Error: there is a block of invalid Nit code, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,2--8: Syntax Error: unexpected identifier 'garbage'..
+test_doc3.nit:27,1--32,0: Error: there is a block of invalid Nit code, thus not considered a nitunit. To suppress this warning, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`). At 1,2--8: Syntax Error: unexpected identifier 'garbage'..
+DocUnits:
+Entities: 6; Documented ones: 5; With nitunits: 3; Failures: 3
+
+TestSuites:
+No test cases found
+Class suites: 0; Test Cases: 0; Failures: 0
+<testsuites><testsuite package="test_doc3"><testcase classname="nitunit.test_doc3.standard::Sys" name="test_doc3::Sys::foo1"><failure message="test_doc3.nit:15,1--18,0: Invalid block of code. At 1,3--9: Syntax Error: unexpected identifier &#39;garbage&#39;.."></failure></testcase><testcase classname="nitunit.test_doc3.standard::Sys" name="test_doc3::Sys::foo2"><failure message="test_doc3.nit:20,1--25,0: Invalid block of code. At 1,2--8: Syntax Error: unexpected identifier &#39;garbage&#39;.."></failure></testcase><testcase classname="nitunit.test_doc3.standard::Sys" name="test_doc3::Sys::foo3"><failure message="test_doc3.nit:27,1--32,0: Invalid block of code. At 1,2--8: Syntax Error: unexpected identifier &#39;garbage&#39;.."></failure></testcase></testsuite><testsuite></testsuite></testsuites>

--- a/tests/test_doc3.nit
+++ b/tests/test_doc3.nit
@@ -1,0 +1,46 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test code
+#
+#      *garbage*
+fun foo1 do end
+
+# Test code
+#
+# ~~~
+# *garbage*
+# ~~~
+fun foo2 do end
+
+# Test code
+#
+# ~~~nit
+# *garbage*
+# ~~~
+fun foo3 do end
+
+# Test code
+#
+# ~~~raw
+# *garbage*
+# ~~~
+fun foo4 do end
+
+# Test code
+#
+# ~~~nitish
+# *garbage*
+# ~~~
+fun foo5 do end


### PR DESCRIPTION
Documentation that contains only bad code (not tagged) is now reported by nitunit as it should be.
