### PR TITLE
Tinks! fix frame lock between clients and servers

### DIFF
--- a/contrib/tinks/src/client/android_client.nit
+++ b/contrib/tinks/src/client/android_client.nit
@@ -65,7 +65,7 @@ redef class ExplosionEvent
 		var d = 20
 		if local_tank != null then
 			d = local_tank.pos.dist(pos).to_i
-			d = 500 - d*20
+			d = 100 - d*5
 			d = d.max(10)
 		end
 

--- a/contrib/tinks/src/client/context.nit
+++ b/contrib/tinks/src/client/context.nit
@@ -93,7 +93,7 @@ class RemoteGameContext
 
 		# Send orders to server
 		var local_player = local_player
-		if local_player != null then
+		if local_player != null and local_player.orders.not_empty then
 			remote_server.writer.serialize local_player.orders
 			remote_server.socket.flush
 			local_player.orders = new Array[TOrder]

--- a/contrib/tinks/src/common.nit
+++ b/contrib/tinks/src/common.nit
@@ -21,6 +21,8 @@ redef class Sys
 	# Name of this app
 	redef fun handshake_app_name do return "tinks"
 
+	redef fun handshake_app_version do return "0.1"
+
 	# Default listening port of the server
 	fun default_listening_port: Int do return 18721
 

--- a/contrib/tinks/src/server/server.nit
+++ b/contrib/tinks/src/server/server.nit
@@ -107,6 +107,8 @@ redef class Server
 		# Get orders from players
 		var clients_to_remove = new Array[RemoteClient]
 		for client in clients do
+			if not client.socket.poll_in then continue
+
 			var orders = client.reader.deserialize
 			var errors = client.reader.errors
 			if errors.not_empty then

--- a/lib/gamnit/network/client.nit
+++ b/lib/gamnit/network/client.nit
@@ -84,6 +84,7 @@ class RemoteServer
 
 		# Setup serialization
 		writer = new BinarySerializer(socket)
+		writer.cache = new AsyncCache(false)
 		reader = new BinaryDeserializer(socket)
 		writer.link reader
 

--- a/lib/gamnit/network/server.nit
+++ b/lib/gamnit/network/server.nit
@@ -119,6 +119,7 @@ class RemoteClient
 	do
 		# Setup serialization
 		writer = new BinarySerializer(socket)
+		writer.cache = new AsyncCache(true)
 		reader = new BinaryDeserializer(socket)
 		writer.link reader
 	end

--- a/lib/serialization/caching.nit
+++ b/lib/serialization/caching.nit
@@ -74,10 +74,13 @@ class SerializerCache
 	# Require: `not has_object(object)`
 	fun new_id_for(object: Serializable): Int
 	do
-		var id = sent.length
+		var id = next_available_id
 		sent[object] = id
 		return id
 	end
+
+	# Get a free id to associate to an object in the cache
+	protected fun next_available_id: Int do return sent.length
 end
 
 # Cache of received objects sorted by there reference id
@@ -114,5 +117,21 @@ class DuplexCache
 		super
 		assert object isa Serializable
 		sent[object] = id
+	end
+end
+
+# A shared cache where 2 clients serialize objects at the same types, prevents references collision
+class AsyncCache
+	super DuplexCache
+
+	# Should this end use even numbers?
+	var use_even: Bool
+
+	private var last_id: Int is lazy do return if use_even then 0 else 1
+
+	redef fun next_available_id
+	do
+		last_id += 2
+		return last_id
 	end
 end

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -149,12 +149,11 @@ class TCPStream
 		return pollin(events, timeout).length != 0
 	end
 
-	# Checks if the socket still is connected
+	# Is this socket still connected?
 	fun connected: Bool
 	do
 		if closed then return false
-		var events = [new NativeSocketPollValues.pollhup, new NativeSocketPollValues.pollerr]
-		if pollin(events, 0).length == 0 then
+		if native.poll_hup_err == 0 then
 			return true
 		else
 			closed = true

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -164,6 +164,15 @@ extern class NativeSocket `{ int* `}
 		return filedesc.check_response(result)
 	end
 
+	# Poll this socket with `POLLHUP|POLLERR`
+	#
+	# A return value of 0 means there is no errors.
+	fun poll_hup_err: Int `{
+		struct pollfd fd = {*self, POLLHUP|POLLERR, 0};
+		int res = poll(&fd, 1, 0);
+		return res;
+	`}
+
 	# Call to the poll function of the C socket
 	#
 	# Signature:


### PR DESCRIPTION
This PR greatly improve multiplayer performance by removing the synchronous frames between the clients and server.

There is still a lot of stuff to do on Tinks! see the notes in #1601.