### PR TITLE
contrib/rss_downloader: compressed feeds and report errors

### DIFF
--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -289,12 +289,8 @@ redef class Text
 	fun gunzip: String
 	do
 		var proc = new ProcessDuplex("gunzip", new Array[String]...)
-		proc.write self
-		proc.stream_out.close
-		var res = proc.read_all
-		proc.stream_in.close
-		proc.wait
-		assert proc.status == 0
+		var res = proc.write_and_read(self)
+		assert proc.status == 0 else print_error "gunzip failed: {proc.last_error or else "Unknown"}"
 		return res
 	end
 end

--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -52,6 +52,9 @@ class Config
 	# XML tag used for pattern recognition
 	fun tag_title: String do return "title"
 
+	# XML tag of the link to act upon
+	fun tag_link: String do return "link"
+
 	# Action to apply on each selected RSS element
 	fun act_on(element: Element)
 	do
@@ -265,7 +268,7 @@ redef class Text
 		var elements = new Array[Element]
 		for item in items do
 			var title = item[tool_config.tag_title].first.as(XMLStartTag).data
-			var link = item["link"].first.as(XMLStartTag).data
+			var link = item[tool_config.tag_link].first.as(XMLStartTag).data
 
 			elements.add new Element(title, link)
 		end

--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -256,6 +256,10 @@ redef class Text
 	fun to_rss_elements: Array[Element]
 	do
 		var xml = to_xml
+		if xml isa XMLError then
+			print_error "RSS Parse Error: {xml.message}:{xml.location or else "null"}"
+			return new Array[Element]
+		end
 		var items = xml["rss"].first["channel"].first["item"]
 
 		var elements = new Array[Element]

--- a/contrib/rss_downloader/src/rss_downloader.nit
+++ b/contrib/rss_downloader/src/rss_downloader.nit
@@ -151,7 +151,7 @@ class Downloader
 
 		if sys.verbose then
 			print "\n# {matches.length} matching elements:"
-			print matches.join("\n")
+			print "* " + matches.join("\n* ")
 			print "\n# Downloading..."
 		end
 
@@ -162,13 +162,13 @@ class Downloader
 				# Do not download a file that is not unique according to `unique_id`
 				if not element.is_unique_exception(config) then
 					# We make some exceptions
-					if sys.verbose then print "File in log, skipping {element}"
+					if sys.verbose then print "- Skipping {element}"
 					continue
 				end
 			end
 
 			# Download element
-			if sys.verbose then print "Acting on {element}"
+			if sys.verbose then print "+ Acting on {element}"
 
 			tool_config.act_on element
 

--- a/lib/dom/examples/checker.nit
+++ b/lib/dom/examples/checker.nit
@@ -1,0 +1,43 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# This file is free software, which comes along with NIT.  This software is
+# distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without  even  the implied warranty of  MERCHANTABILITY or  FITNESS FOR A
+# PARTICULAR PURPOSE.  You can modify it is you want,  provided this header
+# is kept unaltered, and a notification of the changes is added.
+# You  are  allowed  to  redistribute it and sell it, alone or is a part of
+# another product.
+
+# Simple XML validity checker using the `dom` module
+module checker
+
+import dom
+
+# Check arguments
+if args.length != 1 then
+	print_error "Usage: checker xml_file"
+	exit 2
+end
+
+var path = args.first
+if not path.file_exists then
+	print_error "Path '{path}' does not exist"
+	exit 3
+end
+
+# Read file
+var content = path.to_path.read_all
+
+# Parse XML
+var xml = content.to_xml
+
+# Check for errors
+if xml isa XMLError then
+	print_error "XML file at '{path}' is invalid:"
+	print_error xml.message
+	var loc = xml.location
+	if loc != null then print_error loc
+	exit 1
+else
+	print "XML file at '{path}' is valid"
+end

--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -176,6 +176,20 @@ class FileReader
 			end_reached = true
 		end
 	end
+
+	redef fun poll_in
+	do
+		var res = native_poll_in(fd)
+		if res == -1 then
+			last_error = new IOError(errno.to_s)
+			return false
+		else return res > 0
+	end
+
+	private fun native_poll_in(fd: Int): Int `{
+		struct pollfd fds = {fd, POLLIN, 0};
+		return poll(&fds, 1, 0);
+	`}
 end
 
 # `Stream` that can write to a File
@@ -305,16 +319,6 @@ class Stdin
 		path = "/dev/stdin"
 		prepare_buffer(1)
 	end
-
-	redef fun poll_in `{
-		struct pollfd fd = {0, POLLIN, 0};
-		int res = poll(&fd, 1, 0);
-		if (res == -1) {
-			perror("Error poll stdin");
-			exit(EXIT_FAILURE);
-		}
-		return res > 0;
-	`}
 end
 
 # Standard output stream.

--- a/tests/sav/checker.res
+++ b/tests/sav/checker.res
@@ -1,0 +1,1 @@
+Usage: checker xml_file


### PR DESCRIPTION
This PR adds a few features to rss_downloader to support more RSS feeds. It can be configured to decompress the feed and to customize the tag to find the download link. The output has be improved, both on normal behavior and on errors.

As a bonus, add the program I used to debug the RSS feeds as an example for the `dom` module.