### PR TITLE
Use the DOM parser in the RSS Downloader contrib

### DIFF
--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -199,7 +199,7 @@ class Downloader
 			end
 
 			for dir in source_folder.files do if dir.stat.is_dir then
-				folder_names.add dir.to_s
+				folder_names.add dir.filename
 			end
 		end
 

--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -151,11 +151,7 @@ class Downloader
 		for element in matches do
 			var unique_id = element.unique_id(config)
 
-			if local_path.to_path.exists then
-				# Do not redownload a file (we assume that the file name is unique by itself)
-				if sys.verbose then print "File exists, skipping {element}"
-				continue
-			else if history.has(unique_id) then
+			if history.has(unique_id) then
 				# Do not download a file that is not unique according to `unique_id`
 				if not element.is_unique_exception(config) then
 					# We make some exceptions

--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -51,6 +51,13 @@ class Config
 
 	# XML tag used for pattern recognition
 	fun tag_title: String do return "title"
+
+	# Action to apply on each selected RSS element
+	fun act_on(element: Element)
+	do
+		var local_path = download_destination_folder.to_s / element.title
+		element.download_to(local_path)
+	end
 end
 
 # An element from an RSS feed
@@ -142,7 +149,6 @@ class Downloader
 		end
 
 		for element in matches do
-			var local_path = config.download_destination_folder.to_s / element.title
 			var unique_id = element.unique_id(config)
 
 			if local_path.to_path.exists then
@@ -159,8 +165,9 @@ class Downloader
 			end
 
 			# Download element
-			if sys.verbose then print "Fetching {element} as {local_path}"
-			element.download_to(local_path)
+			if sys.verbose then print "Acting on {element}"
+
+			tool_config.act_on element
 
 			# Add `unique_id` to log
 			history.add unique_id

--- a/lib/dom/dom.nit
+++ b/lib/dom/dom.nit
@@ -12,3 +12,32 @@
 module dom
 
 import parser
+
+redef class XMLEntity
+
+	# The `XMLTag` children with the `tag_name`
+	#
+	# ~~~
+	# var code = """
+	# <?xml version="1.0" encoding="us-ascii"?>
+	# <animal>
+	#     <cat/>
+	#     <tiger>This is a white tiger!</tiger>
+	#     <cat/>
+	# </animal>"""
+	#
+	# var xml = code.to_xml
+	# assert xml["animal"].length == 1
+	# assert xml["animal"].first["cat"].length == 2
+	# ~~~
+	fun [](tag_name: String): Array[XMLEntity]
+	do
+		var res = new Array[XMLEntity]
+		for child in children do
+			if child isa XMLTag and child.tag_name == tag_name then
+				res.add child
+			end
+		end
+		return res
+	end
+end

--- a/lib/dom/dom.nit
+++ b/lib/dom/dom.nit
@@ -41,3 +41,29 @@ redef class XMLEntity
 		return res
 	end
 end
+
+redef class XMLStartTag
+
+	# Content of this XML tag held within a `PCDATA` or `CDATA`
+	#
+	# ~~~
+	# var code = """
+	# <?xml version="1.0" encoding="us-ascii"?>
+	# <animal>
+	#     <cat/>
+	#     <tiger>This is a white tiger!</tiger>
+	#     <cat/>
+	# </animal>"""
+	#
+	# var xml = code.to_xml
+	# assert xml["animal"].first["tiger"].first.as(XMLStartTag).data == "This is a white tiger!"
+	# ~~~
+	fun data: String
+	do
+		for child in children do
+			if child isa PCDATA then return child.content
+			if child isa CDATA then return child.content
+		end
+		abort
+	end
+end

--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -360,7 +360,7 @@ class Path
 	# Path to this file
 	redef fun to_s do return path
 
-	# Name of the file name at `to_s`
+	# Short name of the file at `to_s`
 	#
 	# ~~~
 	# var path = "/tmp/somefile".to_path


### PR DESCRIPTION
`rss_downloader` now uses the DOM XML parser instead of regex to read RSS files. It is also easier to customize its behavior from the config class.

This PR also adds a few services to the DOM parser and fix a few bugs.

---

This PR is based on #1448 with fixed line endings.

