### PR TITLE
Fix nitcorn `Content-Length` when working with UTF-8 files

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -157,7 +157,7 @@ class Connection
 	# Write a string to the connection
 	redef fun write(str)
 	do
-		native_buffer_event.write(str.to_cstring, str.length)
+		native_buffer_event.write(str.to_cstring, str.bytelen)
 	end
 
 	redef fun write_byte(byte) do native_buffer_event.write_byte(byte)

--- a/lib/nitcorn/http_response.nit
+++ b/lib/nitcorn/http_response.nit
@@ -42,7 +42,7 @@ class HttpResponse
 	do
 		# Set the content length if not already set
 		if not header.keys.has("Content-Length") then
-			header["Content-Length"] = body.length.to_s
+			header["Content-Length"] = body.bytelen.to_s
 		end
 
 		# Set server ID

--- a/lib/nitcorn/media_types.nit
+++ b/lib/nitcorn/media_types.nit
@@ -96,6 +96,12 @@ class MediaTypes
 		types["asf"]        = "video/x-ms-asf"
 		types["mng"]        = "video/x-mng"
 		types["apk"]        = "application/vnd.android.package-archive"
+		types["svg"]        = "image/svg+xml"
+		types["ttf"]        = "application/x-font-ttf"
+		types["otf"]        = "application/x-font-opentype"
+		types["eof"]        = "application/vnd.ms-fontobject"
+		types["woff"]       = "application/font-woff"
+		types["woff2"]      = "application/font-woff2"
 	end
 end
 


### PR DESCRIPTION
Changes:
* use `bytelen` instead of `length` when setting `Content-Length` header
* add media types for web fonts