### PR TITLE
Opportunity i18n & traduction française

### DIFF
--- a/contrib/opportunity/.gitignore
+++ b/contrib/opportunity/.gitignore
@@ -1,0 +1,2 @@
+src/templates/languages/*.pot
+src/templates/languages/fr/LC_MESSAGES/*.mo

--- a/contrib/opportunity/Makefile
+++ b/contrib/opportunity/Makefile
@@ -1,3 +1,6 @@
-all:
+all: fr
 	mkdir -p bin/
 	../../bin/nitc --dir bin/ src/opportunity_web.nit
+
+fr:
+	make -C src/templates/languages/fr/LC_MESSAGES/

--- a/contrib/opportunity/src/templates/boilerplate.nit
+++ b/contrib/opportunity/src/templates/boilerplate.nit
@@ -23,7 +23,7 @@ class OpportunityHeader
 	super Template
 
 	# Javascript code that is included in the `OpportunityPage`
-	var page_js = "" is writable
+	var page_js: String = "" is writable # FIXME remove static type when #1530 is fixed
 
 	redef fun rendering do
 		add """

--- a/contrib/opportunity/src/templates/boilerplate.nit
+++ b/contrib/opportunity/src/templates/boilerplate.nit
@@ -13,9 +13,10 @@
 # limitations under the License
 
 # Contains the main components of a webpage for Opportunity
-module boilerplate
+module boilerplate is i18n
 
 import template
+import gettext
 
 # Header for a Opportunity page
 class OpportunityHeader
@@ -29,7 +30,7 @@ class OpportunityHeader
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Opportunity - The meetup planner</title>
+	<title>{{{"Opportunity - The meetup planner"}}}</title>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
@@ -69,14 +70,13 @@ class OpportunityHeader
 <nav class="menu" role="navigation">
 	<div class="container">
 		<div class="navbar-header">
-			<a class="navbar-brand" href="./" >Opportunity</a>
+			<a class="navbar-brand" href="./" >{{{"Opportunity"}}}</a>
 		</div>
 	</div>
 </nav>
 <div class="container">
 """
 	end
-
 end
 
 # Footer for a Opportunity page
@@ -89,10 +89,10 @@ class OpportunityFooter
 <div class="footer">
 	<div class="well well-sm">
 		<p class="text-muted text-center">
-			Opportunity, the meetup planner.
+			{{{"Opportunity, the meetup planner."}}}
 		</p>
 		<p class="text-muted text-center">
-			Proudly powered by <a href="http://nitlanguage.org/">Nit</a>!
+			{{{"Proudly powered by %1!".format("<a href=\"http://nitlanguage.org/\">Nit</a>")}}}
 		</p>
 	</div>
 </div>
@@ -100,7 +100,6 @@ class OpportunityFooter
 </html>
 """
 	end
-
 end
 
 # Any Opportunity page that contains the header, body and footer.

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/Makefile
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/Makefile
@@ -1,0 +1,6 @@
+all:
+	msgfmt boilerplate.po -o boilerplate.mo
+	msgfmt welcome.po -o welcome.mo
+	msgfmt meetup.po -o meetup.mo
+	msgfmt meetup_creation.po -o meetup_creation.mo
+	msgfmt meetup_confirmation.po -o meetup_confirmation.mo

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/boilerplate.po
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/boilerplate.po
@@ -1,0 +1,11 @@
+msgid "Opportunity - The meetup planner"
+msgstr "Opportunité - L'organisateur d'événements"
+
+msgid "Opportunity"
+msgstr "Opportunité"
+
+msgid "Opportunity, the meetup planner."
+msgstr "Opportunité, l'organisateur d'événements."
+
+msgid "Proudly powered by %1!"
+msgstr "Fièrement codé en %1!"

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup.po
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup.po
@@ -1,0 +1,20 @@
+msgid "When:"
+msgstr "Quand:"
+
+msgid "Where:"
+msgstr "Où:"
+
+msgid "Participant name"
+msgstr "Nom du participant"
+
+msgid "Modify or delete"
+msgstr "Modifier ou effacer"
+
+msgid "Delete"
+msgstr "Effacer"
+
+msgid "Your name"
+msgstr "Votre nom"
+
+msgid "Done"
+msgstr "Fait"

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup_confirmation.po
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup_confirmation.po
@@ -1,0 +1,8 @@
+msgid "Your meetup was successfully created"
+msgstr "Votre événement a été créé avec succès"
+
+msgid "Invite participants by sharing this link:"
+msgstr "Invitez les participants en partageant ce lien:"
+
+msgid "See you soon for more Opportunities!"
+msgstr "Revenez bientôt pour plus d'Opportunités!"

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup_creation.po
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/meetup_creation.po
@@ -1,0 +1,53 @@
+#: templates::meetup_creation 52--109:129, templates::meetup_creation 125--24:44
+msgid "Another opportunity"
+msgstr "Une autre opportunité"
+
+#: templates::meetup_creation 66--126:132
+msgid "Close"
+msgstr "Fermer"
+
+#: templates::meetup_creation 79--64:76
+msgid "Meetup name"
+msgstr "Nom de l'événement"
+
+#: templates::meetup_creation 81--98:107
+msgid "My Event"
+msgstr "Mon événement"
+
+#: templates::meetup_creation 85--64:70
+msgid "When?"
+msgstr "Quand?"
+
+#: templates::meetup_creation 87--98:116
+msgid "Time of the event"
+msgstr "Moment de l'événement"
+
+#: templates::meetup_creation 91--66:73
+msgid "Where?"
+msgstr "Où?"
+
+#: templates::meetup_creation 93--100:119
+msgid "Place of the event"
+msgstr "Endroit de l'événement"
+
+#: templates::meetup_creation 97--65:85
+msgid "Add a Maybe option?"
+msgstr "Ajouter l'option 'peut-être'"
+
+#: templates::meetup_creation 124--20:38
+msgid "First opportunity"
+msgstr "Première opportunité"
+
+#: templates::meetup_creation 142--76:95
+msgid "Add an opportunity"
+msgstr "Ajouter une opportunité"
+
+#: templates::meetup_creation 143--61:75
+msgid "Create meetup"
+msgstr "Créer l'événement"
+
+msgid "Create a meetup"
+msgstr "Créer un nouvel événement"
+
+msgid "Opportunities"
+msgstr "Opportunités"

--- a/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/welcome.po
+++ b/contrib/opportunity/src/templates/languages/fr/LC_MESSAGES/welcome.po
@@ -1,0 +1,17 @@
+msgid "Welcome to Opportunity!"
+msgstr "Bienvenue sur Opportunité!"
+
+msgid ""
+"Opportunity is a free (as in free software), easy-to-use, meetup planner."
+msgstr ""
+"Opportunité aide à l'organisation d'événements simplement et librement."
+
+msgid ""
+"You can start using it right now by creating a new Meetup and sharing it "
+"with your friends!"
+msgstr ""
+"Vous pouvez utiliser Opportunité dès maintenant et impressionner vos "
+"amis!"
+
+msgid "Create a Meetup"
+msgstr "Créer un événement"

--- a/contrib/opportunity/src/templates/meetup.nit
+++ b/contrib/opportunity/src/templates/meetup.nit
@@ -13,7 +13,7 @@
 # limitations under the License
 
 # Shows a meetup and allows to modify its participants
-module meetup
+module meetup is i18n
 
 import opportunity_model
 import boilerplate
@@ -231,14 +231,14 @@ class OpportunityMeetupPage
 		function modify_people(ele, id){
 			if (in_modification_id != null) {
 				// reset to normal values
-				$('#modify_'+in_modification_id).text("Modify or delete");
+				$('#modify_'+in_modification_id).text("{{{"Modify or delete"}}}");
 				$('#modify_'+in_modification_id).attr("class", "btn btn-xs btn-warning");
 				$('#line_'+in_modification_id).css("background-color", "");
 				$('#delete_'+in_modification_id).css("display", "none");
 			}
 			if (in_modification_id != id) {
 				// activate modifiable mode
-				$('#modify_'+id).text("Done");
+				$('#modify_'+id).text("{{{"Done"}}}");
 				$('#modify_'+id).attr("class", "btn btn-xs btn-success");
 				$('#line_'+id).css("background-color", "LightYellow");
 				$('#delete_'+id).show();
@@ -274,16 +274,16 @@ redef class Meetup
 	<center><h1>{{{name}}}</h1></center>
 """
 		if not date.is_empty then t.add """
-	<center><h4>When: {{{date}}}</h4></center>"""
+	<center><h4>{{{"When:"}}} {{{date}}}</h4></center>"""
 
 		if not place.is_empty then t.add """
-	<center><h4>Where: {{{place}}}</h4></center>"""
+	<center><h4>{{{"Where:"}}} {{{place}}}</h4></center>"""
 
 		t.add """
 </div>
 <table class="table">
 """
-		t.add "<th>Participant name</th>"
+		t.add "<th>{"Participant name"}</th>"
 		for i in answers(db) do
 			t.add "<th class=\"text-center\">"
 			t.add i.to_s
@@ -333,19 +333,19 @@ redef class Meetup
 				end
 				t.add "</center></td>"
 			end
-			t.add """<td class="opportunity-action"><center><button class="btn btn-xs btn-warning" type="button" onclick="modify_people(this, {{{i.id}}})" id="modify_{{{i.id}}}">Modify or delete</button>&nbsp;"""
-			t.add """<button class="btn btn-xs btn-danger" type="button" onclick="remove_people(this)" id="delete_{{{i.id}}}" style="display: none;">Delete</button></center></td>"""
+			t.add """<td class="opportunity-action"><center><button class="btn btn-xs btn-warning" type="button" onclick="modify_people(this, {{{i.id}}})" id="modify_{{{i.id}}}">{{{"Modify or delete"}}}</button>&nbsp;"""
+			t.add """<button class="btn btn-xs btn-danger" type="button" onclick="remove_people(this)" id="delete_{{{i.id}}}" style="display: none;">{{{"Delete"}}}</button></center></td>"""
 			t.add "</tr>"
 		end
 		t.add """
 <tr id="newrow" style="background-color: LightYellow">
-	<td><input id="new_name" type="text" placeholder="Your name" class="input-large"></td>
+	<td><input id="new_name" type="text" placeholder="{{{"Your name"}}}" class="input-large"></td>
 		"""
 		for i in answers(db) do
 			t.add "<td class=\"answer\" id=\"newans_{i.id}\" onclick=\"change_temp_answer(this)\" style=\"color:red;\"><center>✘</center></td>"
 		end
 		t.add """
-	<td><center><span id="add_{{{id}}}" onclick="add_part(this)" style="color:green;" class="action"><button class="btn btn-xs btn-success" type="button">Done</button></span></center></td>"""
+	<td><center><span id="add_{{{id}}}" onclick="add_part(this)" style="color:green;" class="action"><button class="btn btn-xs btn-success" type="button">{{{"Done"}}}</button></span></center></td>"""
 		t.add "</tr>"
 		# Compute score for each answer
 		var scores = new HashMap[Int, Int]

--- a/contrib/opportunity/src/templates/meetup_confirmation.nit
+++ b/contrib/opportunity/src/templates/meetup_confirmation.nit
@@ -13,7 +13,7 @@
 # limitations under the License
 
 # Page to show when the creation of a Meetup is successful
-module meetup_confirmation
+module meetup_confirmation is i18n
 
 import boilerplate
 import opportunity_model
@@ -27,14 +27,14 @@ class MeetupConfirmation
 	init do
 		body = """
 		<div class="page-header">
-			<center><h1>Your meetup was successfully created</h1></center>
+			<center><h1>{{{"Your meetup was successfully created"}}}</h1></center>
 		</div>
 		<div class="container">
 			<div class="alert alert-success text-center" role="alert">
-			Invite participants by sharing this link: <a href="./?meetup_id={{{meetup.id}}}">{{{meetup.name}}}</a>
+			{{{"Invite participants by sharing this link:"}}} <a href="./?meetup_id={{{meetup.id}}}">{{{meetup.name}}}</a>
 			</div>
 			<p class="text-center">
-			See you soon for more Opportunities!
+			{{{"See you soon for more Opportunities!"}}}
 			</p>
 		</div>
 		"""

--- a/contrib/opportunity/src/templates/meetup_creation.nit
+++ b/contrib/opportunity/src/templates/meetup_creation.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-module meetup_creation
+module meetup_creation is i18n
 
 import boilerplate
 import opportunity_model
@@ -49,7 +49,7 @@ function new_answer(sender){
 	ansdiv.append('<div class="form-group">' +
 		'<label for="answer_' + nb + '" class="col-sm-4 control-label">' + nb + '</label>' +
 		'<div class="col-sm-8">' +
-			'<input name="answer_' + nb + '" id="answer_' + nb + '" class="form-control" type="text" placeholder="Another opportunity">' +
+			'<input name="answer_' + nb + '" id="answer_' + nb + '" class="form-control" type="text" placeholder="{{{"Another opportunity"}}}">' +
 		'</div></div>')
 }
 """
@@ -63,7 +63,7 @@ function new_answer(sender){
 		if error != null then
 			bdy.add "<p></p>"
 			bdy.add """<div class="alert alert-danger alert-dismissible" role="alert">
-				<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+				<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">{{{"Close"}}}</span></button>
 				"""
 			bdy.add error.as(not null)
 			bdy.add "</div>"
@@ -71,35 +71,35 @@ function new_answer(sender){
 
 		bdy.add """
 		<div class="page-header">
-			<center><h1>Create a meetup</h1></center>
+			<center><h1>{{{"Create a meetup"}}}</h1></center>
 		</div>
 		"""
 		bdy.add """<form class="form-horizontal" action="meetup_create" method="POST" role="form">
 			<div class = "form-group">
-				<label for="meetup_name" class="col-sm-4 control-label">Meetup name</label>
+				<label for="meetup_name" class="col-sm-4 control-label">{{{"Meetup name"}}}</label>
 				<div class="col-sm-8">
-					<input name="meetup_name" id="meetup_name" type="text" class="form-control" placeholder="My Event" value="{{{if meet != null then meet.name else ""}}}" />
+					<input name="meetup_name" id="meetup_name" type="text" class="form-control" placeholder="{{{"My Event"}}}" value="{{{if meet != null then meet.name else ""}}}" />
 				</div>
 			</div>
 			<div class = "form-group">
-				<label for="meetup_date" class="col-sm-4 control-label">When?</label>
+				<label for="meetup_date" class="col-sm-4 control-label">{{{"When?"}}}</label>
 				<div class="col-sm-8">
-					<input name="meetup_date" id="meetup_date" type="text" class="form-control" placeholder="Time of the event" value="{{{if meet != null then meet.date else ""}}}">
+					<input name="meetup_date" id="meetup_date" type="text" class="form-control" placeholder="{{{"Time of the event"}}}" value="{{{if meet != null then meet.date else ""}}}">
 				</div>
 			</div>
 			<div class = "form-group">
-				<label for="meetup=place" class="col-sm-4 control-label">Where?</label>
+				<label for="meetup=place" class="col-sm-4 control-label">{{{"Where?"}}}</label>
 				<div class="col-sm-8">
-					<input name="meetup_place" id="meetup_place" type="text" class="form-control" placeholder="Place of the event" value="{{{if meet != null then meet.place else ""}}}">
+					<input name="meetup_place" id="meetup_place" type="text" class="form-control" placeholder="{{{"Place of the event"}}}" value="{{{if meet != null then meet.place else ""}}}">
 				</div>
 			</div>
 			<div class = "form-group">
-				<label for="meetup=maybe" class="col-sm-4 control-label">Add a Maybe option?</label>
+				<label for="meetup=maybe" class="col-sm-4 control-label">{{{"Add a Maybe option?"}}}</label>
 				<div class="col-sm-8">
 					<input name="meetup_mode" id="meetup_mode" type="checkbox" class="form-control">
 				</div>
 			</div>
-				<h2>Opportunities</h2>
+				<h2>{{{"Opportunities"}}}</h2>
 <div id="answers">
 """
 
@@ -139,8 +139,8 @@ function new_answer(sender){
 		bdy.add """
 			</div>
 			<div class="form-group">
-				<button type="button" class="btn btn-lg" onclick="new_answer(this)">Add an opportunity</button>
-				<button type="submit" class="btn btn-lg btn-success">Create meetup</button>
+				<button type="button" class="btn btn-lg" onclick="new_answer(this)">{{{"Add an opportunity"}}}</button>
+				<button type="submit" class="btn btn-lg btn-success">{{{"Create meetup"}}}</button>
 			</div>
 		</form>
 		</center>

--- a/contrib/opportunity/src/templates/welcome.nit
+++ b/contrib/opportunity/src/templates/welcome.nit
@@ -13,7 +13,7 @@
 # limitations under the License
 
 # Welcome page for Opportunity
-module welcome
+module welcome is i18n
 
 import boilerplate
 
@@ -24,18 +24,17 @@ class OpportunityHomePage
 	init do
 		body = """
 		<div class="page-header">
-		<h1 class="text-center">Welcome to Opportunity!</h1>
+		<h1 class="text-center">{{{"Welcome to Opportunity!"}}}</h1>
 			</div>
 			<p class="text-center">
-				<p class="text-center">Opportunity is a free (as in free software), easy-to-use, meetup planner.</p>
-				<p class="text-center">You can start using it right now by creating a new Meetup and sharing it with your friends!</p>
+				<p class="text-center">{{{"Opportunity is a free (as in free software), easy-to-use, meetup planner."}}}</p>
+				<p class="text-center">{{{"You can start using it right now by creating a new Meetup and sharing it with your friends!"}}}</p>
 				<p class="text-center">
 				<form action="new_meetup">
-				<button type="submit" class="btn btn-lg center-block btn-success">Create a Meetup</button>
+				<button type="submit" class="btn btn-lg center-block btn-success">{{{"Create a Meetup"}}}</button>
 				</form>
 				</p>
 			</p>
 """
 	end
-
 end

--- a/lib/standard/text/abstract_text.nit
+++ b/lib/standard/text/abstract_text.nit
@@ -868,8 +868,12 @@ abstract class Text
 				i -= 1
 				var fmt_end = i
 				var ciph_len = fmt_end - ciph_st + 1
+
+				var arg_index = substring(ciph_st, ciph_len).to_i - 1
+				if arg_index >= args.length then continue
+
 				s.push substring(curr_st, fmt_st - curr_st)
-				s.push args[substring(ciph_st, ciph_len).to_i - 1].to_s
+				s.push args[arg_index].to_s
 				curr_st = i + 1
 			end
 			i += 1

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -143,7 +143,8 @@ redef class ASuperstringExpr
 		var fmt = ""
 		var exprs = new Array[AExpr]
 		for i in n_exprs do
-			if i isa AStringFormExpr then
+			if i isa AStartStringExpr or i isa AEndStringExpr or i isa AMidStringExpr then
+				assert i isa AStringFormExpr
 				fmt += i.value.as(not null)
 			else
 				fmt += "%"

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -130,8 +130,9 @@ end
 redef class AStringExpr
 
 	redef fun accept_string_finder(v) do
-		var parse = v.toolcontext.parse_expr("\"{str}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit")
 		var str = value.as(not null).escape_to_gettext
+		var code = "\"{str}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit"
+		var parse = v.toolcontext.parse_expr(code)
 		replace_with(parse)
 		v.add_string(str, location)
 	end
@@ -154,7 +155,8 @@ redef class ASuperstringExpr
 		end
 		fmt = fmt.escape_to_gettext
 		v.add_string(fmt, location)
-		var parse = v.toolcontext.parse_expr("\"{fmt}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit.format()")
+		var code = "\"{fmt}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit.format()"
+		var parse = v.toolcontext.parse_expr(code)
 		if not parse isa ACallExpr then
 			v.toolcontext.error(location, "Fatal error in i18n annotation, the parsed superstring could not be generated properly")
 			return

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -131,7 +131,7 @@ redef class AStringExpr
 
 	redef fun accept_string_finder(v) do
 		var str = value.as(not null).escape_to_gettext
-		var code = "\"{str}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit"
+		var code = "\"{str}\".get_translation(\"{v.domain}\", \"{v.languages_location}\")"
 		var parse = v.toolcontext.parse_expr(code)
 		replace_with(parse)
 		v.add_string(str, location)
@@ -155,7 +155,7 @@ redef class ASuperstringExpr
 		end
 		fmt = fmt.escape_to_gettext
 		v.add_string(fmt, location)
-		var code = "\"{fmt}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit.format()"
+		var code = "\"{fmt}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").format()"
 		var parse = v.toolcontext.parse_expr(code)
 		if not parse isa ACallExpr then
 			v.toolcontext.error(location, "Fatal error in i18n annotation, the parsed superstring could not be generated properly")

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -130,8 +130,8 @@ end
 redef class AStringExpr
 
 	redef fun accept_string_finder(v) do
-		var str = value.as(not null).escape_to_c
 		var parse = v.toolcontext.parse_expr("\"{str}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit")
+		var str = value.as(not null).escape_to_gettext
 		replace_with(parse)
 		v.add_string(str, location)
 	end
@@ -152,7 +152,7 @@ redef class ASuperstringExpr
 				fmt += exprs.length.to_s
 			end
 		end
-		fmt = fmt.escape_to_c
+		fmt = fmt.escape_to_gettext
 		v.add_string(fmt, location)
 		var parse = v.toolcontext.parse_expr("\"{fmt}\".get_translation(\"{v.domain}\", \"{v.languages_location}\").unescape_nit.format()")
 		if not parse isa ACallExpr then
@@ -215,5 +215,12 @@ class POFile
 		var f = new FileWriter.open(path)
 		write_to(f)
 		f.close
+	end
+end
+
+redef class Text
+	private fun escape_to_gettext: String
+	do
+		return escape_to_c.replace("\{", "\\\{").replace("\}", "\\\}")
 	end
 end


### PR DESCRIPTION
This PR brings partial i18n support to Opportunity with a french translation. Most strings from the
 UI are covered but not the error messages. This PR also fixes a few bugs in the i18n phase.

I still have difficulty with the deployment. Launching my web server use `LANGUAGE=fr sudo bin/xymus_net` works, but not when using `daemonize -E LANGUAGE=fr ...`. @R4PaSs do you have an idea for a solution?

http://xymus.net/opportunity/ temporary serves the French version of the site. I may have to revert tot the English version if I need monit and I can't fix the locale issue.