### PR TITLE
jwrapper accepts Jar archives

### DIFF
--- a/contrib/jwrapper/.gitignore
+++ b/contrib/jwrapper/.gitignore
@@ -1,4 +1,6 @@
-/gen
+gen/*
 src/javap_lexer.nit
 src/javap_parser.nit
 src/javap_test_parser.nit
+tests/*.nit
+tmp/*

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -17,3 +17,15 @@ clean:
 	rm -f bin/javap_test_parser bin/jwrapper
 	rm -f gen/*
 	rm src/javap_lexer.nit src/javap_parser.nit src/javap_test_parser.nit
+
+check: bin/jwrapper tests/wildcards.javap
+	mkdir -p tmp
+	bin/jwrapper -v -u comment -o tests/wildcards.nit tests/wildcards.javap
+	../../bin/nitpick -q tests/wildcards.nit
+
+check-libs: bin/jwrapper
+	# This config dependent rule must be tweaked according to each system
+	bin/jwrapper -v -u ignore -o tests/rt.nit /usr/lib/jvm/default-java/jre/lib/rt.jar
+	bin/jwrapper -v -u ignore -o tests/java_tools.nit /usr/lib/jvm/default-java/lib/tools.jar
+	bin/jwrapper -v -u ignore -o tests/sablecc.nit ~/apps/sablecc-3-beta.3.altgen.20041114/lib/sablecc.jar
+	bin/jwrapper -v -u ignore -o tests/android.nit ~/sdks/android-sdk/platforms/android-10/android.jar

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -1,15 +1,15 @@
-all: nitcc grammar bin/jwrapper
+all: bin/jwrapper
 
-nitcc:
+../nitcc/src/nitcc:
 	make -C ../nitcc
 
-grammar:
+src/javap_test_parser.nit: ../nitcc/src/nitcc grammar/javap.sablecc
 	../nitcc/src/nitcc grammar/javap.sablecc
 	mkdir -p src gen
-	mv *.nit src/
+	mv javap_*.nit src/
 	mv javap* gen/
 
-bin/jwrapper:
+bin/jwrapper: src/javap_test_parser.nit $(shell ../../bin/nitls -M src/jwrapper.nit) ../../bin/nitc
 	mkdir -p bin
 	../../bin/nitc src/jwrapper.nit -o bin/jwrapper
 
@@ -17,5 +17,3 @@ clean:
 	rm -f bin/javap_test_parser bin/jwrapper
 	rm -f gen/*
 	rm src/javap_lexer.nit src/javap_parser.nit src/javap_test_parser.nit
-
-.PHONY: grammar bin/jwrapper

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -24,7 +24,7 @@ class_declaration = modifier* class_or_interface full_class_name
 class_or_interface = 'class'|'interface';
 
 modifier
-	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile';
+	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile'|'strictfp';
 type = primitive_type brackets*;
 primitive_type
 	= 'boolean'|'byte'|'char'|'short'|'int'|'float'|'long'|'double'

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -8,13 +8,12 @@ blank = (' '|'\n'|'\t'|'\r')+;
 separator = ('.'|'/');
 brackets = '[]';
 wildcard = '?';
+compiled_from = 'Compiled from "' (Any-'"')* '"';
 
 // ---
 Parser
 Ignored blank;
 
-
-compiled_from = 'Compiled from "' identifier+ '.java"';
 files = file+;
 file = compiled_from? class_declaration;
 

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -13,9 +13,10 @@ wildcard = '?';
 Parser
 Ignored blank;
 
-multi_files = compiled_from? class_declaration;
 
 compiled_from = 'Compiled from "' identifier+ '.java"';
+files = file+;
+file = compiled_from? class_declaration;
 
 class_declaration = modifier* class_or_interface full_class_name
 	extends_declaration? implements_declaration? throws_declaration?

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -60,7 +60,7 @@ method_id = identifier;
 
 property_declaration
 	= {method:} modifier* generic_param? type method_id '(' parameter_list? ')' throws_declaration? ';'
-	| {constructor:} modifier* full_class_name '(' parameter_list? ')' throws_declaration? ';'
+	| {constructor:} modifier* generic_param? full_class_name '(' parameter_list? ')' throws_declaration? ';'
 	| {attribute:} modifier* type attribute_id throws_declaration? ';'
 	| {static:} modifier* '{' '}' ';'
 	| ';';

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -3,7 +3,7 @@ Grammar javap;
 // ---
 Lexer
 
-identifier = ('a'..'z'|'A'..'Z'|'_'|'$') ('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9')*;
+identifier = ('a'..'z'|'A'..'Z'|'_'|'$') ('a'..'z'|'A'..'Z'|'_'|'-'|'$'|'0'..'9')*;
 blank = (' '|'\n'|'\t'|'\r')+;
 separator = ('.'|'/');
 brackets = '[]';

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -65,8 +65,8 @@ property_declaration
 	| {static:} modifier* '{' '}' ';'
 	| ';';
 
-implements_declaration = 'implements' interface_list*;
-extends_declaration = 'extends' type;
+implements_declaration = 'implements' interface_list;
+extends_declaration = 'extends' interface_list;
 interface_list
 	= {tail:} interface_list ',' full_class_name
 	| {head:} full_class_name;

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -48,7 +48,9 @@ full_class_name
 	| {head:} class_name;
 class_name = identifier generic_param?;
 
-parameter = type '...'?;
+parameter
+	= type '...'?
+	| {wildcard:} wildcard 'super' full_class_name ;
 parameter_list
 	= {tail:} parameter_list ',' parameter
 	| {head:} parameter;

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -32,8 +32,11 @@ primitive_type
 
 type_ref
 	= full_class_name
-	| generic_identifier 'extends' full_class_name
-	| question_mark;
+	| generic_identifier 'extends' type_bound
+	| wildcard;
+type_bound
+	= {tail:} type_bound '&' full_class_name
+	| {head:} full_class_name;
 
 generic_param = '<' generic_parameter_list '>';
 generic_parameter_list

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -1,11 +1,15 @@
 Grammar javap;
 
+// ---
 Lexer
 
 identifier = ('a'..'z'|'A'..'Z'|'_'|'$') ('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9')*;
 blank = (' '|'\n'|'\t'|'\r')+;
 separator = ('.'|'/');
+brackets = '[]';
+wildcard = '?';
 
+// ---
 Parser
 Ignored blank;
 
@@ -19,42 +23,53 @@ class_declaration = modifier* class_or_interface full_class_name
 
 class_or_interface = 'class'|'interface';
 
-modifier = 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile';
-type = type_specifier '[]'*;
-type_specifier = 'boolean'|'byte'|'char'|'short'|'int'|'float'|'long'|'double' | type_ref;
+modifier
+	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile';
+type = primitive_type brackets*;
+primitive_type
+	= 'boolean'|'byte'|'char'|'short'|'int'|'float'|'long'|'double'
+	| type_ref;
 
-type_ref = full_class_name | generic_identifier 'extends' full_class_name | '?';
-type_refs = {tail:} type_refs ',' type_ref | {head:} type_ref;
+type_ref
+	= full_class_name
+	| generic_identifier 'extends' full_class_name
+	| question_mark;
 
 generic_param = '<' generic_parameter_list '>';
-generic_parameter_list = {tail:} generic_parameter_list ',' parameter | {head:} parameter;
-generic_identifier = full_class_name | '?';
+generic_parameter_list
+	= {tail:} generic_parameter_list ',' parameter
+	| {head:} parameter;
+generic_identifier
+	= full_class_name
+	| wildcard;
 
-full_class_name = full_class_name separator class_name | class_name;
+full_class_name
+	= {tail:} full_class_name separator class_name
+	| {head:} class_name;
 class_name = identifier generic_param?;
 
-interface_name = full_class_name;
-interface_list = {tail:} interface_list ',' interface_name | {head:} interface_name;
-
 parameter = type '...'?;
-parameter_list_comp = {tail:} parameter_list_comp ',' parameter | {head:} parameter;
-parameter_list = parameter_list_comp;
+parameter_list
+	= {tail:} parameter_list ',' parameter
+	| {head:} parameter;
 
-exception = type;
-exception_list = exception_list ',' exception | exception;
-
-statement = variable_declaration | statement_block | ';';
-statement_block = '{' statement* '}';
-
-variable_id = identifier '[]'*;
+attribute_id = identifier brackets*;
 method_id = identifier;
 
-property_declaration = method_declaration | constructor_declaration | variable_declaration | static_declaration | ';';
-variable_declaration = modifier* type variable_id throws_declaration? ';';
-method_declaration = modifier* generic_param? type method_id '(' parameter_list? ')' throws_declaration? ';';
-constructor_declaration = modifier* full_class_name '(' parameter_list? ')' throws_declaration? ';';
+property_declaration
+	= {method:} modifier* generic_param? type method_id '(' parameter_list? ')' throws_declaration? ';'
+	| {constructor:} modifier* full_class_name '(' parameter_list? ')' throws_declaration? ';'
+	| {attribute:} modifier* type attribute_id throws_declaration? ';'
+	| {static:} modifier* '{' '}' ';'
+	| ';';
+
 implements_declaration = 'implements' interface_list*;
-extends_interface_declaration = 'extends' interface_list*;
 extends_declaration = 'extends' type;
-static_declaration = modifier* '{' '}' ';';
+interface_list
+	= {tail:} interface_list ',' full_class_name
+	| {head:} full_class_name;
+
 throws_declaration = 'throws' exception_list?;
+exception_list
+	= {tail:} exception_list ',' type
+	| {head:} type;

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -31,6 +31,9 @@ class CodeGenerator
 	# Comment out methods with unknown (unwrapped) types
 	var comment_unknown_types: Bool
 
+	# Generate stub classes for unknown types used in the generated module
+	var stub_for_unknown_types: Bool
+
 	# Output file
 	var file_out: Writer = new FileWriter.open(file_name) is lazy, writable
 
@@ -60,10 +63,12 @@ class CodeGenerator
 		class_content.add("\nend\n")
 
 		var wrappers = new Array[String]
-		for jtype in jclass.unknown_types do
-			if jtype == jclass.class_type then continue
-			wrappers.add("\n")
-			wrappers.add(gen_unknown_class_header(jtype))
+		if stub_for_unknown_types then
+			for jtype in jclass.unknown_types do
+				if jtype == jclass.class_type then continue
+				wrappers.add("\n")
+				wrappers.add(gen_unknown_class_header(jtype))
+			end
 		end
 
 		var imports = new Array[String]
@@ -148,11 +153,11 @@ class CodeGenerator
 				if jparam.is_wrapped then
 					java_class.imports.add nit_type.mod.as(not null)
 				else
+					java_class.unknown_types.add jparam
 					if comment_unknown_types then
 						comment = "#"
 					else
 						nit_type = jparam.extern_name
-						java_class.unknown_types.add(jparam)
 					end
 				end
 			end
@@ -194,11 +199,11 @@ class CodeGenerator
 				if jreturn_type.is_wrapped then
 					java_class.imports.add return_type.mod.as(not null)
 				else
+					java_class.unknown_types.add jreturn_type
 					if comment_unknown_types then
 						comment = "#"
 					else
 						return_type = jreturn_type.extern_name
-						java_class.unknown_types.add(jreturn_type)
 					end
 				end
 			end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -112,8 +112,10 @@ class CodeGenerator
 	fun gen_class_header(jtype: JavaType): String
 	do
 		var temp = new Array[String]
-		temp.add("extern class Native{jtype.id} in \"Java\" `\{ {jtype} `\}\n")
-		temp.add("\tsuper JavaObject\n\n")
+		var nit_type = jtype.to_nit_type
+		temp.add "# Java class: {jtype.to_package_name}\n"
+		temp.add "extern class {nit_type} in \"Java\" `\{ {jtype.to_package_name} `\}\n"
+		temp.add "\tsuper JavaObject\n\n"
 
 		return temp.join
 	end
@@ -179,6 +181,9 @@ class CodeGenerator
 			nit_id_no += 1
 		end
 
+		# Method documentation
+		var doc = "\t# Java implementation: {java_class}.{jmethod_id}\n"
+
 		# Method identifier
 		var method_id = nmethod_id.to_nit_method_name
 		var nit_signature = new Array[String]
@@ -212,9 +217,9 @@ class CodeGenerator
 
 		var temp = new Array[String]
 
+		temp.add doc
 		temp.add(comment + nit_signature.join)
 
-		# FIXME : This huge `if` block is only necessary to copy primitive arrays as long as there's no better way to do it
 		if comment == "#" then
 			temp.add(" in \"Java\" `\{\n{comment}\t\tself.{jmethod_id}({java_params});\n{comment}\t`\}\n")
 		# Methods with return type

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -1,6 +1,7 @@
 # This file is part of NIT (http://www.nitlanguage.org).
 #
 # Copyright 2014 Frédéric Vachon <fredvac@gmail.com>
+# Copyright 2015 Alexis Laferrière <alexis.laf@xymus.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,30 +22,27 @@ intrude import model
 
 class CodeGenerator
 
-	var with_attributes: Bool
-	var comment_unknown_types: Bool
-	var file_out: FileWriter
+	# Path to the output file
+	var file_name: String
+
+	# Model of Java class being wrapped
 	var java_class: JavaClass
-	var nb_params: Int
-	var module_name: nullable String = null
 
-	init (file_name: String, jclass: JavaClass, with_attributes, comment: Bool)
-	do
-		file_out = new FileWriter.open(file_name)
+	# Comment out methods with unknown (unwrapped) types
+	var comment_unknown_types: Bool
 
-		var nit_ext = ".nit"
-		if file_name.has_suffix(nit_ext) then
+	# Output file
+	var file_out: Writer = new FileWriter.open(file_name) is lazy, writable
+
+	# Name of the Nit module to generate
+	var module_name: nullable String is lazy do
+		if file_name.file_extension == "nit" then
 			# Output file ends with .nit, we expect it to be a valid name
-			module_name = file_name.strip_extension(nit_ext)
-
-			# Otherwise, it may be anything so do not declare a module
-		end
-
-		self.java_class = jclass
-		self.with_attributes = with_attributes
-		self.comment_unknown_types = comment
+			return file_name.basename(".nit")
+		else return null
 	end
 
+	# Generate the Nit module into `file_out`
 	fun generate
 	do
 		var jclass = self.java_class

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -77,7 +77,7 @@ class CodeGenerator
 			imports.add("import android::{import_}\n")
 		end
 
-		file_out.write(gen_licence)
+		file_out.write license
 
 		var module_name = module_name
 		if module_name != null then file_out.write "module {module_name}\n"
@@ -89,9 +89,8 @@ class CodeGenerator
 		file_out.write(wrappers.join)
 	end
 
-	fun gen_licence: String
-	do
-		return """
+	# License for the header of the generated Nit module
+	var license = """
 # This file is part of NIT (http://www.nitlanguage.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,8 +106,7 @@ class CodeGenerator
 # limitations under the License.
 
 # This code has been generated using `jwrapper`
-"""
-	end
+""" is writable
 
 	fun gen_class_header(jtype: JavaType): String
 	do

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -232,7 +232,19 @@ class CodeGenerator
 	end
 end
 
+redef class Sys
+	# List of Nit keywords
+	#
+	# These may also be keywords in Java, but there they would be used capitalized.
+	private var nit_keywords: Array[String] = ["abort", "abstract", "and", "assert",
+		"break", "class", "continue", "do", "else", "end", "enum", "extern", "implies",
+		"import", "init", "interface", "intrude", "if", "in", "is", "isa", "for", "label",
+		"loop", "module", "new", "not", "null",	"nullable", "or", "package", "private",
+		"protected", "public", "return", "self", "super", "then", "type", "var", "while"]
+end
+
 redef class String
+
 	# Convert the Java method name `self` to the Nit style
 	#
 	# * Converts to snake case
@@ -244,8 +256,21 @@ redef class String
 		if name.has_prefix("get_") then
 			name = name.substring_from(4)
 		else if name.has_prefix("set_") then
-			name = name.substring_from(4) + "="
+			name = name.substring_from(4)
+			if nit_keywords.has(name) then name += "_"
+			name += "="
 		end
+
+		# Strip the '_' prefix
+		while name.has_prefix("_") do name = name.substring(1, name.length-1)
+
+		# Escape Nit keywords
+		if nit_keywords.has(name) then name += "_"
+
+		# If the name starts by something other than a letter, prefix with `java_`
+		if not name.chars.first.is_letter then name = "java_" + name
+
+		name = name.replace("$", "_")
 
 		return name
 	end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -52,10 +52,6 @@ class CodeGenerator
 		var class_content = new Array[String]
 		class_content.add(gen_class_header(jclass.class_type))
 
-		if with_attributes then
-			for id, jtype in jclass.attributes do class_content.add(gen_attribute(id, jtype))
-		end
-
 		for id, methods_info in jclass.methods do
 			for method_info in methods_info do
 				var nid = id
@@ -134,11 +130,6 @@ class CodeGenerator
 		temp.add("\tsuper JavaObject\n\nend\n")
 
 		return temp.join
-	end
-
-	fun gen_attribute(jid: String, jtype: JavaType): String
-	do
-		return "\tvar {jid.to_nit_method_name}: {jtype.to_nit_type}\n"
 	end
 
 	fun gen_method(jmethod_id: String, nmethod_id: String, jreturn_type: JavaType, jparam_list: Array[JavaType]): String

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -1,6 +1,7 @@
 # This file is part of NIT (http://www.nitlanguage.org).
 #
 # Copyright 2014 Frédéric Vachon <fredvac@gmail.com>
+# Copyright 2015 Alexis Laferrière <alexis.laf@xymus.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,10 +32,10 @@ class JavaVisitor
 	var java_class = new JavaClass
 	var declaration_type: nullable String =  null
 	var declaration_element: nullable String = null
-	var class_type: JavaType
+	var class_type = new JavaType(self.converter) is lazy
 
 	var variable_id = ""
-	var variable_type: JavaType
+	var variable_type = new JavaType(self.converter) is lazy
 
 	var is_generic_param = false
 	var is_generic_id = false
@@ -47,20 +48,11 @@ class JavaVisitor
 	var is_primitive_array = false
 
 	var method_id = ""
-	var method_return_type: JavaType
+	var method_return_type = new JavaType(self.converter) is lazy
 	var method_params = new Array[JavaType]
 	var param_index = 0
 
 	redef fun visit(n) do n.accept_visitor(self)
-
-	init(converter: JavaTypeConverter)
-	do
-		self.converter = converter
-		self.class_type = new JavaType(self.converter)
-		self.method_return_type = new JavaType(self.converter)
-		self.variable_type = new JavaType(self.converter)
-		super
-	end
 
 	# Add the identifier from `token` to the current context
 	fun add_identifier(token: NToken)

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -206,6 +206,11 @@ redef class N_39dlong_39d
 	redef fun accept_visitor(v) do v.add_identifier self
 end
 
+redef class Nwildcard
+	# TODO use the lower bound
+	redef fun accept_visitor(v) do v.add_identifier "Object"
+end
+
 #                                  #
 #    C L A S S     H E A D E R     #
 #                                  #

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -254,7 +254,9 @@ redef class Nproperty_declaration_method
 		v.declaration_type = null
 
 		if v.method_return_type.has_unresolved_types then v.method_return_type.resolve_types(v.generic_map)
-		v.java_class.add_method(v.method_id, v.method_return_type, v.method_params)
+
+		var method = new JavaMethod(v.method_return_type, v.method_params.clone)
+		v.java_class.methods[v.method_id].add method
 
 		v.method_params.clear
 		v.method_id = ""

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -24,15 +24,20 @@ import code_generator
 import jtype_converter
 intrude import model
 
+# Visitor of the AST generated from javap output
 class JavaVisitor
 	super Visitor
 
 	var converter: JavaTypeConverter
 
-	var java_class = new JavaClass
+	# Model of all the analyzed classes
+	var model: JavaModel
+
+	var java_class: JavaClass is noinit
+
 	var declaration_type: nullable String =  null
 	var declaration_element: nullable String = null
-	var class_type = new JavaType(self.converter) is lazy
+	var class_type: JavaType is noinit
 
 	var variable_id = ""
 	var variable_type = new JavaType(self.converter) is lazy
@@ -101,7 +106,7 @@ redef class Nidentifier
 			if v.declaration_element == "id" then
 				v.method_id = self.text
 			else if v.declaration_element == "return_type" then
-				if self.text == "void" then 
+				if self.text == "void" then
 					v.method_return_type.is_void = true
 				else if v.is_generic_param then
 					v.method_return_type.generic_params[v.gen_params_index].identifier.add(self.text)
@@ -208,6 +213,10 @@ end
 redef class Nclass_declaration
 	redef fun accept_visitor(v)
 	do
+		v.java_class = new JavaClass
+		v.model.classes.add v.java_class
+		v.class_type = new JavaType(v.converter)
+
 		v.declaration_type = "class_header"
 		v.declaration_element = "id"
 		super

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -257,6 +257,7 @@ redef class Nproperty_declaration_method
 	redef fun accept_visitor(v)
 	do
 		v.declaration_type = "method"
+		v.declaration_element = null
 		super
 		v.declaration_type = null
 

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -60,17 +60,29 @@ class JavaVisitor
 	redef fun visit(n) do n.accept_visitor(self)
 
 	# Add the identifier from `token` to the current context
-	fun add_identifier(token: NToken)
+	fun add_identifier(token: String)
 	do
 		if declaration_type == "variable" then
 			if declaration_element == "type" then
-				variable_type.identifier.add(token.text)
+				if is_generic_param then
+					variable_type.generic_params[gen_params_index].identifier.add token
+				else
+					variable_type.identifier.add(token)
+				end
 			end
 		else if declaration_type == "method" then
 			if declaration_element == "return_type" then
-				method_return_type.identifier.add(token.text)
+				if is_generic_param then
+					method_return_type.generic_params[gen_params_index].identifier.add token
+				else
+					method_return_type.identifier.add(token)
+				end
 			else if declaration_element == "parameter_list" then
-				method_params[param_index].identifier.add(token.text)
+				if is_generic_param then
+					method_params[param_index].generic_params[gen_params_index].identifier.add token
+				else
+					method_params[param_index].identifier.add(token)
+				end
 			end
 		end
 	end
@@ -84,58 +96,49 @@ redef class Nidentifier
 	redef fun accept_visitor(v)
 	do
 		if v.declaration_type == "class_header" then
-
+			# Class declaration
 			if v.declaration_element == "id" then
-				v.class_type.identifier.add(self.text)
+				v.class_type.identifier.add text
+				return
 			end
 
 		else if v.declaration_type == "variable" then
-
+			# Attribute declaration
 			if v.declaration_element == "id" then
-				v.variable_id += self.text
-			else if v.declaration_element == "type" then
-				if v.is_generic_param then
-					v.variable_type.generic_params[v.gen_params_index].identifier.add(self.text)
-				else
-					v.variable_type.identifier.add(self.text)
-				end
+				v.variable_id += text
+				return
 			end
 
 		else if v.declaration_type == "method" then
 
 			if v.declaration_element == "id" then
+				# Method id
 				v.method_id = self.text
+				return
 			else if v.declaration_element == "return_type" then
 				if self.text == "void" then
+					# void return type
 					v.method_return_type.is_void = true
-				else if v.is_generic_param then
-					v.method_return_type.generic_params[v.gen_params_index].identifier.add(self.text)
-				else
-					v.method_return_type.identifier.add(self.text)
+					return
 				end
 			else if v.declaration_element == "parameter_list" then
-				if v.is_generic_param then
-					v.method_params[v.param_index].generic_params[v.gen_params_index].identifier.add(self.text)
-				else
-					v.method_params[v.param_index].identifier.add(self.text)
-				end
+				# Parameters, leave it to add_identifier
 
-			# Creates a map to resolve generic return types
-			# Exemple : public **<T extends android/os/Bundle>** T foo();
 			else if v.is_generic_param then
+				# Creates a map to resolve generic return types
+				# Example : public **<T extends android/os/Bundle>** T foo();
 				if v.is_generic_id then
 					v.generic_id = self.text
 					v.generic_map[self.text] = new Array[String]
 
 					if not v.method_return_type.has_unresolved_types then v.method_return_type.has_unresolved_types = true
 				else
-					v.generic_map[v.generic_id].add(self.text)
+					v.generic_map[v.generic_id].add text
 				end
 			end
-
 		end
 
-		super
+		v.add_identifier text
 	end
 end
 
@@ -175,35 +178,35 @@ redef class Nbrackets
 end
 
 redef class N_39dchar_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dboolean_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dfloat_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39ddouble_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dbyte_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dshort_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dint_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class N_39dlong_39d
-	redef fun accept_visitor(v) do v.add_identifier self
+	redef fun accept_visitor(v) do v.add_identifier text
 end
 
 redef class Nwildcard

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -143,7 +143,7 @@ redef class Nidentifier
 end
 
 # Primitive array node
-redef class N_39d_91d_93d_39d
+redef class Nbrackets
 	redef fun accept_visitor(v)
 	do
 		if v.declaration_type == "variable" then
@@ -253,7 +253,7 @@ end
 #                                            #
 
 # Method declaration
-redef class Nmethod_declaration
+redef class Nproperty_declaration_method
 	redef fun accept_visitor(v)
 	do
 		v.declaration_type = "method"
@@ -270,7 +270,7 @@ redef class Nmethod_declaration
 end
 
 # Constructor declaration
-redef class Nconstructor_declaration
+redef class Nproperty_declaration_constructor
 	redef fun accept_visitor(v)
 	do
 		v.declaration_type = "constructor"
@@ -280,7 +280,7 @@ redef class Nconstructor_declaration
 end
 
 # Variable property declaration
-redef class Nvariable_declaration
+redef class Nproperty_declaration_attribute
 	redef fun accept_visitor(v)
 	do
 		v.declaration_type = "variable"
@@ -295,7 +295,7 @@ redef class Nvariable_declaration
 end
 
 # Static property declaration
-redef class Nstatic_declaration
+redef class Nproperty_declaration_static
 	redef fun accept_visitor(v)
 	do
 		v.declaration_type = "static"
@@ -305,7 +305,7 @@ redef class Nstatic_declaration
 end
 
 # Identifier of a variable
-redef class Nvariable_id
+redef class Nattribute_id
 	redef fun accept_visitor(v)
 	do
 		v.declaration_element = "id"

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -14,14 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# jwrapper is a Nit extern class generator `in "Java"`.
-# It takes a .class file and output a Nit file. For further details on installation and usage, refer to the README file.
+# jwrapper wraps Java classes in extern Nit classes
+#
+# This tool takes class file, Jar archives and javap files as input,
+# and it outputs a Nit source file.
+# For further details on installation and usage, refer to the README file.
 #
 # Here's an overview of the project design :
 # * Grammar and lexer : `grammar/javap.sablecc`
 # * The `javap_visitor` implements the visitor that extracts data from the AST
 # * The `code_generator` takes these data and converts it to Nit code via the `jtype_converter` module and generate the output Nit file.
-# * The `types` contains data structures used to represent the data
+# * The `model` contains data structures used to represent the data
 # * The `jwrapper` module implements the user interface
 module jwrapper
 
@@ -40,9 +43,11 @@ var opt_help = new OptionBool("Show this help message", "-h", "--help")
 opts.add_option(opt_output, opt_unknown, opt_verbose, opt_help)
 opts.parse args
 
-if not opts.errors.is_empty or opts.rest.length != 2 or opt_help.value then
-	print "USAGE: jwrapper [OPTIONS] class_file nit_file"
-	print "Options:"
+if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then
+	print """
+Usage: jwrapper [options] file [other_file [...]]
+Input files: bytecode Java class (.class), Jar archive (.jar) or javap output (.javap)
+Options:"""
 	opts.usage
 
 	if opt_help.value then exit 0
@@ -53,7 +58,7 @@ var out_file = opt_output.value
 if out_file == null then out_file = "out.nit"
 
 if not "javap".program_is_in_path then
-	print "ERROR: 'javap' not found."
+	print "Error: 'javap' must be in PATH"
 	exit 1
 end
 

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -1,6 +1,7 @@
 # This file is part of NIT (http://www.nitlanguage.org).
 #
 # Copyright 2014 Frédéric Vachon <fredvac@gmail.com>
+# Copyright 2015 Alexis Laferrière <alexis.laf@xymus.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +30,8 @@
 module jwrapper
 
 import opts
+import performance_analysis
+
 import javap_test_parser
 import code_generator
 import javap_visitor
@@ -62,15 +65,126 @@ if not "javap".program_is_in_path then
 	exit 1
 end
 
-var javap = new ProcessReader("javap", "-public", dot_class)
+# List of bytecode Java classes and javap output files
+var class_files = new Array[String]
+var javap_files = new Array[String]
+var clock = new Clock
 
-var p = new TestParser_javap
-var tree = p.work(javap.read_all)
+# Sort through input files passed as arguments
+for input in opts.rest do
+	var ext = input.file_extension
+	if ext == "class" then
+		class_files.add input
+	else if ext == "javap" then
+		javap_files.add input
+	else if ext == "jar" then
+		var out_dir = "tmp"
+		clock.lapse
 
+		if opt_verbose.value > 0 then print "# Extracting {input}"
+
+		# Extract all files
+		var cmd = "cd {out_dir}; jar -xf {input}"
+		var status = system(cmd)
+		if status != 0 then
+			print_error "Warning: Failed to extract Jar archive '{input}'"
+			continue
+		end
+
+		# List .class files
+		var javap = new ProcessReader("jar", "-tf", input)
+		var output = javap.read_all
+		javap.wait
+		for path in output.split("\n") do
+			if path.file_extension == "class" then
+				class_files.add out_dir / path
+			end
+		end
+		javap.close
+
+		sys.perfs["jar extract"].add clock.lapse
+	else
+		print_error "Warning: Unsupported file extension for input file '{input}'"
+	end
+end
+
+if class_files.is_empty and javap_files.is_empty then
+	print_error "Error: No valid input files, quitting"
+	exit 1
+end
+
+var model = new JavaModel
 var converter = new JavaTypeConverter
 
-var visitor = new JavaVisitor(converter)
-visitor.enter_visit(tree)
+# Concatenated javap output for all the target files
+var javap_output = ""
 
-var generator = new CodeGenerator(out_file, visitor.java_class, opt_attr.value, opt_comment.value)
+# Parse and analyze all the classes at once
+if class_files.not_empty then
+
+	if opt_verbose.value > 0 then print "# Running javap on {class_files.length} Java classes"
+	clock.lapse
+
+	# Run javap of the class file
+	class_files.unshift "-public"
+	var javap = new ProcessReader("javap", class_files...)
+	javap_output += javap.read_all
+	javap.wait
+	javap.close
+	var status = javap.status
+
+	if status != 0 then
+		print_error "Warning: javap failed to parse all class files, is it a valid class file?"
+		exit 1
+	end
+
+	sys.perfs["javap"].add clock.lapse
+end
+
+# Concatenate the preprocessed javap outputs
+for class_file in javap_files do
+	if opt_verbose.value > 0 then print "# Using the preprocessed file {class_file}"
+
+	var ext = class_file.file_extension
+	assert ext == "javap"
+
+	javap_output += class_file.to_path.read_all
+end
+
+if opt_verbose.value > 0 then print "# Parsing javap output"
+if opt_verbose.value > 1 then javap_output.write_to_file "tests/javap.javap"
+
+# Lexer
+var lexer = new Lexer_javap(javap_output)
+var parser = new Parser_javap
+var tokens = lexer.lex
+parser.tokens.add_all tokens
+sys.perfs["core lexer"].add clock.lapse
+
+# Parser
+var root_node = parser.parse
+if root_node isa NError then
+	print_error "Warning: Parsing failed with {root_node.message}:{root_node.position or else ""}"
+	exit 1
+end
+sys.perfs["core parser"].add clock.lapse
+
+# Build model
+if opt_verbose.value > 0 then print "# Building model"
+assert root_node isa NStart
+var visitor = new JavaVisitor(converter, model)
+visitor.enter_visit root_node
+sys.perfs["core model"].add clock.lapse
+
+if opt_verbose.value > 0 then print "# Generating Nit code"
+
+var use_comment = opt_unknown.value == 0
+var use_stub = opt_unknown.value == 1
+var generator = new CodeGenerator(out_file, model, use_comment, use_stub)
 generator.generate
+sys.perfs["code generator"].add clock.lapse
+
+if opt_verbose.value > 1 then
+	print "# Performance Analysis:"
+	print sys.perfs
+end

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -32,19 +32,13 @@ import javap_visitor
 
 var opts = new OptionContext
 
-var opt_attr = new OptionBool("Generate attributes", "-a", "--with-attributes")
-var opt_comment = new OptionBool("Comment methods/attributes containing unknown types", "-c", "--comment")
-var opt_wrap = new OptionBool("Create extern classes wrapping unknown types (Default)", "-w", "--wrap")
+var opt_unknown = new OptionEnum(["comment", "stub", "ignore"], "How to deal with unknown types", 0, "-u")
+var opt_verbose = new OptionCount("Verbosity", "-v")
+var opt_output = new OptionString("Output file", "-o")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_attr, opt_comment, opt_wrap, opt_help)
-
-opts.parse(args)
-
-if opt_wrap.value and opt_comment.value then
-	print "Error: Can't use both '-c' and '-w'"
-	exit 1
-end
+opts.add_option(opt_output, opt_unknown, opt_verbose, opt_help)
+opts.parse args
 
 if not opts.errors.is_empty or opts.rest.length != 2 or opt_help.value then
 	print "USAGE: jwrapper [OPTIONS] class_file nit_file"
@@ -55,8 +49,8 @@ if not opts.errors.is_empty or opts.rest.length != 2 or opt_help.value then
 	exit 1
 end
 
-var dot_class = opts.rest[0]
-var out_file = opts.rest[1]
+var out_file = opt_output.value
+if out_file == null then out_file = "out.nit"
 
 if not "javap".program_is_in_path then
 	print "ERROR: 'javap' not found."

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -17,6 +17,8 @@
 # Contains the java and nit type representation used to convert java to nit code
 module model
 
+import more_collections
+
 import jtype_converter
 
 class JavaType
@@ -291,17 +293,10 @@ class JavaClass
 	var attributes = new HashMap[String, JavaType]
 
 	# Methods of this class organized by their name
-	var methods = new HashMap[String, Array[JavaMethod]]
+	var methods = new MultiHashMap[String, JavaMethod]
 
 	var unknown_types = new HashSet[JavaType]
 	var imports = new HashSet[NitModule]
-
-	fun add_method(id: String, return_type: JavaType, params: Array[JavaType])
-	do
-		var signatures = methods.get_or_default(id, new Array[JavaMethod])
-		signatures.add(new JavaMethod(return_type, new Array[JavaType].from(params)))
-		methods[id] = signatures
-	end
 end
 
 # A Java method, with its signature

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -100,6 +100,8 @@ class JavaType
 			name = "Java" + extern_class_name.join
 		end
 
+		name = name.replace("-", "_")
+
 		var nit_type = new NitType(name)
 		nit_type.is_complete = false
 		return nit_type

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -84,8 +84,6 @@ class JavaType
 		return nit_type
 	end
 
-	fun is_iterable: Bool do return iterable.has(self.id)
-
 	fun is_collection: Bool do return is_primitive_array or collections_list.has(self.id)
 
 	fun is_wrapped: Bool do return find_extern_class != null
@@ -116,22 +114,15 @@ class JavaType
 		return converter.cast_as_return(jtype)
 	end
 
-	redef fun to_s: String
+	redef fun to_s
 	do
 		var id = self.full_id
 
 		if self.is_primitive_array then
-			for i in [0..array_dimension[ do
-				id += "[]"
-			end
+			id += "[]" * array_dimension
 		else if self.has_generic_params then
-			var gen_list = new Array[String]
-
-			for param in generic_params do
-				gen_list.add(param.to_s)
-			end
-
-			id += "<{gen_list.join(", ")}>"
+			var params = [for param in generic_params do param.to_s]
+			id += "<{params.join(", ")}>"
 		end
 
 		return id

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -172,6 +172,8 @@ class JavaType
 
 		var regex = "extern class [a-zA-Z1-9]\\\+[ ]\\\+in[ ]\\\+\"Java\"[ ]*`\{[ ]*" + self.to_s + "\\\+[ ]*`\}"
 		var nit_dir = "NIT_DIR".environ
+		if nit_dir.is_empty then return null
+
 		var grep = new ProcessReader("grep", "-r", regex, nit_dir/"lib/android/", nit_dir/"lib/java/")
 		var to_eat = ["private", "extern", "class"]
 

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -297,6 +297,8 @@ class JavaClass
 
 	# Importations from this class
 	var imports = new HashSet[NitModule]
+
+	redef fun to_s do return class_type.to_s
 end
 
 # Model of all the Java class analyzed in one run

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -95,9 +95,9 @@ class JavaType
 		var name
 		if is_primitive_array then
 			# Primitive arrays have a special naming convention
-			name = "Native" + extern_class_name.join.capitalized + "Array"
+			name = "Java" + extern_class_name.join.capitalized + "Array"
 		else
-			name = "Native" + extern_class_name.join
+			name = "Java" + extern_class_name.join
 		end
 
 		var nit_type = new NitType(name)

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -1,6 +1,7 @@
 # This file is part of NIT (http://www.nitlanguage.org).
 #
 # Copyright 2014 Frédéric Vachon <fredvac@gmail.com>
+# Copyright 2015 Alexis Laferrière <alexis.laf@xymus.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -288,15 +289,28 @@ class NitType
 	end
 end
 
+# Model of a single Java class
 class JavaClass
+	# Type of this class
 	var class_type = new JavaType(new JavaTypeConverter)
+
+	# Attributes of this class
 	var attributes = new HashMap[String, JavaType]
 
 	# Methods of this class organized by their name
 	var methods = new MultiHashMap[String, JavaMethod]
 
-	var unknown_types = new HashSet[JavaType]
+	# Importations from this class
 	var imports = new HashSet[NitModule]
+end
+
+# Model of all the Java class analyzed in one run
+class JavaModel
+	# Unknown Java types used in `classes`
+	var unknown_types = new HashSet[JavaType]
+
+	# All analyzed classes
+	var classes = new Array[JavaClass]
 end
 
 # A Java method, with its signature

--- a/contrib/jwrapper/tests/wildcards.javap
+++ b/contrib/jwrapper/tests/wildcards.javap
@@ -1,0 +1,9 @@
+public abstract class android.net.Uri implements android.os.Parcelable, java.lang.Comparable<android.net.Uri> {
+	public <T extends java/lang/Object> com.sun.jmx.mbeanserver.MXBeanSupport(T, java.lang.Class<T>) throws javax.management.NotCompliantMBeanException;
+
+	public static <T extends java/lang/Object & java/lang/Comparable<? super T>> T max(java.util.Collection<? extends T>);
+
+	public <T extends java/lang/Object> com.sun.jmx.mbeanserver.MXBeanSupport(T, java.lang.Class<T>) throws javax.management.NotCompliantMBeanException;
+
+	public strictfp double doubleValue();
+}

--- a/lib/opts.nit
+++ b/lib/opts.nit
@@ -163,7 +163,7 @@ abstract class OptionParameter
 	end
 end
 
-# An option with a String as parameter
+# An option with a `String` as parameter
 class OptionString
 	super OptionParameter
 	redef type VALUE: nullable String
@@ -174,9 +174,10 @@ class OptionString
 	redef fun convert(str) do return str
 end
 
-# An option with an enum as parameter
-# In the code, declaring an option enum (-e) with an enum like `["zero", "one", "two"]
-# In the command line, typing `myprog -e one` is giving 1 as value
+# An option to choose from an enumeration
+#
+# Declare an enumeration option with all its possible values as an array.
+# Once the arguments are processed, `value` is set as the index of the selected value, if any.
 class OptionEnum
 	super OptionParameter
 	redef type VALUE: Int

--- a/lib/performance_analysis.nit
+++ b/lib/performance_analysis.nit
@@ -60,7 +60,7 @@ class PerfMap
 		return ts
 	end
 
-	redef fun to_s do return "* " + join(": ", "\n* ")
+	redef fun to_s do return "* " + join("\n* ", ": ")
 end
 
 # Statistics on wall clock execution time of a category of events by `name`

--- a/lib/performance_analysis.nit
+++ b/lib/performance_analysis.nit
@@ -81,6 +81,9 @@ class PerfEntry
 	# Number of registered events
 	var count = 0
 
+	# Total execution time of this event
+	var sum = 0.0
+
 	# Register a new event execution time with a `Timespec`
 	fun add(lapse: Timespec) do add_float lapse.to_f
 
@@ -90,9 +93,10 @@ class PerfEntry
 		if time.to_f < min.to_f or count == 0 then min = time
 		if time.to_f > max.to_f then max = time
 
-		avg = (avg * count.to_f + time) / (count+1).to_f
+		sum += time
 		count += 1
+		avg = sum / count.to_f
 	end
 
-	redef fun to_s do return "min {min}, max {max}, avg {avg}, count {count}"
+	redef fun to_s do return "min {min}, max {max}, avg {avg}, sum {sum}, count {count}"
 end


### PR DESCRIPTION
This PR modifies jwrapper to accept Jar archives and fix a bunch of bugs/limitations. This is probably the first of 2 PRs on jwrapper. This one targets the frontend to accept any Java classes (tested on over 25k classes) and to mass produce wrappers. It also ensures that both the generated nit code and jwrapper itself is debuggable.

Although the mass generated Nit code is syntactically valid, more work is needed so it can be usable. We will need to somehow apply Java namespace in generated Nit code, and revamp how new wrappers interact with older/custom wrappers. There is also a few missing features, such as copying the class hierarchy to Nit.

With this PR, jwrapper successfully parses 4 large Jar achives:
* OpenJDK 7 standard library `rt.jar` with 18568 classes.
* OpenJDK 7 tools `tools.jar` with 4144 classes.
* Android lib `android.jar` with 2767 classes.
* SableCC `sablecc-3-beta.3.altgen.20041114/lib/sablecc.jar` with 495 classes.