### PR TITLE
nitrpg: fix crash when the Reviews/Work requests return nothing

### DIFF
--- a/contrib/nitrpg/src/templates/panels.nit
+++ b/contrib/nitrpg/src/templates/panels.nit
@@ -371,8 +371,10 @@ class PlayerReviewsPanel
 			"-involves:{player.name}"
 
 		var issues = new ArraySet[Issue]
-		issues.add_all game.repo.search_issues(q).as(not null)
-		issues.add_all game.repo.search_issues(q2).as(not null)
+		var rq = game.repo.search_issues(q)
+		if rq != null then issues.add_all rq
+		var rq2 = game.repo.search_issues(q2)
+		if rq2 != null then issues.add_all rq2
 		if issues.is_empty then
 			add "<em>No pull request or issue to review yet...</em>"
 			return
@@ -417,8 +419,10 @@ class PlayerWorkPanel
 		var q2 = "is:open sort:updated-asc assignee:{player.name}"
 
 		var issues = new ArraySet[Issue]
-		issues.add_all game.repo.search_issues(q).as(not null)
-		issues.add_all game.repo.search_issues(q2).as(not null)
+		var rq = game.repo.search_issues(q)
+		if rq != null then issues.add_all rq
+		var rq2 = game.repo.search_issues(q2)
+		if rq2 != null then issues.add_all rq2
 		if issues.is_empty then
 			add "<em>No work to do yet...</em>"
 			return


### PR DESCRIPTION
Nitrpg was down since last wednesday because of this. It's now back on track: http://nitlanguage.org/rpg/games/privat/nit

Since the listener didn't crash, no data were loss during the downtime.