### PR TITLE
Basic UDP socket

### DIFF
--- a/examples/mnit_dino/src/dino.nit
+++ b/examples/mnit_dino/src/dino.nit
@@ -31,7 +31,7 @@ redef class App
 	var cavemen_incr = 4
 
 	var game : nullable Game = null
-	var score = new Container[Int](0)
+	var score = new Ref[Int](0)
 	var imgs : nullable ImageSet = null
 	var splash : nullable SplashScreen = null
 
@@ -81,7 +81,7 @@ redef class App
 				if game.won then
 					next_nbr_caveman += cavemen_incr
 				else
-					score = new Container[Int](0)
+					score = new Ref[Int](0)
 					next_nbr_caveman = cavemen_at_first_level
 				end
 				game = new Game( next_nbr_caveman, score )

--- a/examples/mnit_dino/src/game_logic.nit
+++ b/examples/mnit_dino/src/game_logic.nit
@@ -34,7 +34,7 @@ class Game
 
 	var over_since = 0
 
-	var score: Container[Int]
+	var score: Ref[Int]
 
 	var random_radius_min = 200
 	var random_radius_max = 400
@@ -43,7 +43,7 @@ class Game
 
 	var entities_sorter = new EntitiesSorter
 
-	init( cavemen_nbr : Int, score: Container[Int] )
+	init( cavemen_nbr : Int, score: Ref[Int] )
 	do
 		srand_from(cavemen_nbr)
 

--- a/examples/mnit_moles/src/moles_android.nit
+++ b/examples/mnit_moles/src/moles_android.nit
@@ -47,7 +47,7 @@ redef class App
 	end
 end
 
-fun display_scale_container: Container[Float] do return once new Container[Float](0.1)
+fun display_scale_container: Ref[Float] do return once new Ref[Float](0.1)
 redef fun display_scale do return display_scale_container.item
 redef fun display_offset_x: Int do return (300.0*display_scale).to_i
 redef fun display_offset_y: Int do return (800.0*display_scale).to_i

--- a/lib/curl/native_curl.nit
+++ b/lib/curl/native_curl.nit
@@ -115,59 +115,59 @@ extern class NativeCurl `{ CURL * `}
 	# Request Chars internal information from the CURL session
 	fun easy_getinfo_chars(opt: CURLInfoChars): nullable String
 	do
-		 var answ = new Container[NativeString]("".to_cstring)
+		 var answ = new Ref[NativeString]("".to_cstring)
 		 if not native_getinfo_chars(opt, answ).is_ok then return null
 		 if answ.item.address_is_null then return null
 		 return answ.item.to_s
 	end
 
 	# Internal method used to get String object information initially knowns as C Chars type
-	private fun native_getinfo_chars(opt: CURLInfoChars, res: Container[NativeString]): CURLCode
-	import Container[NativeString].item= `{
+	private fun native_getinfo_chars(opt: CURLInfoChars, res: Ref[NativeString]): CURLCode
+	import Ref[NativeString].item= `{
 		char *r;
 		CURLcode c = curl_easy_getinfo( self, opt, &r);
-		if (c == CURLE_OK) Container_of_NativeString_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_NativeString_item__assign(res, r);
 		return c;
 	`}
 
 	# Request Long internal information from the CURL session
 	fun easy_getinfo_long(opt: CURLInfoLong): nullable Int
 	do
-		 var answ = new Container[Int](0)
+		 var answ = new Ref[Int](0)
 		 if not native_getinfo_long(opt, answ).is_ok then return null
 		 return answ.item
 	end
 
 	# Internal method used to get Int object information initially knowns as C Long type
-	private fun native_getinfo_long(opt: CURLInfoLong, res: Container[Int]): CURLCode
-	import Container[Int].item= `{
+	private fun native_getinfo_long(opt: CURLInfoLong, res: Ref[Int]): CURLCode
+	import Ref[Int].item= `{
 		long r;
 		CURLcode c = curl_easy_getinfo( self, opt, &r);
-		if (c == CURLE_OK) Container_of_Int_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_Int_item__assign(res, r);
 		return c;
 	`}
 
 	# Request Double internal information from the CURL session
 	fun easy_getinfo_double(opt: CURLInfoDouble): nullable Float
 	do
-		 var answ = new Container[Float](0.0)
+		 var answ = new Ref[Float](0.0)
 		 if not native_getinfo_double(opt, answ).is_ok then return null
 		 return answ.item
 	end
 
 	# Internal method used to get Int object information initially knowns as C Double type
-	private fun native_getinfo_double(opt: CURLInfoDouble, res: Container[Float]): CURLCode
-	import Container[Float].item= `{
+	private fun native_getinfo_double(opt: CURLInfoDouble, res: Ref[Float]): CURLCode
+	import Ref[Float].item= `{
 		double r;
 		CURLcode c = curl_easy_getinfo(self, opt, &r);
-		if (c == CURLE_OK) Container_of_Float_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_Float_item__assign(res, r);
 		return c;
 	`}
 
 	# Request SList internal information from the CURL session
 	fun easy_getinfo_slist(opt: CURLInfoSList): nullable Array[String]
 	do
-		var answ = new Container[CURLSList](new CURLSList)
+		var answ = new Ref[CURLSList](new CURLSList)
 		if not native_getinfo_slist(opt, answ).is_ok then return null
 
 		var native = answ.item
@@ -177,11 +177,11 @@ extern class NativeCurl `{ CURL * `}
 	end
 
 	# Internal method used to get Array[String] object information initially knowns as C SList type
-	private fun native_getinfo_slist(opt: CURLInfoSList, res: Container[CURLSList]): CURLCode
-	import Container[CURLSList].item= `{
+	private fun native_getinfo_slist(opt: CURLInfoSList, res: Ref[CURLSList]): CURLCode
+	import Ref[CURLSList].item= `{
 		struct curl_slist* csl;
 		CURLcode c = curl_easy_getinfo(self, opt, &csl);
-		if (c == CURLE_OK) Container_of_CURLSList_item__assign(res, csl);
+		if (c == CURLE_OK) Ref_of_CURLSList_item__assign(res, csl);
 		return c;
 	`}
 

--- a/lib/pthreads/concurrent_collections.nit
+++ b/lib/pthreads/concurrent_collections.nit
@@ -26,7 +26,7 @@
 # - [x] `ConcurrentList`
 # - [ ] `ConcurrentHashMap`
 # - [ ] `ConcurrentHashSet`
-# - [ ] `ConcurrentContainer`
+# - [ ] `ConcurrentRef`
 # - [ ] `ConcurrentQueue`
 #
 # Introduced collections specialize their critical methods according to the

--- a/lib/pthreads/redef_collections.nit
+++ b/lib/pthreads/redef_collections.nit
@@ -27,7 +27,7 @@
 # - [ ] `List`
 # - [ ] `HashMap`
 # - [ ] `HashSet`
-# - [ ] `Container`
+# - [ ] `Ref`
 # - [ ] `Queue`
 module redef_collections
 

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -242,7 +242,7 @@ redef class Couple[F, S]
 	end
 end
 
-redef class Container[E]
+redef class Ref[E]
 	super Serializable
 
 	redef init from_deserializer(v)

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -29,6 +29,14 @@ abstract class Socket
 	# Is this socket closed?
 	var closed = false
 
+	# Set whether calls to `accept` are blocking
+	fun blocking=(value: Bool)
+	do
+		# We use the opposite from the native version as the native API
+		# is closer to the C API. In the Nity API, we use a positive version
+		# of the name.
+		native.non_blocking = not value
+	end
 end
 
 # A general TCP socket, either a `TCPStream` or a `TCPServer`
@@ -291,15 +299,6 @@ class TCPServer
 		var native = native.accept
 		if native == null then return null
 		return new TCPStream.server_side(native)
-	end
-
-	# Set whether calls to `accept` are blocking
-	fun blocking=(value: Bool)
-	do
-		# We use the opposite from the native version as the native API
-		# is closer to the C API. In the Nity API, we use a positive version
-		# of the name.
-		native.non_blocking = not value
 	end
 
 	# Close this socket

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -89,8 +89,7 @@ class TCPStream
 		var hostent = sys.gethostbyname(host.to_cstring)
 		if hostent.address_is_null then
 			# Error in name lookup
-			var err = sys.h_errno
-			last_error = new IOError(err.to_s)
+			last_error = new IOError.from_h_errno
 
 			closed = true
 			end_reached = true
@@ -109,7 +108,7 @@ class TCPStream
 		end_reached = closed
 		if closed then
 			# Connection failed
-			last_error = new IOError(errno.strerror)
+			last_error = new IOError.from_errno
 		end
 
 		prepare_buffer(1024)
@@ -357,4 +356,14 @@ class SocketObserver
 		var timeval = new NativeTimeval(seconds, microseconds)
 		return native.select(max.native, read_set.native, write_set.native, except_set.native, timeval) > 0
 	end
+end
+
+redef class IOError
+	# Fill a new `IOError` from the message of `errno`
+	init from_errno do init errno.strerror
+
+	# Fill a new `IOError` from the message of `h_errno`
+	#
+	# Used with `gethostbyname`.
+	init from_h_errno do init h_errno.to_s
 end

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -20,11 +20,20 @@ module socket
 private import socket_c
 intrude import standard::stream
 
-# A general TCP socket, either a `TCPStream` or a `TCPServer`
+# A general Socket, either TCP or UDP
 abstract class Socket
 
 	# Underlying C socket
 	private var native: NativeSocket is noinit
+
+	# Is this socket closed?
+	var closed = false
+
+end
+
+# A general TCP socket, either a `TCPStream` or a `TCPServer`
+abstract class TCPSocket
+	super Socket
 
 	# Port used by the socket
 	var port: Int
@@ -33,14 +42,11 @@ abstract class Socket
 	#
 	# Formatted as xxx.xxx.xxx.xxx.
 	var address: String is noinit
-
-	# Is this socket closed?
-	var closed = false
 end
 
 # Simple communication stream with a remote socket
 class TCPStream
-	super Socket
+	super TCPSocket
 	super BufferedReader
 	super Writer
 	super PollableReader
@@ -232,7 +238,7 @@ end
 #
 # Create streams to communicate with clients using `accept`.
 class TCPServer
-	super Socket
+	super TCPSocket
 
 	private var addrin: NativeSocketAddrIn is noinit
 

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -85,7 +85,7 @@ class TCPStream
 		end
 
 		addrin = new NativeSocketAddrIn.with_hostent(hostname, port)
-		address = addrin.address
+		address = addrin.address.to_s
 		init(addrin.port, hostname.h_name)
 
 		closed = not internal_connect
@@ -103,7 +103,7 @@ class TCPStream
 		_buffer_pos = 0
 		native = h.socket
 		addrin = h.addr_in
-		address = addrin.address
+		address = addrin.address.to_s
 
 		init(addrin.port, address)
 	end
@@ -241,7 +241,7 @@ class TCPServer
 			return
 		end
 		addrin = new NativeSocketAddrIn.with_port(port, new NativeSocketAddressFamilies.af_inet)
-		address = addrin.address
+		address = addrin.address.to_s
 
 		# Bind it
 		closed = not bind

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -258,7 +258,7 @@ extern class NativeSocketAddrIn `{ struct sockaddr_in* `}
 		return sai;
 	`}
 
-	fun address: String import NativeString.to_s `{ return NativeString_to_s((char*)inet_ntoa(self->sin_addr)); `}
+	fun address: NativeString `{ return (char*)inet_ntoa(self->sin_addr); `}
 
 	fun family: NativeSocketAddressFamilies `{ return self->sin_family; `}
 
@@ -267,30 +267,33 @@ extern class NativeSocketAddrIn `{ struct sockaddr_in* `}
 	fun destroy `{ free(self); `}
 end
 
+# Host entry information, a pointer to a `struct hostent`
 extern class NativeSocketHostent `{ struct hostent* `}
-	private fun native_h_aliases(i: Int): String import NativeString.to_s `{ return NativeString_to_s(self->h_aliases[i]); `}
+	private fun native_h_aliases(i: Int): NativeString `{
+		return self->h_aliases[i];
+	`}
 
-	private fun native_h_aliases_reachable(i: Int): Bool `{ return (self->h_aliases[i] != NULL); `}
-
+	# Alternative names for the host
 	fun h_aliases: Array[String]
 	do
-		var i=0
-		var d=new Array[String]
+		var res = new Array[String]
 		loop
-			d.add(native_h_aliases(i))
-			if native_h_aliases_reachable(i+1) == false then break
-			i += 1
+			var ha = native_h_aliases(res.length)
+			if ha.address_is_null then break
+			res.add ha.to_s
 		end
-		return d
+		return res
 	end
 
-	fun h_addr: String import NativeString.to_s `{ return NativeString_to_s((char*)inet_ntoa(*(struct in_addr*)self->h_addr)); `}
+	fun h_addr: NativeString `{
+		return (char*)inet_ntoa(*(struct in_addr*)self->h_addr);
+	`}
 
 	fun h_addrtype: Int `{ return self->h_addrtype; `}
 
 	fun h_length: Int `{ return self->h_length; `}
 
-	fun h_name: String import NativeString.to_s `{ return NativeString_to_s(self->h_name); `}
+	fun h_name: NativeString `{ return self->h_name; `}
 end
 
 extern class NativeTimeval `{ struct timeval* `}

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -125,9 +125,9 @@ extern class NativeSocket `{ int* `}
 		return connect(*self, (struct sockaddr*)addrIn, sizeof(*addrIn));
 	`}
 
-	fun write(buffer: String): Int
-	import String.to_cstring, String.length `{
-		return write(*self, (char*)String_to_cstring(buffer), String_length(buffer));
+	# Write `length` bytes from `buffer`
+	fun write(buffer: NativeString, length: Int): Int `{
+		return write(*self, buffer, length);
 	`}
 
 	# Write `value` as a single byte
@@ -136,14 +136,9 @@ extern class NativeSocket `{ int* `}
 		return write(*self, &byt, 1);
 	`}
 
-	fun read: String import NativeString.to_s_with_length, NativeString `{
-		char *c = new_NativeString(1024);
-		int n = read(*self, c, 1023);
-		if(n < 0) {
-			return NativeString_to_s_with_length("",0);
-		}
-		c[n] = 0;
-		return NativeString_to_s_with_length(c, n);
+	# Read `length` bytes into `buffer`, returns the number of bytes read
+	fun read(buffer: NativeString, length: Int): Int `{
+		return read(*self, buffer, length);
 	`}
 
 	# Sets an option for the socket

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -202,7 +202,7 @@ extern class NativeSocket `{ int* `}
 		return new SocketAcceptResult(s, addrIn)
 	end
 
-	# Set wether this socket is non blocking
+	# Set whether this socket is non blocking
 	fun non_blocking=(value: Bool) `{
 		int flags = fcntl(*self, F_GETFL, 0);
 		if (flags == -1) flags = 0;
@@ -215,6 +215,22 @@ extern class NativeSocket `{ int* `}
 			return;
 		}
 		fcntl(*self, F_SETFL, flags);
+	`}
+
+	# Send `len` bytes from `buf` to `dest_addr`
+	fun sendto(buf: NativeString, len: Int, flags: Int, dest_addr: NativeSocketAddrIn): Int `{
+		return sendto(*self, buf, len, flags, (struct sockaddr*)dest_addr, sizeof(struct sockaddr_in));
+	`}
+
+	# Receive a message into `buf` of maximum `len` bytes
+	fun recv(buf: NativeString, len: Int, flags: Int): Int `{
+		return recv(*self, buf, len, flags);
+	`}
+
+	# Receive a message into `buf` of maximum `len` bytes and store sender info into `src_addr`
+	fun recvfrom(buf: NativeString, len: Int, flags: Int, src_addr: NativeSocketAddrIn): Int `{
+		socklen_t srclen = sizeof(struct sockaddr_in);
+		return recvfrom(*self, buf, len, flags, (struct sockaddr*)src_addr, &srclen);
 	`}
 end
 
@@ -404,6 +420,7 @@ extern class NativeSocketProtocolFamilies `{ int `}
 	new pf_key `{ return PF_KEY; `}
 	new pf_inet6 `{ return PF_INET6; `}
 	new pf_max `{ return PF_MAX; `}
+	new ipproto_udp `{ return IPPROTO_UDP; `}
 end
 
 # Level on which to set options

--- a/lib/standard/collection/abstract_collection.nit
+++ b/lib/standard/collection/abstract_collection.nit
@@ -282,7 +282,7 @@ end
 #
 # Also used when one want to give a single element when a full
 # collection is expected
-class Container[E]
+class Ref[E]
 	super Collection[E]
 
 	redef fun first do return item
@@ -304,14 +304,14 @@ class Container[E]
 		end
 	end
 
-	redef fun iterator do return new ContainerIterator[E](self)
+	redef fun iterator do return new RefIterator[E](self)
 
 	# The stored item
 	var item: E is writable
 end
 
 # This iterator is quite stupid since it is used for only one item.
-private class ContainerIterator[E]
+private class RefIterator[E]
 	super Iterator[E]
 	redef fun item do return _container.item
 
@@ -319,7 +319,7 @@ private class ContainerIterator[E]
 
 	redef var is_ok = true
 
-	var container: Container[E]
+	var container: Ref[E]
 end
 
 # Items can be removed from this collection

--- a/lib/standard/collection/list.nit
+++ b/lib/standard/collection/list.nit
@@ -327,7 +327,7 @@ end
 
 # Linked nodes that constitute a linked list.
 private class ListNode[E]
-	super Container[E]
+	super Ref[E]
 
 	# The next node.
 	var next: nullable ListNode[E] = null

--- a/tests/base_label_for.nit
+++ b/tests/base_label_for.nit
@@ -18,7 +18,7 @@ import abstract_collection
 
 fun maybe: Bool do return true
 
-var a = new Container[Int](1)
+var a = new Ref[Int](1)
 1.output
 for i in a do
 	2.output


### PR DESCRIPTION
This PR intro `UDPSocket` and cleans up a bit of the native layer of socket to avoid using callbacks when possible.

`UDPSocket` support sending messages to remote sockets without a connection and more importantly receive message from any sender. However, as of yet it does not support connections or the stream API of Nit.

Some TODO with the sockets:
* Stop using `gethostbyname` :neutral_face: 
* Decide on one or many APIs. The native layer has an API closed to the C API and to what is available in other languages, maybe it can be clean up further and exposed as is.

---
Please ignore the first 2 commits from #1573.