### PR TITLE
Remove memory leak in Ropes

### DIFF
--- a/lib/standard/text/ropes.nit
+++ b/lib/standard/text/ropes.nit
@@ -449,7 +449,8 @@ class RopeBuffer
 	redef fun enlarge(i) do end
 
 	redef fun to_s do
-		dump_buffer
+		persist_buffer
+		written = true
 		return str
 	end
 

--- a/tests/niti.skip
+++ b/tests/niti.skip
@@ -29,3 +29,4 @@ input
 first_letter_last_letter
 fibonacci_word
 shootout_nsieve
+test_ropebuffer

--- a/tests/nitvm.skip
+++ b/tests/nitvm.skip
@@ -29,3 +29,4 @@ input
 first_letter_last_letter
 fibonacci_word
 shootout_nsieve
+test_ropebuffer

--- a/tests/test_ropebuffer.nit
+++ b/tests/test_ropebuffer.nit
@@ -1,0 +1,20 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+var rb = new RopeBuffer
+
+for i in [0 .. 1000000[ do
+	rb.add 'S'
+	var s = rb.to_s
+end


### PR DESCRIPTION
Early on, the `to_s` of a RopeBuffer was calling `dump_buffer`, which like to double the size of the buffered part after persisting.

By doing do, a simple program like the one submitted along with this PR was consuming an awful lot of RAM, which has the undesirable side-effect of freezing my machine after a few milliseconds of run.

By replacing it with the more memory-friendly `persist buffer`, all my troubles seem so far away !