### PR TITLE
Fix lib/realtime on osx

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -389,6 +389,15 @@ endif
 			makefile.write("CFLAGS += -D NO_STACKTRACE\n\n")
 		end
 
+		makefile.write """
+# Special configuration for Darwin
+ifeq ($(uname_S),Darwin)
+	# Remove POSIX flag -lrt
+	LDLIBS := $(filter-out -lrt,$(LDLIBS))
+endif
+
+"""
+
 		makefile.write("all: {outpath}\n")
 		if outpath != real_outpath then
 			makefile.write("\tcp -- {outpath.escape_to_sh} {real_outpath.escape_to_sh.replace("$","$$")}")


### PR DESCRIPTION
A lot of googling to solve two related issues on Mac OS X

* `clock_gettime` and cie is not provided, and one should use the more complex clock_get_time (and cie)
* the POSIX `-lrt` is refused by the linker

close #868