### PR TITLE
Personalized tests

### DIFF
--- a/tests/Darwin.skip
+++ b/tests/Darwin.skip
@@ -1,0 +1,5 @@
+mnit
+android
+java
+jvm
+neo

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -372,19 +372,25 @@ need_skip()
 skip_exec()
 {
 	test "$noskip" = true && return 1
-	if echo "$1" | grep -f "exec.skip" >/dev/null 2>&1; then
-		echo -n "_ "
-		return 0
-	fi
+	for savdir in $savdirs .; do
+		f="$savdir/exec.skip"
+		if echo "$1" | grep -f "$f" >/dev/null 2>&1; then
+			echo -n "_ no exec by $f; "
+			return 0
+		fi
+	done
 	return 1
 }
 
 skip_cc()
 {
 	test "$noskip" = true && return 1
-	if echo "$1" | grep -f "cc.skip" >/dev/null 2>&1; then
-		return 0
-	fi
+	for savdir in $savdirs .; do
+		f="$savdir/cc.skip"
+		if echo "$1" | grep -f "$f" >/dev/null 2>&1; then
+			return 0
+		fi
+	done
 	return 1
 }
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -481,7 +481,7 @@ case $engine in
 		;;
 esac
 
-savdirs="sav/$engine $savdirs sav/"
+savdirs="sav/`hostname -s` sav/`uname` sav/$engine $savdirs sav/"
 
 # The default nitc compiler
 [ -z "$NITC" ] && find_nitc

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -366,6 +366,14 @@ need_skip()
 		echo >>$xml "<testcase classname='`xmlesc "$3"`' name='`xmlesc "$2"`' `timestamp`><skipped/></testcase>"
 		return 0
 	fi
+
+	# Skip by hostname
+	host_skip_file=`hostname -s`.skip
+	if test -e $host_skip_file && echo "$1" | grep -f "$host_skip_file" >/dev/null 2>&1; then
+		echo "=> $2: [skip hostname]"
+		echo >>$xml "<testcase classname='`xmlesc "$3"`' name='`xmlesc "$2"`' `timestamp`><skipped/></testcase>"
+		return 0
+	fi
 	return 1
 }
 


### PR DESCRIPTION
Extends the tests.sh infrastructure to be configurable by os and hostname

* handle `sav/$os`, `sav/$os/fixme`, `sav/$hostname` and `sav/$hostname/fixme` sav directories that can contains specific results `.res` when there is an expected divergence on results per architecture or machine
* specific `$hostname.skip` file to skip tests on a host basis (`$os.skip` files did already exists to filter at the architecture level)
* additional `sav/$foo/cc.skip` and `sav/$foo/exec.skip` where foo can be engines, os or hostname to fine-tune more things