### PR TITLE
Cached ropes

### DIFF
--- a/lib/standard/text/ropes.nit
+++ b/lib/standard/text/ropes.nit
@@ -204,6 +204,50 @@ private class Concat
 			st = 0
 		end
 	end
+
+	# Returns a balanced version of `self`
+	fun balance: String do
+		var children = new Array[String]
+		var rnod: String
+		var iter: nullable RopeCharIteratorPiece = new RopeCharIteratorPiece(self, false, false, null)
+		loop
+			if iter == null then break
+			rnod = iter.node
+			if not rnod isa Concat then
+				children.push rnod
+				iter = iter.prev
+				continue
+			end
+			if not iter.ldone then
+				iter.ldone = true
+				iter = new RopeCharIteratorPiece(rnod.left, false, false, iter)
+			else if not iter.rdone then
+				iter.rdone = true
+				iter = new RopeCharIteratorPiece(rnod.right, false, false, iter)
+			else
+				iter = iter.prev
+			end
+
+		end
+		return recurse_balance(children, children.length)
+	end
+
+	fun recurse_balance(nodes: Array[String], len: Int): String do
+		var finpos = 0
+		var stpos = 0
+		while stpos < len do
+			if len - stpos > 1 then
+				nodes[finpos] = new Concat(nodes[stpos], nodes[stpos + 1])
+				stpos += 2
+			else
+				nodes[finpos] = nodes[stpos]
+				stpos += 1
+			end
+			finpos += 1
+		end
+		if finpos == 1 then return nodes[0]
+		return recurse_balance(nodes, finpos)
+	end
 end
 
 # Mutable `Rope`, optimized for concatenation operations

--- a/tests/sav/nitpick_args1.res
+++ b/tests/sav/nitpick_args1.res
@@ -1,4 +1,4 @@
-../lib/standard/stream.nit:426,6--17: Documentation warning: Undocumented property `buffer_reset`
+../lib/standard/stream.nit:451,6--17: Documentation warning: Undocumented property `buffer_reset`
 test_advice_repeated_types.nit:36,15--20: Warning: useless type repetition on redefined attribute `_a`
 test_advice_repeated_types.nit:37,18--20: Warning: useless type repetition on parameter `b1` for redefined method `b`
 test_advice_repeated_types.nit:38,18--20: Warning: useless type repetition on parameter `c1` for redefined method `c`


### PR DESCRIPTION
Added a wee bit of optimization on Ropes, indexed accesses are properly cached and file manipulations (especially `read_all`) now yields a good balanced Rope, which should reduce the degenerative cases of random indexed access whilst preserving most of the performance in local access.

This has a positive (though small) impact on a the compiler :

* Before: `I   refs:      14,286,788,827`
* After: `I   refs:      14,197,458,800` (-0.63%)

What is seen in Valgrind is unfortunately unchanged in user-time (nitc-sg compiling nitg-sg) :

* Before: `user	0m5.360s`
* After: `user	0m5.367s`