### PR TITLE
Remove niti hacks on NativeString and NativeFile

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -842,7 +842,7 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 		v.add("signal(SIGINT, sig_handler);")
 		v.add("signal(SIGTERM, sig_handler);")
 		v.add("signal(SIGSEGV, sig_handler);")
-		v.add("signal(SIGPIPE, sig_handler);")
+		v.add("signal(SIGPIPE, SIG_IGN);")
 
 		v.add("glob_argc = argc; glob_argv = argv;")
 		v.add("initialize_gc_option();")

--- a/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
+++ b/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
@@ -119,8 +119,8 @@ private extern class CallArg `{ nit_call_arg* `}
 			assert value isa PrimitiveInstance[Float]
 			self.float = value.val
 		else if static_type.name == "NativeString" then
-			assert value isa PrimitiveInstance[Buffer]
-			self.pointer = value.val.to_cstring
+			assert value isa PrimitiveInstance[NativeString]
+			self.pointer = value.val
 		else if static_type isa MClassType and static_type.mclass.kind == extern_kind then
 			assert value isa PrimitiveInstance[Pointer] else print value.class_name
 			self.pointer = value.val
@@ -148,7 +148,9 @@ private extern class CallArg `{ nit_call_arg* `}
 		else if name == "Float" then
 			return v.float_instance(self.float)
 		else if name == "NativeString" then
-			return v.native_string_instance(self.native_string.to_s)
+			var instance = new PrimitiveInstance[NativeString](static_type, self.native_string)
+			v.init_instance_primitive instance
+			return instance
 		else if static_type isa MClassType and static_type.mclass.kind == extern_kind then
 			# We tag it with the most precise known type
 			var instance = new PrimitiveInstance[Pointer](static_type, self.pointer)

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -75,7 +75,7 @@ redef class AModule
 		var compile_dir = v.compile_dir
 		var foreign_code_lib_path = v.foreign_code_lib_path(mmodule)
 
-		compile_dir.mkdir
+		if not compile_dir.file_exists then compile_dir.mkdir
 
 		# Compile the common FFI part
 		ensure_compile_ffi_wrapper

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -907,17 +907,6 @@ redef class AMethPropdef
 				return v.int_instance(args[0].to_i.bin_xor(args[1].to_i))
 			else if pname == "bin_not" then
 				return v.int_instance(args[0].to_i.bin_not)
-			else if pname == "int_to_s_len" then
-				return v.int_instance(recvval.to_s.length)
-			else if pname == "native_int_to_s" then
-				var s = recvval.to_s
-				var srecv = args[1].val.as(Buffer)
-				srecv.clear
-				srecv.append(s)
-				srecv.add('\0')
-				return null
-			else if pname == "strerror_ext" then
-				return v.native_string_instance(recvval.strerror)
 			end
 		else if cname == "Byte" then
 			var recvval = args[0].to_b
@@ -955,13 +944,6 @@ redef class AMethPropdef
 				return v.byte_instance(args[0].to_b.rshift(args[1].to_i))
 			else if pname == "byte_to_s_len" then
 				return v.int_instance(recvval.to_s.length)
-			else if pname == "native_byte_to_s" then
-				var s = recvval.to_s
-				var srecv = args[1].val.as(Buffer)
-				srecv.clear
-				srecv.append(s)
-				srecv.add('\0')
-				return null
 			end
 		else if cname == "Char" then
 			var recv = args[0].val.as(Char)
@@ -1081,35 +1063,9 @@ redef class AMethPropdef
 				return null
 			else if pname == "atoi" then
 				return v.int_instance(recvval.to_i)
-			else if pname == "file_exists" then
-				return v.bool_instance(recvval.to_s.file_exists)
-			else if pname == "file_mkdir" then
-				var res = recvval.to_s.mkdir
-				return v.bool_instance(res == null)
-			else if pname == "file_chdir" then
-				var res = recvval.to_s.chdir
-				return v.bool_instance(res == null)
-			else if pname == "file_realpath" then
-				return v.native_string_instance(recvval.to_s.realpath)
-			else if pname == "get_environ" then
-				var txt = recvval.to_s.environ
-				return v.native_string_instance(txt)
-			else if pname == "system" then
-				var res = sys.system(recvval.to_s)
-				return v.int_instance(res)
-			else if pname == "atof" then
-				return v.float_instance(recvval.to_f)
 			else if pname == "fast_cstring" then
 				var ns = recvval.to_cstring.to_s.substring_from(args[1].to_i)
 				return v.native_string_instance(ns)
-			end
-		else if cname == "String" then
-			var cs = v.send(v.force_get_primitive_method("to_cstring", args.first.mtype), [args.first])
-			var str = cs.val.to_s
-			if pname == "files" then
-				var res = new Array[Instance]
-				for f in str.files do res.add v.string_instance(f)
-				return v.array_instance(res, v.mainmodule.string_type)
 			end
 		else if pname == "calloc_string" then
 			return v.native_string_instance("!" * args[1].to_i)
@@ -1193,18 +1149,6 @@ redef class AMethPropdef
 		else if pname == "native_argv" then
 			var txt = v.arguments[args[1].to_i]
 			return v.native_string_instance(txt)
-		else if pname == "get_time" then
-			return v.int_instance(get_time)
-		else if pname == "srand" then
-			srand
-			return null
-		else if pname == "srand_from" then
-			srand_from(args[1].to_i)
-			return null
-		else if pname == "atan2" then
-			return v.float_instance(atan2(args[1].to_f, args[2].to_f))
-		else if pname == "pi" then
-			return v.float_instance(pi)
 		else if pname == "lexer_goto" then
 			return v.int_instance(lexer_goto(args[1].to_i, args[2].to_i))
 		else if pname == "lexer_accept" then
@@ -1213,16 +1157,6 @@ redef class AMethPropdef
 			return v.int_instance(parser_goto(args[1].to_i, args[2].to_i))
 		else if pname == "parser_action" then
 			return v.int_instance(parser_action(args[1].to_i, args[2].to_i))
-		else if pname == "file_getcwd" then
-			return v.native_string_instance(getcwd)
-		else if pname == "errno" then
-			return v.int_instance(sys.errno)
-		else if pname == "address_is_null" then
-			var recv = args[0]
-			if recv isa PrimitiveInstance[PrimitiveNativeFile] then
-				return v.bool_instance(recv.val.address_is_null)
-			end
-			return v.false_instance
 		end
 		return v.error_instance
 	end

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -1091,54 +1091,6 @@ redef class AMethPropdef
 				recvval.copy_to(0, args[2].to_i, args[1].val.as(Array[Instance]), 0)
 				return null
 			end
-		else if cname == "NativeFile" then
-			if pname == "native_stdout" then
-				var inst = new PrimitiveNativeFile.native_stdout
-				var instance = new PrimitiveInstance[PrimitiveNativeFile](mpropdef.mclassdef.mclass.mclass_type, inst)
-				v.init_instance_primitive(instance)
-				return instance
-			else if pname == "native_stdin" then
-				var inst = new PrimitiveNativeFile.native_stdin
-				var instance = new PrimitiveInstance[PrimitiveNativeFile](mpropdef.mclassdef.mclass.mclass_type, inst)
-				v.init_instance_primitive(instance)
-				return instance
-			else if pname == "native_stderr" then
-				var inst = new PrimitiveNativeFile.native_stderr
-				var instance = new PrimitiveInstance[PrimitiveNativeFile](mpropdef.mclassdef.mclass.mclass_type, inst)
-				v.init_instance_primitive(instance)
-				return instance
-			else if pname == "io_open_read" then
-				var a1 = args[1].val.as(Buffer)
-				var inst = new PrimitiveNativeFile.io_open_read(a1.to_s)
-				var instance = new PrimitiveInstance[PrimitiveNativeFile](mpropdef.mclassdef.mclass.mclass_type, inst)
-				v.init_instance_primitive(instance)
-				return instance
-			else if pname == "io_open_write" then
-				var a1 = args[1].val.as(Buffer)
-				var inst = new PrimitiveNativeFile.io_open_write(a1.to_s)
-				var instance = new PrimitiveInstance[PrimitiveNativeFile](mpropdef.mclassdef.mclass.mclass_type, inst)
-				v.init_instance_primitive(instance)
-				return instance
-			end
-			var recvval = args.first.val
-			if pname == "io_write" then
-				var a1 = args[1].val.as(Buffer)
-				return v.int_instance(recvval.as(PrimitiveNativeFile).io_write(a1.to_cstring, args[2].to_i))
-			else if pname == "io_read" then
-				var a1 = args[1].val.as(Buffer)
-				var ns = new NativeString(a1.length)
-				var len = recvval.as(PrimitiveNativeFile).io_read(ns, args[2].to_i)
-				a1.clear
-				a1.append(ns.to_s_with_length(len))
-				return v.int_instance(len)
-			else if pname == "flush" then
-				recvval.as(PrimitiveNativeFile).flush
-				return null
-			else if pname == "io_close" then
-				return v.int_instance(recvval.as(PrimitiveNativeFile).io_close)
-			else if pname == "set_buffering_type" then
-				return v.int_instance(recvval.as(PrimitiveNativeFile).set_buffering_type(args[1].to_i, args[2].to_i))
-			end
 		else if pname == "native_argc" then
 			return v.int_instance(v.arguments.length)
 		else if pname == "native_argv" then

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args1.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args1.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args2.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args2.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args3.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args3.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args4.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args4.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args5.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args5.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args6.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args6.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args7.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args7.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args8.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args8.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/neo_doxygen_dump_args9.res
+++ b/tests/sav/niti/fixme/neo_doxygen_dump_args9.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/nitdoc_args4.res
+++ b/tests/sav/niti/fixme/nitdoc_args4.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/nitiwiki_args1.res
+++ b/tests/sav/niti/fixme/nitiwiki_args1.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_binary.res
+++ b/tests/sav/niti/fixme/test_binary.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_binary_alt1.res
+++ b/tests/sav/niti/fixme/test_binary_alt1.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_binary_alt2.res
+++ b/tests/sav/niti/fixme/test_binary_alt2.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_binary_alt3.res
+++ b/tests/sav/niti/fixme/test_binary_alt3.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_exec.res
+++ b/tests/sav/niti/fixme/test_exec.res
@@ -1,1 +1,0 @@
-UNDEFINED

--- a/tests/sav/niti/fixme/test_fdstream.res
+++ b/tests/sav/niti/fixme/test_fdstream.res
@@ -1,1 +1,0 @@
-UNDEFINED


### PR DESCRIPTION
Previously, the interpreter used a FlatBuffer to implement NativeString and a File to implement NativeFile. This caused issues with applications using (mostly) `is_address_null` which could not be implemented correctly with these implementations.

This PR uses a real NativeString and NativeFile to implement the same class. For NativeFile, it is handled by the FFI so removing the old code is enough. For NativeString, many of its methods are intern so they had to be updated.