### PR TITLE
Protected setters

### DIFF
--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1270,7 +1270,9 @@ redef class AAttrPropdef
 			if atwritable != null then
 				mvisibility = new_property_visibility(modelbuilder, mclassdef, atwritable.n_visibility)
 			else
-				mvisibility = private_visibility
+				mvisibility = mreadprop.visibility
+				# By default, use protected visibility at most
+				if mvisibility > protected_visibility then mvisibility = protected_visibility
 			end
 			mwriteprop = new MMethod(mclassdef, writename, mvisibility)
 			if not self.check_redef_keyword(modelbuilder, mclassdef, nwkwredef, false, mwriteprop) then return

--- a/tests/sav/base_attr3_alt1.res
+++ b/tests/sav/base_attr3_alt1.res
@@ -1,5 +1,3 @@
-alt/base_attr3_alt1.nit:22,3--4: Error: method or variable `a1=` unknown in `B`.
-alt/base_attr3_alt1.nit:24,3--4: Error: method or variable `a2=` unknown in `B`.
 alt/base_attr3_alt1.nit:25,3--4: Error: method or variable `a3` unknown in `B`.
 alt/base_attr3_alt1.nit:26,3--4: Error: method or variable `a3=` unknown in `B`.
 alt/base_attr3_alt1.nit:31,3--4: Error: method or variable `a6` unknown in `B`.

--- a/tests/sav/base_attr3_alt2.res
+++ b/tests/sav/base_attr3_alt2.res
@@ -1,6 +1,6 @@
-alt/base_attr3_alt2.nit:49,5--6: Error: method `a1=` does not exists in `A`.
+alt/base_attr3_alt2.nit:49,5--6: Error: method `a1=` is protected and can only accessed by `self`.
 alt/base_attr3_alt2.nit:50,5--6: Error: method `a2` is protected and can only accessed by `self`.
-alt/base_attr3_alt2.nit:51,5--6: Error: method `a2=` does not exists in `A`.
+alt/base_attr3_alt2.nit:51,5--6: Error: method `a2=` is protected and can only accessed by `self`.
 alt/base_attr3_alt2.nit:52,5--6: Error: method `a3` does not exists in `A`.
 alt/base_attr3_alt2.nit:53,5--6: Error: method `a3=` does not exists in `A`.
 alt/base_attr3_alt2.nit:56,5--6: Error: method `a5` is protected and can only accessed by `self`.

--- a/tests/sav/base_attr3_alt3.res
+++ b/tests/sav/base_attr3_alt3.res
@@ -1,6 +1,6 @@
-alt/base_attr3_alt3.nit:80,4--5: Error: method `a1=` does not exists in `A`.
+alt/base_attr3_alt3.nit:80,4--5: Error: method `a1=` is protected and can only accessed by `self`.
 alt/base_attr3_alt3.nit:81,4--5: Error: method `a2` is protected and can only accessed by `self`.
-alt/base_attr3_alt3.nit:82,4--5: Error: method `a2=` does not exists in `A`.
+alt/base_attr3_alt3.nit:82,4--5: Error: method `a2=` is protected and can only accessed by `self`.
 alt/base_attr3_alt3.nit:83,4--5: Error: method `a3` does not exists in `A`.
 alt/base_attr3_alt3.nit:84,4--5: Error: method `a3=` does not exists in `A`.
 alt/base_attr3_alt3.nit:87,4--5: Error: method `a5` is protected and can only accessed by `self`.

--- a/tests/sav/base_attr3_alt4.res
+++ b/tests/sav/base_attr3_alt4.res
@@ -1,6 +1,6 @@
-alt/base_attr3_alt4.nit:110,4--5: Error: method `a1=` does not exists in `B`.
+alt/base_attr3_alt4.nit:110,4--5: Error: method `a1=` is protected and can only accessed by `self`.
 alt/base_attr3_alt4.nit:111,4--5: Error: method `a2` is protected and can only accessed by `self`.
-alt/base_attr3_alt4.nit:112,4--5: Error: method `a2=` does not exists in `B`.
+alt/base_attr3_alt4.nit:112,4--5: Error: method `a2=` is protected and can only accessed by `self`.
 alt/base_attr3_alt4.nit:113,4--5: Error: method `a3` does not exists in `B`.
 alt/base_attr3_alt4.nit:114,4--5: Error: method `a3=` does not exists in `B`.
 alt/base_attr3_alt4.nit:117,4--5: Error: method `a5` is protected and can only accessed by `self`.

--- a/tests/sav/error_ref_attr.res
+++ b/tests/sav/error_ref_attr.res
@@ -1,1 +1,2 @@
 error_ref_attr.nit:20,15--17: Redef Error: expected `B` return type; got `Int`.
+error_ref_attr.nit:20,15--17: Redef Error: expected `B` type for parameter `a'; got `Int`.

--- a/tests/sav/nitdoc_args2.res
+++ b/tests/sav/nitdoc_args2.res
@@ -22,8 +22,11 @@ js/
 less/
 module_base_attr_nullable-.html
 property_base_attr_nullable-__Bar__a3.html
+property_base_attr_nullable-__Bar__a3_61d.html
 property_base_attr_nullable-__Foo__a1.html
+property_base_attr_nullable-__Foo__a1_61d.html
 property_base_attr_nullable-__Foo__a2.html
+property_base_attr_nullable-__Foo__a2_61d.html
 property_base_attr_nullable-__Foo__nop.html
 property_base_attr_nullable-__Foo__run.html
 property_base_attr_nullable-__Foo__run_other.html
@@ -32,6 +35,7 @@ property_base_attr_nullable-__Int__output.html
 property_base_attr_nullable-__Integer__init.html
 property_base_attr_nullable-__Integer__output.html
 property_base_attr_nullable-__Integer__val.html
+property_base_attr_nullable-__Integer__val_61d.html
 property_base_attr_nullable-__Object__init.html
 property_base_attr_nullable-__Sys__main.html
 quicksearch-list.js

--- a/tests/sav/nitdoc_args4.res
+++ b/tests/sav/nitdoc_args4.res
@@ -536,20 +536,35 @@ MClassPage Career
 		## test_prog__rpg.concern
 		## test_prog__rpg__careers.concern
 			### test_prog__rpg__careers__Career__endurance_bonus.definition
+			### test_prog__rpg__careers__Career__endurance_bonus_61d.definition
 			### test_prog__rpg__careers__Career__intelligence_bonus.definition
+			### test_prog__rpg__careers__Career__intelligence_bonus_61d.definition
 			### test_prog__rpg__careers__Career__strength_bonus.definition
+			### test_prog__rpg__careers__Career__strength_bonus_61d.definition
 
 MPropertyPage endurance_bonus
 	# endurance_bonus.section
 		## test_prog__rpg__careers__Career__endurance_bonus.intro
 
+MPropertyPage endurance_bonus=
+	# endurance_bonus=.section
+		## test_prog__rpg__careers__Career__endurance_bonus_61d.intro
+
 MPropertyPage intelligence_bonus
 	# intelligence_bonus.section
 		## test_prog__rpg__careers__Career__intelligence_bonus.intro
 
+MPropertyPage intelligence_bonus=
+	# intelligence_bonus=.section
+		## test_prog__rpg__careers__Career__intelligence_bonus_61d.intro
+
 MPropertyPage strength_bonus
 	# strength_bonus.section
 		## test_prog__rpg__careers__Career__strength_bonus.intro
+
+MPropertyPage strength_bonus=
+	# strength_bonus=.section
+		## test_prog__rpg__careers__Career__strength_bonus_61d.intro
 
 MClassPage Magician
 	# Magician.section
@@ -628,14 +643,19 @@ MClassPage Character
 		## test_prog__rpg.concern
 		## test_prog__rpg__character.concern
 			### test_prog__rpg__character__Character__age.definition
+			### test_prog__rpg__character__Character__age_61d.definition
 			### test_prog__rpg__character__Character__career.definition
 			### test_prog__rpg__character__Character__career_61d.definition
 			### test_prog__rpg__character__Character__health.definition
+			### test_prog__rpg__character__Character__health_61d.definition
 			### test_prog__rpg__character__Character__max_health.definition
 			### test_prog__rpg__character__Character__name.definition
+			### test_prog__rpg__character__Character__name_61d.definition
 			### test_prog__rpg__character__Character__quit.definition
 			### test_prog__rpg__character__Character__race.definition
+			### test_prog__rpg__character__Character__race_61d.definition
 			### test_prog__rpg__character__Character__sex.definition
+			### test_prog__rpg__character__Character__sex_61d.definition
 			### test_prog__rpg__character__Character__total_endurance.definition
 			### test_prog__rpg__character__Character__total_intelligence.definition
 			### test_prog__rpg__character__Character__total_strengh.definition
@@ -646,6 +666,10 @@ MClassPage Character
 MPropertyPage age
 	# age.section
 		## test_prog__rpg__character__Character__age.intro
+
+MPropertyPage age=
+	# age=.section
+		## test_prog__rpg__character__Character__age_61d.intro
 
 MPropertyPage career
 	# career.section
@@ -659,6 +683,10 @@ MPropertyPage health
 	# health.section
 		## test_prog__rpg__character__Character__health.intro
 
+MPropertyPage health=
+	# health=.section
+		## test_prog__rpg__character__Character__health_61d.intro
+
 MPropertyPage max_health
 	# max_health.section
 		## test_prog__rpg__character__Character__max_health.intro
@@ -666,6 +694,10 @@ MPropertyPage max_health
 MPropertyPage name
 	# name.section
 		## test_prog__rpg__character__Character__name.intro
+
+MPropertyPage name=
+	# name=.section
+		## test_prog__rpg__character__Character__name_61d.intro
 
 MPropertyPage quit
 	# quit.section
@@ -675,9 +707,17 @@ MPropertyPage race
 	# race.section
 		## test_prog__rpg__character__Character__race.intro
 
+MPropertyPage race=
+	# race=.section
+		## test_prog__rpg__character__Character__race_61d.intro
+
 MPropertyPage sex
 	# sex.section
 		## test_prog__rpg__character__Character__sex.intro
+
+MPropertyPage sex=
+	# sex=.section
+		## test_prog__rpg__character__Character__sex_61d.intro
 
 MPropertyPage total_endurance
 	# total_endurance.section
@@ -928,20 +968,35 @@ MClassPage Race
 		## test_prog__rpg.concern
 		## test_prog__rpg__races.concern
 			### test_prog__rpg__races__Race__base_endurance.definition
+			### test_prog__rpg__races__Race__base_endurance_61d.definition
 			### test_prog__rpg__races__Race__base_intelligence.definition
+			### test_prog__rpg__races__Race__base_intelligence_61d.definition
 			### test_prog__rpg__races__Race__base_strength.definition
+			### test_prog__rpg__races__Race__base_strength_61d.definition
 
 MPropertyPage base_endurance
 	# base_endurance.section
 		## test_prog__rpg__races__Race__base_endurance.intro
 
+MPropertyPage base_endurance=
+	# base_endurance=.section
+		## test_prog__rpg__races__Race__base_endurance_61d.intro
+
 MPropertyPage base_intelligence
 	# base_intelligence.section
 		## test_prog__rpg__races__Race__base_intelligence.intro
 
+MPropertyPage base_intelligence=
+	# base_intelligence=.section
+		## test_prog__rpg__races__Race__base_intelligence_61d.intro
+
 MPropertyPage base_strength
 	# base_strength.section
 		## test_prog__rpg__races__Race__base_strength.intro
+
+MPropertyPage base_strength=
+	# base_strength=.section
+		## test_prog__rpg__races__Race__base_strength_61d.intro
 
 MModulePage rpg
 	# rpg.section
@@ -952,24 +1007,24 @@ MModulePage rpg
 				#### test_prog__rpg__rpg.imports
 				#### test_prog__rpg__rpg.clients
 
-Generated 85 pages
+Generated 96 pages
  list:
-  MPropertyPage: 47 (55.29%)
-  MClassPage: 20 (23.52%)
-  MModulePage: 8 (9.41%)
-  MGroupPage: 4 (4.70%)
-  ReadmePage: 4 (4.70%)
-  SearchPage: 1 (1.17%)
-  OverviewPage: 1 (1.17%)
-Found 160 mentities
+  MPropertyPage: 58 (60.41%)
+  MClassPage: 20 (20.83%)
+  MModulePage: 8 (8.33%)
+  MGroupPage: 4 (4.16%)
+  ReadmePage: 4 (4.16%)
+  SearchPage: 1 (1.04%)
+  OverviewPage: 1 (1.04%)
+Found 182 mentities
  list:
-  MMethodDef: 57 (35.62%)
-  MMethod: 46 (28.75%)
-  MClassDef: 22 (13.75%)
-  MClass: 20 (12.50%)
-  MModule: 8 (5.00%)
-  MGroup: 4 (2.50%)
-  MVirtualTypeDef: 1 (0.62%)
-  MVirtualTypeProp: 1 (0.62%)
-  MProject: 1 (0.62%)
+  MMethodDef: 68 (37.36%)
+  MMethod: 57 (31.31%)
+  MClassDef: 22 (12.08%)
+  MClass: 20 (10.98%)
+  MModule: 8 (4.39%)
+  MGroup: 4 (2.19%)
+  MVirtualTypeDef: 1 (0.54%)
+  MVirtualTypeProp: 1 (0.54%)
+  MProject: 1 (0.54%)
 quicksearch-list.js

--- a/tests/sav/nitmetrics_args1.res
+++ b/tests/sav/nitmetrics_args1.res
@@ -695,12 +695,13 @@ Statistics of type usage:
   A: 1 (11.11%)
 
 # Mendel metrics
-	large mclasses (threshold: 3.354)
+	large mclasses (threshold: 3.915)
+	   C: 5
+	   B: 4
 	   Sys: 4
-	budding mclasses (threshold: 4.177)
-	   Sys: 5.0
-	blooming mclasses (threshold: 14.626)
-	   Sys: 20.0
+	budding mclasses (threshold: 5.033)
+	blooming mclasses (threshold: 21.874)
+	   C: 25.0
 --- Detection of the usage of covariance static type conformance ---
 -- Total --
 - Kinds of the subtype -


### PR DESCRIPTION
Setters of attributes are private by default. This cause some issue as they are exposed as initializers but still invisible in client modules.
The proposed solution to resolve this inconsistency is to make setters protected by default so they are visible in client modules but only usable in subclasses.

This is a change is the spec, to RFC label is set is people have comments on the sanity/usability/kiss/pola/etc. 

Close #1552