### PR TITLE
A little fix to android::audio

### DIFF
--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 # App audio abstraction
+# Default behaviour is loading the audio from the `assets` folder of the project with its name and extension
+# Platforms implementations can modify this comportement
 #
 # Once the application has started (after `App.setup`)
 # use `App.load_sound` to get a sound
@@ -41,7 +43,7 @@ abstract class PlayableAudio
 	# Is this already loaded ?
 	protected var is_loaded = false is writable
 
-	# load this playable audio
+	# Load this playable audio
 	fun load is abstract
 
 	# Plays the sound


### PR DESCRIPTION
As explained in PR #1587, there is a bit of a problem when making applications which runs on both linux and android about the loading of the sounds

This PR just reverse the order of the loading for the android audio API, so that if you want to use the sounds in the res folder for your android application, and the sounds in the assets folder for the linux application, you just have to create a new sound with its extension and it will work fine :)

Edit: It also enables the use of different sound formats between android and Linux