### PR TITLE
Fix Chainz of Friendz buttons on Android

### DIFF
--- a/contrib/friendz/src/friendz_android.nit
+++ b/contrib/friendz/src/friendz_android.nit
@@ -39,7 +39,7 @@ redef class App
 end
 
 redef class AndroidPointerEvent
-	redef fun is_motion do return not just_went_down
+	redef fun is_motion do return is_move
 
 	redef fun x do return super / app.zoom
 	redef fun y do return super / app.zoom

--- a/lib/android/input_events.nit
+++ b/lib/android/input_events.nit
@@ -190,6 +190,10 @@ class AndroidPointerEvent
 		return action.is_down or action.is_move or action.is_pointer_down
 	end
 
+	# Is this a move event?
+	fun is_move: Bool do return motion_event.acting_pointer == self and
+		motion_event.native.action.is_move
+
 	redef fun depressed do return not pressed
 
 	# Does this pointer just began touching the screen?

--- a/lib/android/input_events.nit
+++ b/lib/android/input_events.nit
@@ -165,13 +165,13 @@ class AndroidPointerEvent
 
 	private var pointer_index: Int
 
-	redef fun x: Float do return native_x(motion_event.native, pointer_index)
+	redef fun x do return native_x(motion_event.native, pointer_index)
 
 	private fun native_x(motion_event: NativeAndroidMotionEvent, pointer_index: Int): Float `{
 		return AMotionEvent_getX(motion_event, pointer_index);
 	`}
 
-	redef fun y: Float do return native_y(motion_event.native, pointer_index)
+	redef fun y do return native_y(motion_event.native, pointer_index)
 
 	private fun native_y(motion_event: NativeAndroidMotionEvent, pointer_index: Int): Float `{
 		return AMotionEvent_getY(motion_event, pointer_index);
@@ -213,8 +213,8 @@ extern class AndroidKeyEvent `{AInputEvent *`}
 
 	private fun action: Int `{ return AKeyEvent_getAction(self); `}
 
-	redef fun is_down: Bool do return action == 0
-	redef fun is_up: Bool do return action == 1
+	redef fun is_down do return action == 0
+	redef fun is_up do return action == 1
 
 	# Hardware code of the key raising this event
 	fun key_code: Int `{ return AKeyEvent_getKeyCode(self); `}


### PR DESCRIPTION
Intro `AndroidPointerEvent::is_move` and tweak Chainz of Friendz so it doesn't consider the release event as a move event.