### PR TITLE
NSieve optimization

### DIFF
--- a/lib/c.nit
+++ b/lib/c.nit
@@ -119,7 +119,7 @@ end
 
 # Wrapper around an array of `unsigned char` in C (`unsigned char*`) with length and destroy state
 class CByteArray
-	super CArray[Int]
+	super CArray[Byte]
 	redef type NATIVE: NativeCByteArray
 
 	# Allocate a new array of `size`
@@ -128,8 +128,8 @@ class CByteArray
 		super size
 	end
 
-	# Build from an `Array[Int]`
-	new from(array: Array[Int])
+	# Build from a `SequenceRead[Byte]`
+	new from(array: SequenceRead[Byte])
 	do
 		var carray = new CByteArray(array.length)
 		for i in array.length.times do
@@ -142,7 +142,7 @@ end
 # An array of `unsigned char` in C (`unsigned char*`)
 extern class NativeCByteArray `{ unsigned char* `}
 	super NativeCArray
-	redef type E: Int
+	redef type E: Byte
 
 	# Allocate a new array of `size`
 	new(size: Int) `{ return calloc(size, sizeof(unsigned char)); `}

--- a/tests/sav/shootout_nsieve_bytes_alt.res
+++ b/tests/sav/shootout_nsieve_bytes_alt.res
@@ -1,0 +1,3 @@
+Primes up to 40000 4203
+Primes up to 20000 2262
+Primes up to 10000 1229

--- a/tests/shootout_nsieve_bytes_alt.nit
+++ b/tests/shootout_nsieve_bytes_alt.nit
@@ -1,7 +1,5 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2005-2008 Jean Privat <jean@pryen.org>
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import c
-
 class Bitarray
 
-	var narr: CByteArray
+	var narr: Bytes
 
 	init do
 		for x in [0 .. narr.length[ do narr[x] = 0xFFu8
@@ -43,7 +39,7 @@ fun nsieve(n: Int): Int
 do
 	var count = 0
 	var b_arrsz = ((n - 1).to_f / 8.0).ceil.to_i
-	var bitarr = new Bitarray(new CByteArray(b_arrsz))
+	var bitarr = new Bitarray(new Bytes(new NativeString(b_arrsz), b_arrsz, b_arrsz))
 	for i in [2 .. n[ do
 		# If self is already false, then no need to check for multiples
 		if not bitarr[i] then continue


### PR DESCRIPTION
The `shootout_nsieve` benchmark has been present in tests for a long time (longer than I can remember actually).

Up until now, its performances have been constant and quite good, since the work was done in less than 15ms.

However, due to its use of `FlatBuffer` and indexed access, it degenerates when using UTF-8 (see #1277) and the run time of `shootout_nsieve` scales from `0m0.011s` to `1m59.870s`.

This PR fixes that.