### PR TITLE
Improve initial make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,6 @@ $(BINS): nitc_0 parser/parser.nit
 	./git-gen-version.sh
 	test -d ../bin || mkdir ../bin
 	./nitc_0 ${NITCOPT} -v --dir ../bin $(SRCS)
-	rm -r .nit_compile || true # to clean old .nit_compile generated file
 
 $(OBJS): nitc_0 parser/parser.nit
 	./git-gen-version.sh

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 NITCOPT=--semi-global
-OLDNITCOPT=
+OLDNITCOPT=--semi-global
 OBJS=nitc nitpick nit nitdoc nitls nitunit nitpretty nitmetrics nitx nitlight nitdbg_client nitserial
 SRCS=$(patsubst %,%.nit,$(OBJS))
 BINS=$(patsubst %,../bin/%,$(OBJS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ OBJS=nitc nitpick nit nitdoc nitls nitunit nitpretty nitmetrics nitx nitlight ni
 SRCS=$(patsubst %,%.nit,$(OBJS))
 BINS=$(patsubst %,../bin/%,$(OBJS))
 
-all: $(BINS)
+all: bin/nitc
 
 nitc_0: ../c_src/nitc parser/parser.nit
 	@echo '***************************************************************'
@@ -29,7 +29,7 @@ nitc_0: ../c_src/nitc parser/parser.nit
 	./git-gen-version.sh
 	../c_src/nitc ${OLDNITCOPT} -o nitc_0 -v nitc.nit
 
-$(BINS): nitc_0 parser/parser.nit
+bin/nitc: nitc_0 parser/parser.nit
 	@echo '***************************************************************'
 	@echo '* Compile binaries from NIT source files                      *'
 	@echo '***************************************************************'


### PR DESCRIPTION
Small improvement to make the initial make better.
For the final user perspective, an useless error message is removed and the whole process should be slightly faster.

Before:

* real time with cleared ccache: 4m46s
* user time with cleared ccache: 13m23s
* real time with full ccache: 42.5s
* user time with full ccache: 41.8s

After:

* real time with cleared ccache: 4m30s (-5.6%)
* user time with cleared ccache: 13m23s (-4.6%)
* real time with full ccache: 42.5s (-27.8%)
* user time with full ccache: 41.8s (-24.63)
