### PR TITLE
Fix bug with reverse iterators in arrays

### DIFF
--- a/lib/standard/collection/array.nit
+++ b/lib/standard/collection/array.nit
@@ -553,6 +553,9 @@ private class ArrayReverseIterator[E]
 	do
 		_index = _array.length - 1
 	end
+
+	# Do not cache `self`
+	redef fun finish do end
 end
 
 # Others collections ##########################################################

--- a/tests/sav/test_new_native_alt1.res
+++ b/tests/sav/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/standard/collection/array.nit:957)
+Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/standard/collection/array.nit:960)
 NativeString
 0x4e
 Nit


### PR DESCRIPTION
Using `Array::iterator` after a finished `reverse_iterator` iterates only on the first element, or crash if array is empty. As `ReverseArrayIterator` specialize `ArrayIterator`, it can cache itself in the array to be used by `iterator`.

This PR simply disable caching for reverse iterators. We could add a distinct cache for the reverse iterator if we need the performance.

This minimal program highlights the bug:
~~~nit
var a = [1, 2, 3]
for x in a.reverse_iterator do print x
print "-"
for x in a.iterator do print x
~~~

Output:
~~~
3
2
1
-
1
~~~