### PR TITLE
Bug fixes in SSA module

### DIFF
--- a/src/ssa.nit
+++ b/src/ssa.nit
@@ -706,7 +706,7 @@ redef class AAssertExpr
 			self.n_else.generate_basic_blocks(ssa, block_false)
 		else
 			block_false.first = self
-			block_false.first = self
+			block_false.last = self
 		end
 
 		old_block.link(block_false)
@@ -1083,6 +1083,8 @@ redef class AWhileExpr
 
 		# Create a new Block after the while
 		var new_block = new BasicBlock
+		new_block.first = self
+		new_block.last = self
 		new_block.need_update = true
 
 		old_block.link_special(new_block)
@@ -1131,6 +1133,9 @@ redef class AForExpr
 		block.link(old_block)
 
 		var new_block = new BasicBlock
+		new_block.first = self
+		new_block.last = self
+
 		new_block.need_update = true
 
 		return new_block

--- a/src/ssa.nit
+++ b/src/ssa.nit
@@ -1076,7 +1076,7 @@ redef class AWhileExpr
 		old_block.link(block)
 
 		self.n_expr.generate_basic_blocks(ssa, old_block)
-		var inside_block = self.n_block.generate_basic_blocks(ssa, block)
+		self.n_block.generate_basic_blocks(ssa, block)
 
 		# Link the inside of the block to the previous block
 		block.link_special(old_block)


### PR DESCRIPTION
This small PR fixes two bugs in SSA.

First: A property was unecessary specific in the hierarchy.
Second: Bad initialization of two attributes which cause runtime error in new tests.
