### PR TITLE
niti-ffi: NativeString is re-a `char*` since #1502

### DIFF
--- a/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
+++ b/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
@@ -96,7 +96,7 @@ private extern class CallArg `{ nit_call_arg* `}
 	fun instance=(value: Instance) `{ self->value_Pointer = value; `}
 
 	# The `NativeString` held by this cell
-	fun native_string: NativeString `{ return (unsigned char*)self->value_Pointer; `}
+	fun native_string: NativeString `{ return (char*)self->value_Pointer; `}
 
 	# Set the content of this cell according to `static_type`
 	#


### PR DESCRIPTION
This removes a warning during the initial make.