### PR TITLE
lib/standard/bytes: Added pop method

### DIFF
--- a/lib/standard/bytes.nit
+++ b/lib/standard/bytes.nit
@@ -46,6 +46,7 @@ class Bytes
 		init(ns, 0, 0)
 	end
 
+	# Init a `Bytes` with capacity `cap`
 	init with_capacity(cap: Int) do
 		var ns = new NativeString(cap)
 		init(ns, 0, cap)
@@ -169,6 +170,7 @@ private class BytesIterator
 end
 
 redef class NativeString
+	# Creates a new `Bytes` object from `self` with `strlen` as length
 	fun to_bytes: Bytes do
 		var len = cstring_length
 		return new Bytes(self, len, len)

--- a/lib/standard/bytes.nit
+++ b/lib/standard/bytes.nit
@@ -96,6 +96,16 @@ class Bytes
 		end
 	end
 
+	#     var b = new Bytes.empty
+	#     b.append([0x41u8, 0x41u8, 0x18u8])
+	#     b.pop
+	#     assert b.to_s == "AA"
+	redef fun pop do
+		assert length >= 1
+		length -= 1
+		return items[length]
+	end
+
 	redef fun clear do length = 0
 
 	# Regenerates the buffer, necessary when it was persisted

--- a/tests/sav/nitpick_args1.res
+++ b/tests/sav/nitpick_args1.res
@@ -1,5 +1,3 @@
-../lib/standard/bytes.nit:49,7--19: Documentation warning: Undocumented property `with_capacity`
-../lib/standard/bytes.nit:162,6--13: Documentation warning: Undocumented property `to_bytes`
 ../lib/standard/stream.nit:426,6--17: Documentation warning: Undocumented property `buffer_reset`
 ../lib/standard/file.nit:455,6--19: Documentation warning: Undocumented property `read_all_bytes`
 test_advice_repeated_types.nit:36,15--20: Warning: useless type repetition on redefined attribute `_a`


### PR DESCRIPTION
The method was missing from Bytes, I needed it so I implemented it, and here's the associated PR.