### PR TITLE
Rename Container to Ref

### DIFF
--- a/examples/mnit_dino/src/dino.nit
+++ b/examples/mnit_dino/src/dino.nit
@@ -31,7 +31,7 @@ redef class App
 	var cavemen_incr = 4
 
 	var game : nullable Game = null
-	var score = new Container[Int](0)
+	var score = new Ref[Int](0)
 	var imgs : nullable ImageSet = null
 	var splash : nullable SplashScreen = null
 
@@ -81,7 +81,7 @@ redef class App
 				if game.won then
 					next_nbr_caveman += cavemen_incr
 				else
-					score = new Container[Int](0)
+					score = new Ref[Int](0)
 					next_nbr_caveman = cavemen_at_first_level
 				end
 				game = new Game( next_nbr_caveman, score )

--- a/examples/mnit_dino/src/game_logic.nit
+++ b/examples/mnit_dino/src/game_logic.nit
@@ -34,7 +34,7 @@ class Game
 
 	var over_since = 0
 
-	var score: Container[Int]
+	var score: Ref[Int]
 
 	var random_radius_min = 200
 	var random_radius_max = 400
@@ -43,7 +43,7 @@ class Game
 
 	var entities_sorter = new EntitiesSorter
 
-	init( cavemen_nbr : Int, score: Container[Int] )
+	init( cavemen_nbr : Int, score: Ref[Int] )
 	do
 		srand_from(cavemen_nbr)
 

--- a/examples/mnit_moles/src/moles_android.nit
+++ b/examples/mnit_moles/src/moles_android.nit
@@ -47,7 +47,7 @@ redef class App
 	end
 end
 
-fun display_scale_container: Container[Float] do return once new Container[Float](0.1)
+fun display_scale_container: Ref[Float] do return once new Ref[Float](0.1)
 redef fun display_scale do return display_scale_container.item
 redef fun display_offset_x: Int do return (300.0*display_scale).to_i
 redef fun display_offset_y: Int do return (800.0*display_scale).to_i

--- a/lib/curl/native_curl.nit
+++ b/lib/curl/native_curl.nit
@@ -115,59 +115,59 @@ extern class NativeCurl `{ CURL * `}
 	# Request Chars internal information from the CURL session
 	fun easy_getinfo_chars(opt: CURLInfoChars): nullable String
 	do
-		 var answ = new Container[NativeString]("".to_cstring)
+		 var answ = new Ref[NativeString]("".to_cstring)
 		 if not native_getinfo_chars(opt, answ).is_ok then return null
 		 if answ.item.address_is_null then return null
 		 return answ.item.to_s
 	end
 
 	# Internal method used to get String object information initially knowns as C Chars type
-	private fun native_getinfo_chars(opt: CURLInfoChars, res: Container[NativeString]): CURLCode
-	import Container[NativeString].item= `{
+	private fun native_getinfo_chars(opt: CURLInfoChars, res: Ref[NativeString]): CURLCode
+	import Ref[NativeString].item= `{
 		char *r;
 		CURLcode c = curl_easy_getinfo( self, opt, &r);
-		if (c == CURLE_OK) Container_of_NativeString_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_NativeString_item__assign(res, r);
 		return c;
 	`}
 
 	# Request Long internal information from the CURL session
 	fun easy_getinfo_long(opt: CURLInfoLong): nullable Int
 	do
-		 var answ = new Container[Int](0)
+		 var answ = new Ref[Int](0)
 		 if not native_getinfo_long(opt, answ).is_ok then return null
 		 return answ.item
 	end
 
 	# Internal method used to get Int object information initially knowns as C Long type
-	private fun native_getinfo_long(opt: CURLInfoLong, res: Container[Int]): CURLCode
-	import Container[Int].item= `{
+	private fun native_getinfo_long(opt: CURLInfoLong, res: Ref[Int]): CURLCode
+	import Ref[Int].item= `{
 		long r;
 		CURLcode c = curl_easy_getinfo( self, opt, &r);
-		if (c == CURLE_OK) Container_of_Int_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_Int_item__assign(res, r);
 		return c;
 	`}
 
 	# Request Double internal information from the CURL session
 	fun easy_getinfo_double(opt: CURLInfoDouble): nullable Float
 	do
-		 var answ = new Container[Float](0.0)
+		 var answ = new Ref[Float](0.0)
 		 if not native_getinfo_double(opt, answ).is_ok then return null
 		 return answ.item
 	end
 
 	# Internal method used to get Int object information initially knowns as C Double type
-	private fun native_getinfo_double(opt: CURLInfoDouble, res: Container[Float]): CURLCode
-	import Container[Float].item= `{
+	private fun native_getinfo_double(opt: CURLInfoDouble, res: Ref[Float]): CURLCode
+	import Ref[Float].item= `{
 		double r;
 		CURLcode c = curl_easy_getinfo(self, opt, &r);
-		if (c == CURLE_OK) Container_of_Float_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_Float_item__assign(res, r);
 		return c;
 	`}
 
 	# Request SList internal information from the CURL session
 	fun easy_getinfo_slist(opt: CURLInfoSList): nullable Array[String]
 	do
-		var answ = new Container[CURLSList](new CURLSList)
+		var answ = new Ref[CURLSList](new CURLSList)
 		if not native_getinfo_slist(opt, answ).is_ok then return null
 
 		var native = answ.item
@@ -177,11 +177,11 @@ extern class NativeCurl `{ CURL * `}
 	end
 
 	# Internal method used to get Array[String] object information initially knowns as C SList type
-	private fun native_getinfo_slist(opt: CURLInfoSList, res: Container[CURLSList]): CURLCode
-	import Container[CURLSList].item= `{
+	private fun native_getinfo_slist(opt: CURLInfoSList, res: Ref[CURLSList]): CURLCode
+	import Ref[CURLSList].item= `{
 		struct curl_slist* csl;
 		CURLcode c = curl_easy_getinfo(self, opt, &csl);
-		if (c == CURLE_OK) Container_of_CURLSList_item__assign(res, csl);
+		if (c == CURLE_OK) Ref_of_CURLSList_item__assign(res, csl);
 		return c;
 	`}
 

--- a/lib/pthreads/concurrent_collections.nit
+++ b/lib/pthreads/concurrent_collections.nit
@@ -26,7 +26,7 @@
 # - [x] `ConcurrentList`
 # - [ ] `ConcurrentHashMap`
 # - [ ] `ConcurrentHashSet`
-# - [ ] `ConcurrentContainer`
+# - [ ] `ConcurrentRef`
 # - [ ] `ConcurrentQueue`
 #
 # Introduced collections specialize their critical methods according to the

--- a/lib/pthreads/redef_collections.nit
+++ b/lib/pthreads/redef_collections.nit
@@ -27,7 +27,7 @@
 # - [ ] `List`
 # - [ ] `HashMap`
 # - [ ] `HashSet`
-# - [ ] `Container`
+# - [ ] `Ref`
 # - [ ] `Queue`
 module redef_collections
 

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -242,7 +242,7 @@ redef class Couple[F, S]
 	end
 end
 
-redef class Container[E]
+redef class Ref[E]
 	super Serializable
 
 	redef init from_deserializer(v)

--- a/lib/standard/collection/abstract_collection.nit
+++ b/lib/standard/collection/abstract_collection.nit
@@ -282,7 +282,7 @@ end
 #
 # Also used when one want to give a single element when a full
 # collection is expected
-class Container[E]
+class Ref[E]
 	super Collection[E]
 
 	redef fun first do return item
@@ -304,14 +304,14 @@ class Container[E]
 		end
 	end
 
-	redef fun iterator do return new ContainerIterator[E](self)
+	redef fun iterator do return new RefIterator[E](self)
 
 	# The stored item
 	var item: E is writable
 end
 
 # This iterator is quite stupid since it is used for only one item.
-private class ContainerIterator[E]
+private class RefIterator[E]
 	super Iterator[E]
 	redef fun item do return _container.item
 
@@ -319,7 +319,7 @@ private class ContainerIterator[E]
 
 	redef var is_ok = true
 
-	var container: Container[E]
+	var container: Ref[E]
 end
 
 # Items can be removed from this collection

--- a/lib/standard/collection/list.nit
+++ b/lib/standard/collection/list.nit
@@ -327,7 +327,7 @@ end
 
 # Linked nodes that constitute a linked list.
 private class ListNode[E]
-	super Container[E]
+	super Ref[E]
 
 	# The next node.
 	var next: nullable ListNode[E] = null

--- a/tests/base_label_for.nit
+++ b/tests/base_label_for.nit
@@ -18,7 +18,7 @@ import abstract_collection
 
 fun maybe: Bool do return true
 
-var a = new Container[Int](1)
+var a = new Ref[Int](1)
 1.output
 for i in a do
 	2.output


### PR DESCRIPTION
The `Container` class is widely misunderstood and underused.  However it can be very useful to implement a return parameter. This PR rename the class according to this usage. It will make some signatures easier to understand: (example inspired by a similar function from `UDPSocket`)

~~~nit
# This method has 3 outputs:
# * The received message written into `buffer`.
# * The number of bytes written as the return value.
# * The information on the sender of the message is stored in `sender_info`.
fun recv_from(buffer: NativeString, sender_info: Ref[nullable SocketAddress]): Int
~~~

### Bonus Ref tip!

`Ref` can also be used as a hackish equivalent to a `static` variable in C. This example use the dreaded `once` keyword to easily get a singleton, but it could be done cleaner with an attribute in `Sys`.

~~~nit
fun foo
   ...

    # Count the number of times foo is executed
    var counter = once new Ref[Int](0)
    counter.item += 1
    print "foo has been executed {counter.item} times"
end
~~~