### PR TITLE
jwrapper generates full APIs, with contructors, getters and setters

### DIFF
--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -34,8 +34,27 @@ check: bin/jwrapper tests/wildcards.javap
 
 check-libs: bin/jwrapper
 	# This config dependent rule must be tweaked according to each system
-	bin/jwrapper -v -u ignore -o tests/rt.nit /usr/lib/jvm/default-java/jre/lib/rt.jar
-	bin/jwrapper -v -u ignore -o tests/java_tools.nit /usr/lib/jvm/default-java/lib/tools.jar
-	bin/jwrapper -v -u ignore -o tests/sablecc.nit ~/apps/sablecc-3-beta.3.altgen.20041114/lib/sablecc.jar
-	bin/jwrapper -v -u ignore -o tests/android.nit ~/sdks/android-sdk/platforms/android-10/android.jar
+
+	# The full local Java standard library
+	bin/jwrapper -v -u comment -o tests/rt_full.nit /usr/lib/jvm/default-java/jre/lib/rt.jar
+	echo "+ Disabled functions: `grep '#	fun' tests/rt_full.nit | wc -l` / `grep '^	fun' tests/rt_full.nit | wc -l`"
+	nitpick tests/rt_full.nit
+
+	# Only the `java` namespace of the standard library to avoid conflicts with other libs
+	bin/jwrapper -v -u comment -o tests/rt.nit /usr/lib/jvm/default-java/jre/lib/rt.jar -r ^java
+	echo "+ Disabled functions: `grep '#	fun' tests/rt.nit | wc -l` / `grep '^	fun' tests/rt.nit | wc -l`"
+	nitpick tests/rt.nit
+
+	# tools.jar, not using the standard library because of conflicts on sun.tools.jar.*
+	bin/jwrapper -v -u comment -o tests/java_tools.nit /usr/lib/jvm/default-java/lib/tools.jar -i tests/rt.nit
+	sed -i -e "s/import java/import java\nimport rt/" tests/java_tools.nit
+	echo "+ Disabled functions: `grep '#	fun' tests/java_tools.nit | wc -l` / `grep '^	fun' tests/java_tools.nit | wc -l`"
+	nitpick tests/java_tools.nit
+
+	# SableCC using the standard Java library
+	bin/jwrapper -v -u comment -o tests/sablecc.nit ~/apps/sablecc-3-beta.3.altgen.20041114/lib/sablecc.jar -i tests/rt.nit
+	sed -i -e "s/import java/import java\nimport rt/" tests/sablecc.nit
+	echo "+ Disabled functions: `grep '#	fun' tests/sablecc.nit | wc -l` / `grep '^	fun' tests/sablecc.nit | wc -l`"
+	nitpick tests/sablecc.nit
+
 	make -C examples/android_api/ check

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -30,6 +30,7 @@ check: bin/jwrapper tests/wildcards.javap
 	../../bin/nitpick -q tests/many.nit
 	bin/jwrapper -v -u comment -o tests/wildcards.nit tests/wildcards.javap
 	../../bin/nitpick -q tests/wildcards.nit
+	make -C examples/queue/ check
 
 check-libs: bin/jwrapper
 	# This config dependent rule must be tweaked according to each system

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -20,6 +20,14 @@ clean:
 
 check: bin/jwrapper tests/wildcards.javap
 	mkdir -p tmp
+	bin/jwrapper -v -u comment -o tests/long.nit tests/long.javap
+	../../bin/nitpick -q tests/long.nit
+	bin/jwrapper -v -u comment -o tests/inits.nit tests/inits.javap
+	../../bin/nitpick -q tests/inits.nit
+	bin/jwrapper -v -u comment -o tests/testjvm.nit tests/testjvm.javap
+	../../bin/nitpick -q tests/testjvm.nit
+	bin/jwrapper -v -u comment -o tests/many.nit tests/many.javap
+	../../bin/nitpick -q tests/many.nit
 	bin/jwrapper -v -u comment -o tests/wildcards.nit tests/wildcards.javap
 	../../bin/nitpick -q tests/wildcards.nit
 

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -38,3 +38,4 @@ check-libs: bin/jwrapper
 	bin/jwrapper -v -u ignore -o tests/java_tools.nit /usr/lib/jvm/default-java/lib/tools.jar
 	bin/jwrapper -v -u ignore -o tests/sablecc.nit ~/apps/sablecc-3-beta.3.altgen.20041114/lib/sablecc.jar
 	bin/jwrapper -v -u ignore -o tests/android.nit ~/sdks/android-sdk/platforms/android-10/android.jar
+	make -C examples/android_api/ check

--- a/contrib/jwrapper/examples/android_api/.gitignore
+++ b/contrib/jwrapper/examples/android_api/.gitignore
@@ -1,0 +1,3 @@
+android.nit
+std.nit
+tmp/

--- a/contrib/jwrapper/examples/android_api/Makefile
+++ b/contrib/jwrapper/examples/android_api/Makefile
@@ -1,0 +1,19 @@
+ANDROID_JAR ?= ~/sdks/android-sdk/platforms/android-10/android.jar
+
+all: android_api.nit
+
+java_api.nit:
+	mkdir -p tmp
+	../../bin/jwrapper -v -u comment -o java_api.nit -r "^java" $(ANDROID_JAR)
+
+android_api.nit: java_api.nit
+	../../bin/jwrapper -v -u comment -o android_api.nit -r "^android" -i java_api.nit $(ANDROID_JAR)
+	echo "+ Disabled functions: `grep '#	fun' $@ | wc -l` / `grep '^	fun' $@ | wc -l`"
+
+	# Insert an import between the 2 modules
+	sed -i -e "s/import java/import java\nimport java_api/" android_api.nit
+
+check: android_api.nit
+	../../../../bin/nitpick android_api.nit
+
+.PHONY: android_api.nit java_api.nit

--- a/contrib/jwrapper/examples/queue/.gitignore
+++ b/contrib/jwrapper/examples/queue/.gitignore
@@ -1,0 +1,5 @@
+Queue.class
+queue.nit
+user_test
+user_test.res
+user_test.jar

--- a/contrib/jwrapper/examples/queue/Makefile
+++ b/contrib/jwrapper/examples/queue/Makefile
@@ -1,0 +1,22 @@
+# Nit test program
+user_test: queue.nit $(shell ../../../../bin/nitls -M user_test.nit) ../../../../bin/nitc
+	CLASSPATH=`pwd` ../../../../bin/nitc user_test.nit
+
+	# Manually add our class file to the Jar for easy access
+	jar -uf user_test.jar Queue.class
+
+# Compiled Java class
+Queue.class: Queue.java
+	javac Queue.java
+
+# The Nit wrapper to the Java class
+queue.nit: Queue.class
+	../../bin/jwrapper Queue.class -o queue.nit -p "Java" -i auto
+
+# Test
+check: user_test
+	# Execute test
+	./user_test > user_test.res
+
+	# Compare the result with the expected
+	diff user_test.sav user_test.res

--- a/contrib/jwrapper/examples/queue/Queue.java
+++ b/contrib/jwrapper/examples/queue/Queue.java
@@ -1,0 +1,61 @@
+/*
+* This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+import java.util.*;
+
+public class Queue
+{
+    // function pointer
+    public native void printError( String errorMsg );
+
+    // internal list
+    private LinkedList<String> list;
+
+    public Queue()
+    {
+        list = new LinkedList<String>();
+    }
+
+    public void push( String element )
+    {
+        System.out.print( "From java, pushing " );
+        System.out.print( element );
+        System.out.print( "\n" );
+        list.addLast( element );
+    }
+
+    public String pop() // knows where is native printError
+    {
+        String element;
+
+        try
+        {
+            element = list.removeFirst();
+        }
+        catch ( NoSuchElementException e )
+        {
+            printError( "From java, empty queue." );
+            element = null;
+            throw e;
+        }
+
+        System.out.print( "From java, popping " );
+        System.out.print( element );
+        System.out.print( "\n" );
+
+        return element;
+    }
+}

--- a/contrib/jwrapper/examples/queue/user_test.nit
+++ b/contrib/jwrapper/examples/queue/user_test.nit
@@ -1,0 +1,23 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+
+var queue = new JavaQueue
+queue.push "one".to_java_string
+queue.push "two".to_java_string
+queue.push "tree".to_java_string
+print queue.pop
+print queue.pop
+print queue.pop

--- a/contrib/jwrapper/examples/queue/user_test.sav
+++ b/contrib/jwrapper/examples/queue/user_test.sav
@@ -1,0 +1,9 @@
+From java, pushing one
+From java, pushing two
+From java, pushing tree
+From java, popping one
+one
+From java, popping two
+two
+From java, popping tree
+tree

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -9,6 +9,7 @@ separator = ('.'|'/');
 brackets = '[]';
 wildcard = '?';
 compiled_from = 'Compiled from "' (Any-'"')* '"';
+dots = '...';
 
 // ---
 Parser
@@ -25,23 +26,23 @@ class_or_interface = 'class'|'interface';
 
 modifier
 	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile'|'strictfp';
-type = primitive_type brackets*;
-primitive_type
-	= 'boolean'|'byte'|'char'|'short'|'int'|'float'|'long'|'double'
-	| type_ref;
 
-type_ref
-	= full_class_name
-	| generic_identifier 'extends' type_bound
-	| wildcard;
+type = base_type brackets*;
+
+base_type
+	= {primitive:} primitive_base_type
+	| {class:} full_class_name
+	| {extends:} generic_identifier 'extends' type_bound
+	| {super:} generic_identifier 'super' type_bound
+	| {wildcard:} wildcard
+	| {void:} 'void';
+
+primitive_base_type = 'boolean'|'byte'|'char'|'short'|'int'|'float'|'long'|'double';
+
 type_bound
 	= {tail:} type_bound '&' full_class_name
 	| {head:} full_class_name;
 
-generic_param = '<' generic_parameter_list '>';
-generic_parameter_list
-	= {tail:} generic_parameter_list ',' parameter
-	| {head:} parameter;
 generic_identifier
 	= full_class_name
 	| wildcard;
@@ -49,22 +50,19 @@ generic_identifier
 full_class_name
 	= {tail:} full_class_name separator class_name
 	| {head:} class_name;
-class_name = identifier generic_param?;
+class_name = identifier generic_parameters?;
 
-parameter
-	= type '...'?
-	| {wildcard:} wildcard 'super' full_class_name ;
-parameter_list
-	= {tail:} parameter_list ',' parameter
+generic_parameters = '<' parameters '>';
+
+parameter = type dots?;
+parameters
+	= {tail:} parameters ',' parameter
 	| {head:} parameter;
 
-attribute_id = identifier brackets*;
-method_id = identifier;
-
 property_declaration
-	= {method:} modifier* generic_param? type method_id '(' parameter_list? ')' throws_declaration? ';'
-	| {constructor:} modifier* generic_param? full_class_name '(' parameter_list? ')' throws_declaration? ';'
-	| {attribute:} modifier* type attribute_id throws_declaration? ';'
+	= {method:} modifier* generic_parameters? type identifier '(' parameters? ')' throws_declaration? ';'
+	| {constructor:} modifier* generic_parameters? full_class_name '(' parameters? ')' throws_declaration? ';'
+	| {attribute:} modifier* type identifier brackets* throws_declaration? ';'
 	| {static:} modifier* '{' '}' ';'
 	| ';';
 

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -299,13 +299,6 @@ redef class String
 	fun to_nit_method_name: String
 	do
 		var name = self.to_snake_case
-		if name.has_prefix("get_") then
-			name = name.substring_from(4)
-		else if name.has_prefix("set_") then
-			name = name.substring_from(4)
-			if nit_keywords.has(name) then name += "_"
-			name += "="
-		end
 
 		# Strip the '_' prefix
 		while name.has_prefix("_") do name = name.substring(1, name.length-1)

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -152,6 +152,7 @@ class CodeGenerator
 			var nit_type = model.java_to_nit_type(jparam)
 
 			if not nit_type.is_known then comment = "#"
+			if jparam.is_primitive_array then comment = "#"
 
 			var cast = jparam.param_cast
 
@@ -187,6 +188,7 @@ class CodeGenerator
 			return_type = model.java_to_nit_type(jreturn_type)
 
 			if not return_type.is_known then comment = "#"
+			if jreturn_type.is_primitive_array then comment = "#"
 
 			nit_signature.add ": {return_type} "
 		end
@@ -217,6 +219,7 @@ class CodeGenerator
 
 		var c = ""
 		if not nit_type.is_known then c = "#"
+		if java_type.is_primitive_array then c = "#"
 
 		file_out.write """
 	# Java getter: {{{java_class}}}.{{{java_id}}}
@@ -252,6 +255,7 @@ class CodeGenerator
 				param_id = param_id.successor(1)
 
 				if not nit_type.is_known then c = "#"
+				if java_type.is_primitive_array then c = "#"
 			end
 
 			nit_params_s = "(" + nit_params.join(", ") + ")"

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -181,6 +181,7 @@ class CodeGenerator
 
 		# Method identifier
 		var method_id = nmethod_id.to_nit_method_name
+		method_id = java_class.nit_name_for(method_id, jparam_list, java_class.methods[jmethod_id].length > 1)
 		var nit_signature = new Array[String]
 
 		nit_signature.add "\tfun {method_id}"
@@ -272,6 +273,36 @@ redef class String
 
 		name = name.replace("$", "_")
 
+		return name
+	end
+end
+
+redef class JavaClass
+	# Property names used in this class
+	private var used_name = new HashSet[String]
+
+	# Get an available property name for the Java property with `name` and parameters
+	#
+	# If `use_parameters_name` then expect that there will be conflicts,
+	# so use the types of `parameters` to build the name.
+	private fun nit_name_for(name: String, parameters: Array[JavaType], use_parameters_name: Bool): String
+	do
+		# Append the name of each parameter
+		if use_parameters_name then
+			for param in parameters do
+				name += "_" + param.id
+			end
+		end
+
+		# As a last resort, append numbers to the name
+		var base_name = name
+		var count = 1
+		while used_name.has(name) do
+			name = base_name + count.to_s
+			count += 1
+		end
+
+		used_name.add name
 		return name
 	end
 end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -237,10 +237,10 @@ redef class Sys
 	#
 	# These may also be keywords in Java, but there they would be used capitalized.
 	private var nit_keywords: Array[String] = ["abort", "abstract", "and", "assert",
-		"break", "class", "continue", "do", "else", "end", "enum", "extern", "implies",
-		"import", "init", "interface", "intrude", "if", "in", "is", "isa", "for", "label",
+		"break", "class", "continue", "do", "else", "end", "enum", "extern", "false", "implies",
+		"import", "init", "interface", "intrude", "if", "in", "is", "isa", "isset", "for", "label",
 		"loop", "module", "new", "not", "null",	"nullable", "or", "package", "private",
-		"protected", "public", "return", "self", "super", "then", "type", "var", "while"]
+		"protected", "public", "return", "self", "super", "then", "true", "type", "var", "while"]
 end
 
 redef class String

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -58,11 +58,12 @@ class CodeGenerator
 
 		# All importations
 		var imports = new HashSet[String]
-		imports.add "import mnit_android\n"
+		imports.add "import java\n"
 		for jclass in model.classes do
 			for import_ in jclass.imports do imports.add "import android::{import_}\n"
 		end
 		file_out.write imports.join("\n")
+		file_out.write "\n"
 
 		for jclass in model.classes do
 

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -272,11 +272,17 @@ redef class Sys
 	# List of Nit keywords
 	#
 	# These may also be keywords in Java, but there they would be used capitalized.
-	private var nit_keywords: Array[String] = ["abort", "abstract", "and", "assert",
+	private var nit_keywords = new HashSet[String].from(["abort", "abstract", "and", "assert",
 		"break", "class", "continue", "do", "else", "end", "enum", "extern", "false", "implies",
 		"import", "init", "interface", "intrude", "if", "in", "is", "isa", "isset", "for", "label",
 		"loop", "module", "new", "not", "null",	"nullable", "or", "package", "private",
-		"protected", "public", "return", "self", "super", "then", "true", "type", "var", "while"]
+		"protected", "public", "return", "self", "super", "then", "true", "type", "var", "while",
+
+	# Top-level methods
+		"class_name", "get_time", "hash", "is_same_type", "is_same_instance", "output",
+
+	# Pointer or JavaObject methods
+		"free"])
 end
 
 redef class String

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -70,13 +70,8 @@ class CodeGenerator
 			generate_class_header(jclass.class_type)
 
 			for id, signatures in jclass.methods do
-				var c = 0
 				for signature in signatures do
-					var nid = id
-					if c > 0 then nid += c.to_s
-					c += 1
-
-					generate_method(jclass, id, nid, signature.return_type, signature.params)
+					generate_method(jclass, id, id, signature.return_type, signature.params)
 					file_out.write "\n"
 				end
 			end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -99,7 +99,7 @@ class CodeGenerator
 		end
 
 		if stub_for_unknown_types then
-			for jtype in model.unknown_types do
+			for jtype, nit_type in model.unknown_types do
 				generate_unknown_class_header(jtype)
 				file_out.write "\n"
 			end
@@ -127,7 +127,7 @@ class CodeGenerator
 
 	private fun generate_class_header(jtype: JavaType)
 	do
-		var nit_type = jtype.to_nit_type
+		var nit_type = model.java_to_nit_type(jtype)
 		file_out.write "# Java class: {jtype.to_package_name}\n"
 		file_out.write "extern class {nit_type} in \"Java\" `\{ {jtype.to_package_name} `\}\n"
 		file_out.write "\tsuper JavaObject\n\n"
@@ -154,24 +154,11 @@ class CodeGenerator
 		# Parameters
 		for i in [0..jparam_list.length[ do
 			var jparam = jparam_list[i]
-			var nit_type = jparam.to_nit_type
+			var nit_type = model.java_to_nit_type(jparam)
 
-			if not nit_type.is_complete then
-				if jparam.is_wrapped then
-					java_class.imports.add nit_type.mod.as(not null)
-				else
-					model.unknown_types.add jparam
-					if comment_unknown_types then
-						comment = "#"
-					else
-						nit_type = jparam.extern_name
-					end
-				end
-			end
+			if not nit_type.is_known then comment = "#"
 
-			var cast = ""
-
-			if not jparam.is_collection then cast = jparam.param_cast
+			var cast = jparam.param_cast
 
 			nit_types.add(nit_type)
 
@@ -201,22 +188,10 @@ class CodeGenerator
 		end
 
 		var return_type = null
-
 		if not jreturn_type.is_void then
-			return_type = jreturn_type.to_nit_type
+			return_type = model.java_to_nit_type(jreturn_type)
 
-			if not return_type.is_complete then
-				if jreturn_type.is_wrapped then
-					java_class.imports.add return_type.mod.as(not null)
-				else
-					model.unknown_types.add jreturn_type
-					if comment_unknown_types then
-						comment = "#"
-					else
-						return_type = jreturn_type.extern_name
-					end
-				end
-			end
+			if not return_type.is_known then comment = "#"
 
 			nit_signature.add ": {return_type} "
 		end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -122,12 +122,7 @@ class CodeGenerator
 
 	fun gen_unknown_class_header(jtype: JavaType): String
 	do
-		var nit_type: NitType
-		if jtype.extern_name.has_generic_params then
-			nit_type = jtype.extern_name.generic_params.first
-		else
-			nit_type = jtype.extern_name
-		end
+		var nit_type = jtype.extern_name
 
 		var temp = new Array[String]
 		temp.add("extern class {nit_type} in \"Java\" `\{ {jtype.to_package_name} `\}\n")

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -80,6 +80,12 @@ class CodeGenerator
 					file_out.write "\n"
 				end
 			end
+
+			# Attributes
+			for id, java_type in jclass.attributes do
+				generate_getter_setter(jclass, id, java_type)
+			end
+
 			file_out.write "end\n\n"
 		end
 
@@ -230,6 +236,30 @@ class CodeGenerator
 		end
 
 		return temp.join
+	end
+
+	# Generate getter and setter to access an attribute, of field
+	private fun generate_getter_setter(java_class: JavaClass, java_id: String, java_type: JavaType)
+	do
+		var nit_type = model.java_to_nit_type(java_type)
+		var nit_id = java_id.to_nit_method_name
+		nit_id = java_class.nit_name_for(nit_id, [java_type], false)
+
+		var c = ""
+		if not nit_type.is_known then c = "#"
+
+		file_out.write """
+	# Java getter: {{{java_class}}}.{{{java_id}}}
+{{{c}}}	fun {{{nit_id}}}: {{{nit_type}}} in "Java" `{
+{{{c}}}		return self.{{{java_id}}};
+{{{c}}}	`}
+
+	# Java setter: {{{java_class}}}.{{{java_id}}}
+{{{c}}}	fun {{{nit_id}}}=(value: {{{nit_type}}}) in "Java" `{
+{{{c}}}		self.{{{java_id}}} = value;
+{{{c}}}	`}
+
+"""
 	end
 end
 

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -168,7 +168,6 @@ class CodeGenerator
 			if not jparam.is_collection then cast = jparam.param_cast
 
 			nit_types.add(nit_type)
-			nit_type.arg_id = "{nit_id}{nit_id_no}"
 
 			if i == jparam_list.length - 1 then
 				java_params += "{cast}{nit_id}{nit_id_no}"

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -151,7 +151,7 @@ class CodeGenerator
 			var jparam = jparam_list[i]
 			var nit_type = model.java_to_nit_type(jparam)
 
-			if not nit_type.is_known then comment = "#"
+			if not nit_type.is_known and comment_unknown_types then comment = "#"
 			if jparam.is_primitive_array then comment = "#"
 
 			var cast = jparam.param_cast
@@ -187,7 +187,7 @@ class CodeGenerator
 		if not jreturn_type.is_void then
 			return_type = model.java_to_nit_type(jreturn_type)
 
-			if not return_type.is_known then comment = "#"
+			if not return_type.is_known and comment_unknown_types then comment = "#"
 			if jreturn_type.is_primitive_array then comment = "#"
 
 			nit_signature.add ": {return_type} "
@@ -218,7 +218,7 @@ class CodeGenerator
 		nit_id = java_class.nit_name_for(nit_id, [java_type], false)
 
 		var c = ""
-		if not nit_type.is_known then c = "#"
+		if not nit_type.is_known and comment_unknown_types then c = "#"
 		if java_type.is_primitive_array then c = "#"
 
 		file_out.write """
@@ -254,7 +254,7 @@ class CodeGenerator
 				nit_params.add  "{param_id}: {nit_type}"
 				param_id = param_id.successor(1)
 
-				if not nit_type.is_known then c = "#"
+				if not nit_type.is_known and comment_unknown_types then c = "#"
 				if java_type.is_primitive_array then c = "#"
 			end
 

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -59,13 +59,13 @@ class CodeGenerator
 		# All importations
 		var imports = new HashSet[String]
 		imports.add "import java\n"
-		for jclass in model.classes do
+		for key, jclass in model.classes do
 			for import_ in jclass.imports do imports.add "import android::{import_}\n"
 		end
 		file_out.write imports.join("\n")
 		file_out.write "\n"
 
-		for jclass in model.classes do
+		for key, jclass in model.classes do
 
 			file_out.write gen_class_header(jclass.class_type)
 

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -28,8 +28,6 @@ intrude import model
 class JavaVisitor
 	super Visitor
 
-	var converter: JavaTypeConverter
-
 	# Model of all the analyzed classes
 	var model: JavaModel
 
@@ -40,7 +38,7 @@ class JavaVisitor
 	var class_type: JavaType is noinit
 
 	var variable_id = ""
-	var variable_type = new JavaType(self.converter) is lazy
+	var variable_type = new JavaType is lazy
 
 	var is_generic_param = false
 	var is_generic_id = false
@@ -53,7 +51,7 @@ class JavaVisitor
 	var is_primitive_array = false
 
 	var method_id = ""
-	var method_return_type = new JavaType(self.converter) is lazy
+	var method_return_type = new JavaType is lazy
 	var method_params = new Array[JavaType]
 	var param_index = 0
 
@@ -223,7 +221,7 @@ redef class Nclass_declaration
 	do
 		v.java_class = new JavaClass
 		v.model.classes.add v.java_class
-		v.class_type = new JavaType(v.converter)
+		v.class_type = new JavaType
 
 		v.declaration_type = "class_header"
 		v.declaration_element = "id"
@@ -277,7 +275,7 @@ redef class Nproperty_declaration_method
 
 		v.method_params.clear
 		v.method_id = ""
-		v.method_return_type = new JavaType(v.converter)
+		v.method_return_type = new JavaType
 	end
 end
 
@@ -302,7 +300,7 @@ redef class Nproperty_declaration_attribute
 		v.java_class.attributes[v.variable_id] = v.variable_type
 
 		v.variable_id = ""
-		v.variable_type = new JavaType(v.converter)
+		v.variable_type = new JavaType
 	end
 end
 
@@ -423,13 +421,13 @@ redef class Nparameter
 		if v.declaration_type == "method" then
 			if v.declaration_element == "parameter_list" then
 				if v.is_generic_param then
-					v.method_params[v.param_index].generic_params.add(new JavaType(v.converter))
+					v.method_params[v.param_index].generic_params.add new JavaType
 
 					super
 
 					v.gen_params_index += 1
 				else
-					v.method_params.add(new JavaType(v.converter))
+					v.method_params.add new JavaType
 
 					super
 
@@ -437,7 +435,7 @@ redef class Nparameter
 				end
 			else if v.declaration_element == "return_type" and v.is_generic_param then
 
-				v.method_return_type.generic_params.add(new JavaType(v.converter))
+				v.method_return_type.generic_params.add new JavaType
 
 				super
 
@@ -449,7 +447,7 @@ redef class Nparameter
 			end
 		else if v.declaration_type == "variable" then
 			if v.declaration_element == "type" and v.is_generic_param then
-				v.variable_type.generic_params.add(new JavaType(v.converter))
+				v.variable_type.generic_params.add new JavaType
 
 				super
 

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -50,7 +50,7 @@ redef class Nclass_declaration
 		var jtype = n_full_class_name.to_java_type
 
 		v.java_class = new JavaClass(jtype)
-		v.model.classes.add v.java_class
+		v.model.add_class v.java_class
 
 		# Visit all properties
 		super

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -99,7 +99,15 @@ end
 redef class Nproperty_declaration_constructor
 	redef fun accept_visitor(v)
 	do
-		# TODO
+		# Collect parameters
+		var n_parameters = n_parameters
+		var params
+		if n_parameters != null then
+			params = n_parameters.to_a
+		else params = new Array[JavaType]
+
+		var method = new JavaConstructor(params)
+		v.java_class.constructors.add method
 	end
 end
 

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -31,207 +31,29 @@ class JavaVisitor
 	# Model of all the analyzed classes
 	var model: JavaModel
 
+	# Java class in construction
 	var java_class: JavaClass is noinit
 
-	var declaration_type: nullable String =  null
-	var declaration_element: nullable String = null
-	var class_type: JavaType is noinit
-
-	var variable_id = ""
-	var variable_type = new JavaType is lazy
-
-	var is_generic_param = false
-	var is_generic_id = false
-	var generic_id = ""
-	var gen_params_index = 0
-
-	# Used to resolve generic return types (T -> foo.faz.Bar)
-	var generic_map = new HashMap[String, Array[String]]
-
-	var is_primitive_array = false
-
-	var method_id = ""
-	var method_return_type = new JavaType is lazy
-	var method_params = new Array[JavaType]
-	var param_index = 0
-
 	redef fun visit(n) do n.accept_visitor(self)
-
-	# Add the identifier from `token` to the current context
-	fun add_identifier(token: String)
-	do
-		if declaration_type == "variable" then
-			if declaration_element == "type" then
-				if is_generic_param then
-					variable_type.generic_params[gen_params_index].identifier.add token
-				else
-					variable_type.identifier.add(token)
-				end
-			end
-		else if declaration_type == "method" then
-			if declaration_element == "return_type" then
-				if is_generic_param then
-					method_return_type.generic_params[gen_params_index].identifier.add token
-				else
-					method_return_type.identifier.add(token)
-				end
-			else if declaration_element == "parameter_list" then
-				if is_generic_param then
-					method_params[param_index].generic_params[gen_params_index].identifier.add token
-				else
-					method_params[param_index].identifier.add(token)
-				end
-			end
-		end
-	end
 end
 
 redef class Node
-	fun accept_visitor(v: JavaVisitor) do visit_children(v)
+	private fun accept_visitor(v: JavaVisitor) do visit_children(v)
 end
 
-redef class Nidentifier
-	redef fun accept_visitor(v)
-	do
-		if v.declaration_type == "class_header" then
-			# Class declaration
-			if v.declaration_element == "id" then
-				v.class_type.identifier.add text
-				return
-			end
-
-		else if v.declaration_type == "variable" then
-			# Attribute declaration
-			if v.declaration_element == "id" then
-				v.variable_id += text
-				return
-			end
-
-		else if v.declaration_type == "method" then
-
-			if v.declaration_element == "id" then
-				# Method id
-				v.method_id = self.text
-				return
-			else if v.declaration_element == "return_type" then
-				if self.text == "void" then
-					# void return type
-					v.method_return_type.is_void = true
-					return
-				end
-			else if v.declaration_element == "parameter_list" then
-				# Parameters, leave it to add_identifier
-
-			else if v.is_generic_param then
-				# Creates a map to resolve generic return types
-				# Example : public **<T extends android/os/Bundle>** T foo();
-				if v.is_generic_id then
-					v.generic_id = self.text
-					v.generic_map[self.text] = new Array[String]
-
-					if not v.method_return_type.has_unresolved_types then v.method_return_type.has_unresolved_types = true
-				else
-					v.generic_map[v.generic_id].add text
-				end
-			end
-		end
-
-		v.add_identifier text
-	end
-end
-
-# Primitive array node
-redef class Nbrackets
-	redef fun accept_visitor(v)
-	do
-		if v.declaration_type == "variable" then
-			if v.declaration_element == "type" then
-				if v.is_generic_param then
-					v.variable_type.generic_params[v.gen_params_index].array_dimension += 1
-				else
-					v.variable_type.array_dimension += 1
-				end
-			end
-
-		else if v.declaration_type == "method" then
-
-			if v.declaration_element == "return_type" then
-				if v.is_generic_param then
-					v.method_return_type.generic_params[v.gen_params_index].array_dimension += 1
-				else
-					v.method_return_type.array_dimension += 1
-				end
-			else if v.declaration_element == "parameter_list" then
-				if v.is_generic_param then
-					v.method_params[v.param_index].generic_params[v.gen_params_index].array_dimension += 1
-				else
-					v.method_params[v.param_index].array_dimension += 1
-				end
-			end
-
-		end
-
-		super
-	end
-end
-
-redef class N_39dchar_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dboolean_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dfloat_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39ddouble_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dbyte_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dshort_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dint_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class N_39dlong_39d
-	redef fun accept_visitor(v) do v.add_identifier text
-end
-
-redef class Nwildcard
-	# TODO use the lower bound
-	redef fun accept_visitor(v) do v.add_identifier "Object"
-end
-
-#                                  #
-#    C L A S S     H E A D E R     #
-#                                  #
+# ---
+# Class Header
 
 redef class Nclass_declaration
 	redef fun accept_visitor(v)
 	do
-		v.java_class = new JavaClass
+		var jtype = n_full_class_name.to_java_type
+
+		v.java_class = new JavaClass(jtype)
 		v.model.classes.add v.java_class
-		v.class_type = new JavaType
 
-		v.declaration_type = "class_header"
-		v.declaration_element = "id"
+		# Visit all properties
 		super
-
-		# Exit class declaration
-		v.declaration_type = null
-		v.declaration_element = null
-
-		v.java_class.class_type = v.class_type
 	end
 end
 
@@ -239,9 +61,7 @@ end
 redef class Nextends_declaration
 	redef fun accept_visitor(v)
 	do
-		v.declaration_element = "extends"
-		super
-		v.declaration_element = null
+		# TODO
 	end
 end
 
@@ -249,33 +69,29 @@ end
 redef class Nimplements_declaration
 	redef fun accept_visitor(v)
 	do
-		v.declaration_element = "implements"
-		super
-		v.declaration_element = null
+		# TODO
 	end
 end
 
-#                                            #
-# P R O P E R T Y    D E C L A R A T I O N S #
-#                                            #
+# ---
+# Properties
 
 # Method declaration
 redef class Nproperty_declaration_method
 	redef fun accept_visitor(v)
 	do
-		v.declaration_type = "method"
-		v.declaration_element = null
-		super
-		v.declaration_type = null
+		var id = n_identifier.text
+		var return_jtype = n_type.to_java_type
 
-		if v.method_return_type.has_unresolved_types then v.method_return_type.resolve_types(v.generic_map)
+		# Collect parameters
+		var n_parameters = n_parameters
+		var params
+		if n_parameters != null then
+			params = n_parameters.to_a
+		else params = new Array[JavaType]
 
-		var method = new JavaMethod(v.method_return_type, v.method_params.clone)
-		v.java_class.methods[v.method_id].add method
-
-		v.method_params.clear
-		v.method_id = ""
-		v.method_return_type = new JavaType
+		var method = new JavaMethod(return_jtype, params)
+		v.java_class.methods[id].add method
 	end
 end
 
@@ -283,9 +99,7 @@ end
 redef class Nproperty_declaration_constructor
 	redef fun accept_visitor(v)
 	do
-		v.declaration_type = "constructor"
-		super
-		v.declaration_type = null
+		# TODO
 	end
 end
 
@@ -293,14 +107,14 @@ end
 redef class Nproperty_declaration_attribute
 	redef fun accept_visitor(v)
 	do
-		v.declaration_type = "variable"
-		super
-		v.declaration_type = null
+		var id = n_identifier.text
+		var jtype = n_type.to_java_type
 
-		v.java_class.attributes[v.variable_id] = v.variable_type
+		# Manually count the array depth as it is after the id
+		var brackets = n_brackets
+		if brackets != null then jtype.array_dimension += brackets.children.length
 
-		v.variable_id = ""
-		v.variable_type = new JavaType
+		v.java_class.attributes[id] = jtype
 	end
 end
 
@@ -308,153 +122,130 @@ end
 redef class Nproperty_declaration_static
 	redef fun accept_visitor(v)
 	do
-		v.declaration_type = "static"
-		super
-		v.declaration_type = null
+		# TODO
 	end
 end
 
-# Identifier of a variable
-redef class Nattribute_id
-	redef fun accept_visitor(v)
-	do
-		v.declaration_element = "id"
-		super
-		v.declaration_element = null
-	end
-end
-
-# Identifier of the method
-redef class Nmethod_id
-	redef fun accept_visitor(v)
-	do
-		v.declaration_element = "id"
-		super
-		v.declaration_element = null
-	end
-end
+# ---
+# Services
 
 redef class Ntype
-	redef fun accept_visitor(v)
+	private fun to_java_type: JavaType
 	do
-		if v.declaration_type == "variable" and v.declaration_element != "id" then
-			v.declaration_element = "type"
-		end
+		var jtype = n_base_type.to_java_type
 
-		if v.declaration_type == "method" and v.declaration_element == null then
-			# Makes sure it is not the generic return type definition
-			if not (v.method_return_type.identifier.is_empty and v.is_generic_param) then
-				v.declaration_element = "return_type"
-			end
-		end
+		var brackets = n_brackets
+		if brackets != null then jtype.array_dimension += brackets.children.length
 
-		super
-
-		if v.declaration_element == "variable" then
-			v.declaration_element = null
-		end
+		return jtype
 	end
 end
 
-redef class Ngeneric_param
-	redef fun accept_visitor(v)
+redef class Nbase_type
+	private fun to_java_type: JavaType
 	do
-		# Ignore the weird generic return type declaration
-		if v.declaration_type == "method" then
-			if v.declaration_element == null then
-				v.is_generic_param = true
-			else
-				v.is_generic_param = true
-				v.gen_params_index = 0
-
-				if v.declaration_element == "return_type" then
-					v.method_return_type.generic_params = new Array[JavaType]
-				else if v.declaration_element == "parameter_list" then
-					v.method_params[v.param_index].generic_params = new Array[JavaType]
-				end
-			end
-		else if v.declaration_type == "variable" then
-			if v.declaration_element == "type" then
-				v.is_generic_param = true
-				v.gen_params_index = 0
-				v.variable_type.generic_params = new Array[JavaType]
-			end
-		end
-
-		super
-
-		v.declaration_element = null
-		v.is_generic_param = false
+		# By default, everything is bound by object
+		# TODO use a more precise bound
+		var jtype = new JavaType
+		jtype.identifier.add_all(["java", "lang", "object"])
+		return jtype
 	end
 end
 
-redef class Ngeneric_identifier
-	redef fun accept_visitor(v)
+redef class Nbase_type_class
+	redef fun to_java_type do return n_full_class_name.to_java_type
+end
+
+redef class Nbase_type_primitive
+	redef fun to_java_type
 	do
-		if v.declaration_type == "method" then
-			if v.declaration_element == null then
-				v.is_generic_id = true
-			end
+		# All the concrete nodes under this production are tokens
+		for node in depth do
+			if not node isa NToken then continue
+
+			var jtype = new JavaType
+			jtype.identifier.add node.text
+			return jtype
 		end
 
-		super
-
-		v.is_generic_id = false
-
+		abort
 	end
 end
 
-redef class Nparameter_list
-	redef fun accept_visitor(v)
+redef class Nbase_type_void
+	redef fun to_java_type
 	do
-		v.declaration_element = "parameter_list"
-		v.param_index = 0
-		super
-		v.declaration_element = null
-		v.param_index = 0
+		var jtype = new JavaType
+		jtype.is_void = true
+		return jtype
+	end
+end
+
+redef class Nfull_class_name
+	# All the identifiers composing this class name
+	private fun to_a: Array[String] is abstract
+
+	# Access `n_class_name` on both alternatives
+	private fun n_class_name_common: Nclass_name is abstract
+
+	private fun to_java_type: JavaType
+	do
+		var jtype = new JavaType
+		jtype.identifier = to_a
+
+		# Generic parameters
+		var n_params = n_class_name_common.n_generic_parameters
+		if n_params != null then jtype.generic_params = n_params.n_parameters.to_a
+
+		return jtype
+	end
+end
+
+redef class Nfull_class_name_head
+	redef fun n_class_name_common do return n_class_name
+
+	redef fun to_a do return [n_class_name.n_identifier.text]
+end
+
+redef class Nfull_class_name_tail
+	redef fun n_class_name_common do return n_class_name
+
+	redef fun to_a
+	do
+		var a = n_full_class_name.to_a
+		a.add n_class_name.n_identifier.text
+		return a
+	end
+end
+
+redef class Nparameters
+	# Get the types composing this list of parameters
+	#
+	# This is used both on methods signatures and type parameters.
+	private fun to_a: Array[JavaType] is abstract
+end
+
+redef class Nparameters_head
+	redef fun to_a do return [n_parameter.to_java_type]
+end
+
+redef class Nparameters_tail
+	redef fun to_a
+	do
+		var a = n_parameters.to_a
+		a.add n_parameter.to_java_type
+		return a
 	end
 end
 
 redef class Nparameter
-	redef fun accept_visitor(v)
+	private fun to_java_type: JavaType
 	do
-		if v.declaration_type == "method" then
-			if v.declaration_element == "parameter_list" then
-				if v.is_generic_param then
-					v.method_params[v.param_index].generic_params.add new JavaType
+		var jtype = n_type.to_java_type
 
-					super
+		var dots = n_dots
+		if dots != null then jtype.is_vararg = true
 
-					v.gen_params_index += 1
-				else
-					v.method_params.add new JavaType
-
-					super
-
-					v.param_index += 1
-				end
-			else if v.declaration_element == "return_type" and v.is_generic_param then
-
-				v.method_return_type.generic_params.add new JavaType
-
-				super
-
-				v.gen_params_index += 1
-
-			# For generic return type definition
-			else if v.declaration_element == null then
-				super
-			end
-		else if v.declaration_type == "variable" then
-			if v.declaration_element == "type" and v.is_generic_param then
-				v.variable_type.generic_params.add new JavaType
-
-				super
-
-				v.gen_params_index += 1
-			end
-		else
-			super
-		end
+		return jtype
 	end
 end

--- a/contrib/jwrapper/src/jtype_converter.nit
+++ b/contrib/jwrapper/src/jtype_converter.nit
@@ -17,6 +17,11 @@
 # Services to convert java type to nit type and get casts if needed
 module jtype_converter
 
+redef class Sys
+	# Converter between Java and Nit type
+	var converter = new JavaTypeConverter
+end
+
 class JavaTypeConverter
 
 	var type_map = new HashMap[String, String]

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -44,7 +44,7 @@ var opt_output = new OptionString("Output file", "-o")
 var opt_regex = new OptionString("Regex pattern to filter classes in Jar archives", "-r")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -172,7 +172,7 @@ sys.perfs["core parser"].add clock.lapse
 # Build model
 if opt_verbose.value > 0 then print "# Building model"
 assert root_node isa NStart
-var visitor = new JavaVisitor(converter, model)
+var visitor = new JavaVisitor(model)
 visitor.enter_visit root_node
 sys.perfs["core model"].add clock.lapse
 

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -44,7 +44,7 @@ var opt_output = new OptionString("Output file", "-o")
 var opt_regex = new OptionString("Regex pattern to filter classes in Jar archives", "-r")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_regex, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -43,7 +43,7 @@ var opt_verbose = new OptionCount("Verbosity", "-v")
 var opt_output = new OptionString("Output file", "-o")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -19,6 +19,7 @@
 module model
 
 import more_collections
+import opts
 
 import jtype_converter
 
@@ -297,4 +298,10 @@ redef class Sys
 
 		return map
 	end
+
+	# Option to set `extern_class_prefix`
+	var opt_extern_class_prefix = new OptionString("Prefix to extern classes (By default uses the full namespace)", "-p")
+
+	# Prefix used to name extern classes, if `null` use the full namespace
+	var extern_class_prefix: nullable String is lazy do return opt_extern_class_prefix.value
 end

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -56,10 +56,6 @@ class JavaType
 		return converter.cast_as_param(self.id)
 	end
 
-	fun is_collection: Bool do return is_primitive_array or collections_list.has(self.id)
-
-	fun is_wrapped: Bool do return find_extern_class[full_id] != null
-
 	# Name to give an extern class wrapping this type
 	fun extern_name: String
 	do
@@ -87,15 +83,6 @@ class JavaType
 		name = name.replace("-", "_")
 		name = name.replace("$", "_")
 		return name
-	end
-
-	fun to_cast(jtype: String, is_param: Bool): String
-	do
-		if is_param then
-			return converter.cast_as_param(jtype)
-		end
-
-		return converter.cast_as_return(jtype)
 	end
 
 	redef fun to_s
@@ -139,10 +126,6 @@ class JavaType
 	redef fun ==(other) do return other isa JavaType and self.full_id == other.full_id
 
 	redef fun hash do return self.full_id.hash
-
-	var collections_list: Array[String] is lazy do return ["List", "ArrayList", "LinkedList", "Vector", "Set", "SortedSet", "HashSet", "TreeSet", "LinkedHashSet", "Map", "SortedMap", "HashMap", "TreeMap", "Hashtable", "LinkedHashMap"]
-	var iterable: Array[String] is lazy do return ["ArrayList", "Set", "HashSet", "LinkedHashSet", "LinkedList", "Stack", "TreeSet", "Vector"]
-	var maps: Array[String] is lazy do return ["Map", "SortedMap", "HashMap", "TreeMap", "Hashtable", "LinkedHashMap"]
 end
 
 class NitType

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -232,7 +232,6 @@ end
 
 class NitType
 	var identifier: String
-	var arg_id: String
 	var generic_params: nullable Array[NitType] = null
 
 	# If this NitType was found in `lib/android`, contains the module name to import

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -25,7 +25,12 @@ import jtype_converter
 class JavaType
 	var identifier = new Array[String]
 	var generic_params: nullable Array[JavaType] = null
+
+	# Is this a void return type?
 	var is_void = false
+
+	# Is this type a vararg?
+	var is_vararg = false is writable
 
 	# Has some generic type to be resolved (T extends foo => T is resolved to foo)
 	var has_unresolved_types = false
@@ -211,7 +216,7 @@ end
 # Model of a single Java class
 class JavaClass
 	# Type of this class
-	var class_type = new JavaType
+	var class_type: JavaType
 
 	# Attributes of this class
 	var attributes = new HashMap[String, JavaType]

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -280,7 +280,7 @@ redef class Sys
 		if lib_paths.is_empty then return map
 
 		# Use grep to find all extern classes implemented in Java
-		var grep_regex = "extern class [a-zA-Z0-9]\\\+[ ]\\\+in[ ]\\\+\"Java\""
+		var grep_regex = "extern class [a-zA-Z0-9_]\\\+[ ]\\\+in[ ]\\\+\"Java\""
 		var grep_args = ["-r", "--with-filename", grep_regex]
 		grep_args.add_all lib_paths
 
@@ -290,7 +290,7 @@ redef class Sys
 		grep.wait
 
 		# Sort out the modules, Nit class names and Java types
-		var regex = """(.+):\\s*extern +class +([a-zA-Z0-9]+) *in *"Java" *`\\{ *([a-zA-Z0-9.$/]+) *`\\}""".to_re
+		var regex = """(.+):\\s*extern +class +([a-zA-Z0-9_]+) *in *"Java" *`\\{ *([a-zA-Z0-9.$/]+) *`\\}""".to_re
 		for line in lines do
 			var matches = line.search_all(regex)
 			for match in matches do

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -236,7 +236,14 @@ class JavaModel
 	var unknown_types = new HashSet[JavaType]
 
 	# All analyzed classes
-	var classes = new Array[JavaClass]
+	var classes = new HashMap[String, JavaClass]
+
+	# Add a class in `classes`
+	fun add_class(jclass: JavaClass)
+	do
+		var key = jclass.class_type.full_id
+		classes[key] = jclass
+	end
 end
 
 # A Java method, with its signature

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -23,7 +23,6 @@ import more_collections
 import jtype_converter
 
 class JavaType
-	private var converter: JavaTypeConverter
 	var identifier = new Array[String]
 	var generic_params: nullable Array[JavaType] = null
 	var is_void = false
@@ -39,8 +38,6 @@ class JavaType
 	fun has_generic_params: Bool do return not generic_params == null
 	fun full_id: String do return identifier.join(".")
 	fun id: String do return identifier.last.replace("$", "")
-
-	init(converter: JavaTypeConverter) do self.converter = converter
 
 	fun return_cast: String do return converter.cast_as_return(self.id)
 
@@ -287,7 +284,7 @@ end
 # Model of a single Java class
 class JavaClass
 	# Type of this class
-	var class_type = new JavaType(new JavaTypeConverter)
+	var class_type = new JavaType
 
 	# Attributes of this class
 	var attributes = new HashMap[String, JavaType]

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -87,7 +87,7 @@ class JavaType
 
 	fun extern_name: NitType
 	do
-		if is_wrapped then return new NitType.with_module(find_extern_class.as(not null).first, find_extern_class.as(not null).second)
+		if is_wrapped then return new NitType(find_extern_class.as(not null).first, find_extern_class.as(not null).second)
 
 		var name
 		if is_primitive_array then
@@ -231,6 +231,7 @@ class JavaType
 end
 
 class NitType
+	# Nit class name
 	var identifier: String
 	var generic_params: nullable Array[NitType] = null
 
@@ -242,25 +243,6 @@ class NitType
 
 	fun has_generic_params: Bool do return not generic_params == null
 
-	fun id: String do return identifier
-
-	init (id: String)
-	do
-		self.identifier = id
-	end
-
-	init with_generic_params(id: String, gen_params: String...)
-	do
-		self.init(id)
-		self.generic_params = new Array[NitType]
-		for param in gen_params do self.generic_params.add new NitType(param)
-	end
-
-	init with_module(id: String, mod: NitModule)
-	do
-		self.init(id)
-		self.mod = mod
-	end
 
 	redef fun to_s: String
 	do

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -192,6 +192,9 @@ class JavaClass
 	# Methods of this class organized by their name
 	var methods = new MultiHashMap[String, JavaMethod]
 
+	# Constructors of this class
+	var constructors = new Array[JavaConstructor]
+
 	# Importations from this class
 	var imports = new HashSet[NitModule]
 
@@ -220,6 +223,12 @@ class JavaMethod
 	var return_type: JavaType
 
 	# Type of the arguments of the method
+	var params: Array[JavaType]
+end
+
+# A Java method, with its signature
+class JavaConstructor
+	# Type of the parameters of this constructor
 	var params: Array[JavaType]
 end
 

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -66,18 +66,6 @@ class JavaType
 			nit_type = new NitType(type_id)
 		end
 
-		if not self.has_generic_params then return nit_type
-
-		nit_type.generic_params = new Array[NitType]
-
-		for param in generic_params do
-			var nit_param = param.to_nit_type
-
-			nit_type.generic_params.add(nit_param)
-
-			if not nit_param.is_complete then nit_type.is_complete = false
-		end
-
 		return nit_type
 	end
 
@@ -198,32 +186,9 @@ class JavaType
 
 	# Comparison based on fully qualified named and generic params
 	# Ignores primitive array so `a.b.c[][] == a.b.c`
-	redef fun ==(other)
-	do
-		if other isa JavaType then
-			return self.repr == other.repr
-		end
-		return false
-	end
+	redef fun ==(other) do return other isa JavaType and self.full_id == other.full_id
 
-	redef fun hash do return self.repr.hash
-
-	private fun repr: String
-	do
-		var id = self.full_id
-
-		if self.has_generic_params then
-			var gen_list = new Array[String]
-
-			for param in generic_params do
-				gen_list.add(param.to_s)
-			end
-
-			id += "<{gen_list.join(", ")}>"
-		end
-
-		return id
-	end
+	redef fun hash do return self.full_id.hash
 
 	var collections_list: Array[String] is lazy do return ["List", "ArrayList", "LinkedList", "Vector", "Set", "SortedSet", "HashSet", "TreeSet", "LinkedHashSet", "Map", "SortedMap", "HashMap", "TreeMap", "Hashtable", "LinkedHashMap"]
 	var iterable: Array[String] is lazy do return ["ArrayList", "Set", "HashSet", "LinkedHashSet", "LinkedList", "Stack", "TreeSet", "Vector"]
@@ -233,7 +198,6 @@ end
 class NitType
 	# Nit class name
 	var identifier: String
-	var generic_params: nullable Array[NitType] = null
 
 	# If this NitType was found in `lib/android`, contains the module name to import
 	var mod: nullable NitModule
@@ -241,25 +205,7 @@ class NitType
 	# Returns `true` if all types have been successfully converted to Nit type
 	var is_complete: Bool = true
 
-	fun has_generic_params: Bool do return not generic_params == null
-
-
-	redef fun to_s: String
-	do
-		var id = self.identifier
-
-		if self.has_generic_params then
-			var gen_list = new Array[String]
-
-			for param in generic_params do
-				gen_list.add(param.to_s)
-			end
-
-			id += "[{gen_list.join(", ")}]"
-		end
-
-		return id
-	end
+	redef fun to_s do return identifier
 end
 
 # Model of a single Java class

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -121,9 +121,10 @@ class JavaType
 		end
 	end
 
-	# Comparison based on fully qualified named and generic params
-	# Ignores primitive array so `a.b.c[][] == a.b.c`
-	redef fun ==(other) do return other isa JavaType and self.full_id == other.full_id
+	# Comparison based on fully qualified named
+	redef fun ==(other) do return other isa JavaType and
+		self.full_id == other.full_id and
+		self.is_primitive_array == other.is_primitive_array
 
 	redef fun hash do return self.full_id.hash
 end

--- a/contrib/jwrapper/tests/inits.javap
+++ b/contrib/jwrapper/tests/inits.javap
@@ -1,0 +1,5 @@
+public class org.example.ClassA {
+	public org.example.ClassA();
+	public org.example.ClassA(long);
+	public org.example.ClassA(java.lang.Object);
+}

--- a/contrib/jwrapper/tests/long.javap
+++ b/contrib/jwrapper/tests/long.javap
@@ -1,0 +1,3 @@
+
+class com.sun.xml.internal.bind.v2.model.impl.RuntimeElementInfoImpl$RuntimePropertyImpl extends com.sun.xml.internal.bind.v2.model.impl.ElementInfoImpl<java.lang.reflect.Type, java.lang.Class, java.lang.reflect.Field, java.lang.reflect.Method>.PropertyImpl implements com.sun.xml.internal.bind.v2.model.runtime.RuntimeElementPropertyInfo, com.sun.xml.internal.bind.v2.model.runtime.RuntimeTypeRef {
+}

--- a/contrib/jwrapper/tests/many.javap
+++ b/contrib/jwrapper/tests/many.javap
@@ -1,0 +1,8 @@
+public class org.example.ClassA {
+	public org.example.ClassB Foo(org.example.ClassC);
+	public org.example.ClassB Bar(org.example.ClassC);
+	public org.example.ClassB an_attribute;
+}
+public class org.example.ClassB extends org.example.ClassA {
+	public org.example.ClassA Foo(org.example.ClassC);
+}

--- a/contrib/jwrapper/tests/testjvm.javap
+++ b/contrib/jwrapper/tests/testjvm.javap
@@ -1,0 +1,9 @@
+Compiled from "TestJvm.java"
+public class test_jvm.TestJvm {
+  public test_jvm.TestJvm();
+  public test_jvm.Test2 getTest();
+  public boolean isBool();
+  public char getC();
+  public int getI();
+  public float getF();
+}

--- a/lib/java/java.nit
+++ b/lib/java/java.nit
@@ -104,7 +104,7 @@ extern class JavaString in "Java" `{ java.lang.String `}
 		JNIEnv *env = Sys_jni_env(sys);
 
 		// Get the data from Java
-		const jbyte *java_cstr = (char*)(*env)->GetStringUTFChars(env, self, NULL);
+		const char *java_cstr = (*env)->GetStringUTFChars(env, self, NULL);
 		jsize len = (*env)->GetStringUTFLength(env, self);
 
 		// Copy it in control of Nit

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -457,7 +457,7 @@ redef class MType
 	# JNI type name (in C)
 	#
 	# So this is a C type, usually defined in `jni.h`
-	private fun jni_type: String do return "jint"
+	private fun jni_type: String do return "long"
 
 	# JNI short type name (for signatures)
 	#


### PR DESCRIPTION
This PR is the second part to #1578, it updates the structure of jwrapper, adds a lot of features and creates usable APIs.

Main changes:
* Rewrite of the AST visitor, type conversion and entity naming.
* Generate constructors.
* Generate getter/setters to attributes.
* Add the -p option to choose the prefix of extern class names, use the namespace by default.
* Add the -i option to scan for existing wrappers in any directory or file.
* Add the -r option to filter the target classes from a Jar archive using a regular expression.
* Add more simple tests with javap outputs.
* Add a complete (and working) example of using a custom Java collection from Nit.
* Add an example of generating an API for Android using jwrapper. This API passes nitpick, but it has not been tested as it needs to be integrated in our Android framework.

What's to do next:
* Support for primitive arrays. (This is the main reason why ~10% of the functions are disabled)
* Add static functions as top-level methods.
* Generate class hierarchy.
* Use nitls with the -i option and to add importations to the generated module.
* Fix generic params usage.