### PR TITLE
misc/vim: highlight the new Int literals

### DIFF
--- a/misc/vim/syntax/nit.vim
+++ b/misc/vim/syntax/nit.vim
@@ -36,8 +36,9 @@ syn match NITExprSubst "{\([^}]\|\n\)*}" contained
 syn match NITExprSubstLong "\\." contained
 syn match NITExprSubstLong "{*\zs{{{\([^}]\|\n\)*}}}\ze}*" contained
 
-" Numbers and ASCII Codes
-syn match NITNumber "\<\(\d\+\.\d\+\|\d\+\)\>"
+" Numbers
+syn match NITNumber "\<\([0-9_]\+\|0[bB][01_]\+\|0[oO][0-7_]\+\|0[xX][0-9a-fA-F_]\+\)\([iu]\(8\|16\|32\)\)\?\>"
+syn match NITNumber "\<[0-9_]\+\.[0-9_]\+\>"
 
 " Identifiers
 syn match NITClass		"\<\u\w*"


### PR DESCRIPTION
Add support for bin, oct and hex literals which are restrictive enough to detect invalid digits. Also accept `_` in all Int literals, and the suffixes `[iu]8|16|32` proposed by #1588.

Supports `_` in Float literals, it's not yet available but it can't be too far off.