### PR TITLE
jwrapper reproduces Java class hierarchy in Nit and serialize model

### DIFF
--- a/contrib/jwrapper/.gitignore
+++ b/contrib/jwrapper/.gitignore
@@ -2,5 +2,6 @@ gen/*
 src/javap_lexer.nit
 src/javap_parser.nit
 src/javap_test_parser.nit
+src/serial.nit
 tests/*.nit
 tmp/*

--- a/contrib/jwrapper/Makefile
+++ b/contrib/jwrapper/Makefile
@@ -9,9 +9,12 @@ src/javap_test_parser.nit: ../nitcc/src/nitcc grammar/javap.sablecc
 	mv javap_*.nit src/
 	mv javap* gen/
 
-bin/jwrapper: src/javap_test_parser.nit $(shell ../../bin/nitls -M src/jwrapper.nit) ../../bin/nitc
+src/serial.nit: $(shell ../../bin/nitls -M src/jwrapper.nit)
+	../../bin/nitserial -o src/serial.nit -d project src/jwrapper.nit
+
+bin/jwrapper: src/javap_test_parser.nit src/serial.nit $(shell ../../bin/nitls -M src/jwrapper.nit) ../../bin/nitc
 	mkdir -p bin
-	../../bin/nitc src/jwrapper.nit -o bin/jwrapper
+	../../bin/nitc src/jwrapper.nit -o bin/jwrapper -m src/serial.nit
 
 clean:
 	rm -f bin/javap_test_parser bin/jwrapper

--- a/contrib/jwrapper/examples/android_api/.gitignore
+++ b/contrib/jwrapper/examples/android_api/.gitignore
@@ -1,3 +1,4 @@
 android_api.nit
 java_api.nit
+java_api.jwrapper.bin
 tmp/

--- a/contrib/jwrapper/examples/android_api/Makefile
+++ b/contrib/jwrapper/examples/android_api/Makefile
@@ -4,11 +4,11 @@ all: android_api.nit
 
 java_api.nit:
 	mkdir -p tmp
-	../../bin/jwrapper -vv -u comment -o java_api.nit -r "^(java|javax|junit|org)" $(ANDROID_JAR) -i ../../../../lib/java/collections.nit
+	../../bin/jwrapper -vv -u comment -o java_api.nit -r "^(java|javax|junit|org)" $(ANDROID_JAR) -i ../../../../lib/java/collections.nit --save-model
 	echo "+ Disabled functions: `grep '#\s*fun' $@ | wc -l` / `grep '^\s*fun' $@ | wc -l`"
 
 android_api.nit: java_api.nit
-	../../bin/jwrapper -vv -u comment -o android_api.nit -r "^(android|com.android)" -i java_api.nit $(ANDROID_JAR) -i ../../../../lib/java/collections.nit
+	../../bin/jwrapper -vv -u comment -o android_api.nit -r "^(android|com.android)" -i java_api.nit $(ANDROID_JAR) -i ../../../../lib/java/collections.nit -m java_api.jwrapper.bin
 	echo "+ Disabled functions: `grep '#\s*fun' $@ | wc -l` / `grep '^\s*fun' $@ | wc -l`"
 
 	# Insert an import between the 2 modules

--- a/contrib/jwrapper/examples/java_api/Makefile
+++ b/contrib/jwrapper/examples/java_api/Makefile
@@ -16,16 +16,19 @@ check: api_user
 	./api_user > api_user.res
 	diff api_user.sav api_user.res
 
-check-more-java:
+full_java_api.nit:
 	mkdir -p tmp
-	../../bin/jwrapper -vv -u comment -o java_api.nit $(RT_JAR) \
+	../../bin/jwrapper -vv -u comment -o full_java_api.nit $(RT_JAR) \
 		-r "^(java|org)" -i ../../../../lib/java/collections.nit
 	echo "+ Disabled functions: `grep '#\s*fun' $@ | wc -l` / `grep '^\s*fun' $@ | wc -l`"
 
-	# This may take a while...
-	time -f "%E k:%S u:%U" ../../../../bin/nitc -v api_user.nit --no-cc
+	# Force compilation of the Java code
+	echo 'fun foo in "Java" `{  `}; foo' >> full_java_api.nit
 
-	# Don't compile the C only the Java
-	make -C nit_compile Nit_rt.class
+	# This may take a while...
+	time -f "%E k:%S u:%U" ../../../../bin/nitc -v full_java_api.nit --no-cc
+
+	# Don't compile the C, only the Java
+	make -C nit_compile Nit_full_java_api.class
 
 .PHONY: api_user java_api.nit

--- a/contrib/jwrapper/examples/java_api/api_user.nit
+++ b/contrib/jwrapper/examples/java_api/api_user.nit
@@ -18,17 +18,22 @@ import java_api
 var str = java_lang_integer_to_string_int(5678)
 
 # Do some Java side printing
-var stdout = java_lang_system_out
-stdout.println_int 1234
-stdout.println_String str
+java_lang_system_out.println_int 1234
+java_lang_system_out.println_String str
 
 # Test a generic list
 var list = new Java_util_ArrayList
 
-print list.is_empty
-assert list.is_empty
+print "List is empty? {list.is_empty}"
+print "List size {list.size}"
 
-print list.size
-assert list.size == 0
+list.add str
+print "List is empty? {list.is_empty}"
+print "List size {list.size}"
+
+var str_back = list.get(0)
+java_lang_system_out.println_String str_back.to_string
 
 list.clear
+print "List is empty? {list.is_empty}"
+print "List size {list.size}"

--- a/contrib/jwrapper/examples/java_api/api_user.sav
+++ b/contrib/jwrapper/examples/java_api/api_user.sav
@@ -1,4 +1,9 @@
 1234
 5678
-true
-0
+List is empty? true
+List size 0
+List is empty? false
+List size 1
+5678
+List is empty? true
+List size 0

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -15,6 +15,9 @@ dots = '...';
 Parser
 Ignored blank;
 
+// ---
+// Class and properties
+
 files = file+;
 file = compiled_from? class_declaration;
 
@@ -22,12 +25,31 @@ class_declaration = modifier* class_or_interface full_class_name
 	extends_declaration? implements_declaration? throws_declaration?
 	'{' property_declaration* '}';
 
+modifier
+	= 'public'|'private'|'protected'|'static'|'final'|'native'
+	|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile'|'strictfp';
+
 class_or_interface = 'class'|'interface';
 
-modifier
-	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile'|'strictfp';
+implements_declaration = 'implements' types;
+extends_declaration = 'extends' types;
+throws_declaration = 'throws' types?;
+
+property_declaration
+	= {method:} modifier* generic_parameters? type identifier '(' types? ')' throws_declaration? ';'
+	| {constructor:} modifier* generic_parameters? full_class_name '(' types? ')' throws_declaration? ';'
+	| {attribute:} modifier* type identifier brackets* throws_declaration? ';'
+	| {static:} modifier* '{' '}' ';'
+	| ';';
+
+// ---
+// Types
 
 type = base_type brackets* dots?;
+
+types
+	= {tail:} types ',' type
+	| {head:} type;
 
 base_type
 	= {primitive:} primitive_base_type
@@ -47,24 +69,10 @@ generic_identifier
 	= {class:} full_class_name
 	| {wildcard:} wildcard;
 
+class_name = identifier generic_parameters?;
+
 full_class_name
 	= {tail:} full_class_name separator class_name
 	| {head:} class_name;
-class_name = identifier generic_parameters?;
 
 generic_parameters = '<' types '>';
-
-types
-	= {tail:} types ',' type
-	| {head:} type;
-
-property_declaration
-	= {method:} modifier* generic_parameters? type identifier '(' types? ')' throws_declaration? ';'
-	| {constructor:} modifier* generic_parameters? full_class_name '(' types? ')' throws_declaration? ';'
-	| {attribute:} modifier* type identifier brackets* throws_declaration? ';'
-	| {static:} modifier* '{' '}' ';'
-	| ';';
-
-implements_declaration = 'implements' types;
-extends_declaration = 'extends' types;
-throws_declaration = 'throws' types?;

--- a/contrib/jwrapper/grammar/javap.sablecc
+++ b/contrib/jwrapper/grammar/javap.sablecc
@@ -27,7 +27,7 @@ class_or_interface = 'class'|'interface';
 modifier
 	= 'public'|'private'|'protected'|'static'|'final'|'native'|'synchronized'|'abstract'|'threadsafe'|'transient'|'volatile'|'strictfp';
 
-type = base_type brackets*;
+type = base_type brackets* dots?;
 
 base_type
 	= {primitive:} primitive_base_type
@@ -52,27 +52,19 @@ full_class_name
 	| {head:} class_name;
 class_name = identifier generic_parameters?;
 
-generic_parameters = '<' parameters '>';
+generic_parameters = '<' types '>';
 
-parameter = type dots?;
-parameters
-	= {tail:} parameters ',' parameter
-	| {head:} parameter;
+types
+	= {tail:} types ',' type
+	| {head:} type;
 
 property_declaration
-	= {method:} modifier* generic_parameters? type identifier '(' parameters? ')' throws_declaration? ';'
-	| {constructor:} modifier* generic_parameters? full_class_name '(' parameters? ')' throws_declaration? ';'
+	= {method:} modifier* generic_parameters? type identifier '(' types? ')' throws_declaration? ';'
+	| {constructor:} modifier* generic_parameters? full_class_name '(' types? ')' throws_declaration? ';'
 	| {attribute:} modifier* type identifier brackets* throws_declaration? ';'
 	| {static:} modifier* '{' '}' ';'
 	| ';';
 
-implements_declaration = 'implements' interface_list;
-extends_declaration = 'extends' interface_list;
-interface_list
-	= {tail:} interface_list ',' full_class_name
-	| {head:} full_class_name;
-
-throws_declaration = 'throws' exception_list?;
-exception_list
-	= {tail:} exception_list ',' type
-	| {head:} type;
+implements_declaration = 'implements' types;
+extends_declaration = 'extends' types;
+throws_declaration = 'throws' types?;

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -72,7 +72,7 @@ class CodeGenerator
 			# Skip classes with an invalid name at the Java language level
 			if jclass.class_type.extern_equivalent.has("-") then continue
 
-			generate_class_header(jclass.class_type)
+			generate_class_header(jclass)
 
 			for id, signatures in jclass.methods do
 				for signature in signatures do if not signature.is_static then
@@ -151,12 +151,19 @@ class CodeGenerator
 # This code has been generated using `jwrapper`
 """ is writable
 
-	private fun generate_class_header(jtype: JavaType)
+	private fun generate_class_header(java_class: JavaClass)
 	do
-		var nit_type = model.java_to_nit_type(jtype)
-		file_out.write "# Java class: {jtype}\n"
-		file_out.write "extern class {nit_type} in \"Java\" `\{ {jtype.extern_equivalent} `\}\n"
-		file_out.write "\tsuper JavaObject\n\n"
+		var java_type = java_class.class_type
+		var nit_type = model.java_to_nit_type(java_type)
+
+		var supers = ["super JavaObject"]
+
+		file_out.write """
+# Java class: {{{java_type}}}
+extern class {{{nit_type}}} in "Java" `{ {{{java_type.extern_equivalent}}} `}
+	{{{supers.join("\n\t")}}}
+
+"""
 	end
 
 	private fun generate_unknown_class_header(jtype: JavaType)

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -65,10 +65,14 @@ class CodeGenerator
 		file_out.write imports.join("\n")
 		file_out.write "\n"
 
-		for key, jclass in model.classes do
-			# Skip anonymous classes
-			if jclass.class_type.is_anonymous then continue
+		# Sort classes from top-level classes (java.lang.Object) to leaves
+		var standard_classes = new Array[JavaClass]
+		for name, jclass in model.classes do
+			if not jclass.class_type.is_anonymous then standard_classes.add jclass
+		end
+		var linearized = model.class_hierarchy.linearize(standard_classes)
 
+		for jclass in linearized do
 			# Skip classes with an invalid name at the Java language level
 			if jclass.class_type.extern_equivalent.has("-") then continue
 

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -146,6 +146,8 @@ class CodeGenerator
 	# Serialize `model` to a file next to `file_name`
 	fun write_model_to_file
 	do
+		if not sys.opt_save_model.value then return
+
 		# Write the model to file next to the Nit module
 		var model_path = file_name.strip_extension + ".jwrapper.bin"
 		var model_stream = model_path.to_path.open_wo
@@ -435,6 +437,9 @@ redef class Sys
 
 	# Option to _not_ generate properties (static or from classes)
 	var opt_no_properties = new OptionBool("Do not wrap properties, only classes and basic services", "-n", "--no-properties")
+
+	# Should the model be serialized to a file?
+	var opt_save_model = new OptionBool("Save the model next to the generated Nit module", "-s", "--save-model")
 end
 
 redef class String

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -128,6 +128,8 @@ class CodeGenerator
 				file_out.write "\n"
 			end
 		end
+
+		file_out.close
 	end
 
 	# License for the header of the generated Nit module

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -196,7 +196,8 @@ class CodeGenerator
 		end
 
 		if effective_supers == 0 then
-			if java_class.class_type.package_name == "java.lang.Object" then
+			if java_class.class_type.package_name == "java.lang.Object" or
+			   not model.knows_the_object_class then
 				supers.add "super JavaObject"
 			else supers.add "super Java_lang_Object"
 		end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -74,8 +74,9 @@ class CodeGenerator
 
 			generate_class_header(jclass)
 
-			for id, signatures in jclass.methods do
-				for signature in signatures do if not signature.is_static then
+			for id, signatures in jclass.local_intro_methods do
+				for signature in signatures do
+					assert not signature.is_static
 					generate_method(jclass, id, id, signature.return_type, signature.params)
 					file_out.write "\n"
 				end

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -444,7 +444,7 @@ end
 
 redef class JavaClass
 	# Property names used in this class
-	private var used_names = new HashSet[String]
+	private var used_names = new HashSet[String] is serialize
 
 	# Get an available property name for the Java property with `name` and parameters
 	#

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -137,6 +137,17 @@ class CodeGenerator
 		file_out.close
 	end
 
+	# Serialize `model` to a file next to `file_name`
+	fun write_model_to_file
+	do
+		# Write the model to file next to the Nit module
+		var model_path = file_name.strip_extension + ".jwrapper.bin"
+		var model_stream = model_path.to_path.open_wo
+		var serializer = new BinarySerializer(model_stream)
+		serializer.serialize model
+		model_stream.close
+	end
+
 	# License for the header of the generated Nit module
 	var license = """
 # This file is part of NIT (http://www.nitlanguage.org).

--- a/contrib/jwrapper/src/code_generator.nit
+++ b/contrib/jwrapper/src/code_generator.nit
@@ -53,7 +53,7 @@ class CodeGenerator
 
 		# Module declaration
 		var module_name = module_name
-		if module_name != null then file_out.write "module {module_name}\n"
+		if module_name != null then file_out.write "module {module_name} is no_warning(\"useless-superclass\")\n"
 		file_out.write "\n"
 
 		# All importations

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -61,7 +61,7 @@ end
 redef class Nextends_declaration
 	redef fun accept_visitor(v)
 	do
-		# TODO
+		v.java_class.extends.add_all n_types.to_a
 	end
 end
 
@@ -69,7 +69,7 @@ end
 redef class Nimplements_declaration
 	redef fun accept_visitor(v)
 	do
-		# TODO
+		v.java_class.implements.add_all n_types.to_a
 	end
 end
 

--- a/contrib/jwrapper/src/javap_visitor.nit
+++ b/contrib/jwrapper/src/javap_visitor.nit
@@ -91,14 +91,14 @@ redef class Nproperty_declaration_method
 		var n_params = n_generic_parameters
 		var generic_params
 		if n_params != null then
-			generic_params = n_params.n_parameters.to_a
+			generic_params = n_params.n_types.to_a
 		else generic_params = new Array[JavaType]
 
 		# Collect parameters
-		var n_parameters = n_parameters
+		var n_types = n_types
 		var params
-		if n_parameters != null then
-			params = n_parameters.to_a
+		if n_types != null then
+			params = n_types.to_a
 		else params = new Array[JavaType]
 
 		var method = new JavaMethod(is_static, return_jtype, params, generic_params)
@@ -111,17 +111,17 @@ redef class Nproperty_declaration_constructor
 	redef fun accept_visitor(v)
 	do
 		# Collect parameters
-		var n_parameters = n_parameters
+		var n_types = n_types
 		var params
-		if n_parameters != null then
-			params = n_parameters.to_a
+		if n_types != null then
+			params = n_types.to_a
 		else params = new Array[JavaType]
 
 		# Generic parameters
 		var n_params = n_generic_parameters
 		var generic_params
 		if n_params != null then
-			generic_params = n_params.n_parameters.to_a
+			generic_params = n_params.n_types.to_a
 		else generic_params = new Array[JavaType]
 
 		var method = new JavaConstructor(params, generic_params)
@@ -166,6 +166,9 @@ redef class Ntype
 
 		var brackets = n_brackets
 		if brackets != null then jtype.array_dimension += brackets.children.length
+
+		var dots = n_dots
+		if dots != null then jtype.is_vararg = true
 
 		return jtype
 	end
@@ -259,7 +262,7 @@ redef class Nfull_class_name
 
 		# Generic parameters
 		var n_params = n_class_name_common.n_generic_parameters
-		if n_params != null then jtype.generic_params = n_params.n_parameters.to_a
+		if n_params != null then jtype.generic_params = n_params.n_types.to_a
 
 		return jtype
 	end
@@ -282,35 +285,23 @@ redef class Nfull_class_name_tail
 	end
 end
 
-redef class Nparameters
+redef class Ntypes
 	# Get the types composing this list of parameters
 	#
 	# This is used both on methods signatures and type parameters.
 	private fun to_a: Array[JavaType] is abstract
 end
 
-redef class Nparameters_head
-	redef fun to_a do return [n_parameter.to_java_type]
+redef class Ntypes_head
+	redef fun to_a do return [n_type.to_java_type]
 end
 
-redef class Nparameters_tail
+redef class Ntypes_tail
 	redef fun to_a
 	do
-		var a = n_parameters.to_a
-		a.add n_parameter.to_java_type
+		var a = n_types.to_a
+		a.add n_type.to_java_type
 		return a
-	end
-end
-
-redef class Nparameter
-	private fun to_java_type: JavaType
-	do
-		var jtype = n_type.to_java_type
-
-		var dots = n_dots
-		if dots != null then jtype.is_vararg = true
-
-		return jtype
 	end
 end
 

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -44,7 +44,7 @@ var opt_output = new OptionString("Output file", "-o")
 var opt_regex = new OptionString("Regex pattern to filter classes in Jar archives", "-r")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_load_models, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_load_models, opt_no_properties, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -194,8 +194,13 @@ var visitor = new JavaVisitor(model)
 visitor.enter_visit root_node
 sys.perfs["core model"].add clock.lapse
 
+# Resolve types
 model.resolve_types
 sys.perfs["core resolve"].add clock.lapse
+
+# Build class hierarchy
+model.build_class_hierarchy
+sys.perfs["core hierarchy"].add clock.lapse
 
 if opt_verbose.value > 0 then print "# Generating Nit code"
 

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -204,11 +204,16 @@ sys.perfs["core hierarchy"].add clock.lapse
 
 if opt_verbose.value > 0 then print "# Generating Nit code"
 
+# Generate the Nit module
 var use_comment = opt_unknown.value == 0
 var use_stub = opt_unknown.value == 1
 var generator = new CodeGenerator(out_file, model, use_comment, use_stub)
 generator.generate
 sys.perfs["code generator"].add clock.lapse
+
+# Write the model to a file, for use by subsequent passes
+generator.write_model_to_file
+sys.perfs["writing model"].add clock.lapse
 
 if opt_verbose.value > 1 then
 	print "# Performance Analysis:"

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -44,7 +44,7 @@ var opt_output = new OptionString("Output file", "-o")
 var opt_regex = new OptionString("Regex pattern to filter classes in Jar archives", "-r")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_load_models, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -90,8 +90,10 @@ for input in opts.rest do
 	else if ext == "javap" then
 		javap_files.add input
 	else if ext == "jar" then
-		var out_dir = "tmp"
 		clock.lapse
+
+		var out_dir = "tmp"
+		if not out_dir.file_exists then out_dir.mkdir
 
 		if opt_verbose.value > 0 then print "# Extracting {input}"
 

--- a/contrib/jwrapper/src/jwrapper.nit
+++ b/contrib/jwrapper/src/jwrapper.nit
@@ -44,7 +44,7 @@ var opt_output = new OptionString("Output file", "-o")
 var opt_regex = new OptionString("Regex pattern to filter classes in Jar archives", "-r")
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
-opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_load_models, opt_no_properties, opt_verbose, opt_help)
+opts.add_option(opt_output, opt_unknown, opt_extern_class_prefix, opt_libs, opt_regex, opt_cast_objects, opt_arrays, opt_save_model, opt_load_models, opt_no_properties, opt_verbose, opt_help)
 opts.parse args
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -230,6 +230,9 @@ class JavaClass
 			end
 		end
 	end
+
+	redef fun hash do return class_type.hash
+	redef fun ==(o) do return o isa JavaClass and o.class_type == class_type
 end
 
 # Model of all the Java class analyzed in one run
@@ -334,6 +337,9 @@ class JavaMethod
 
 	# Generic parameters of this method
 	var generic_params: Array[JavaType]
+
+	redef fun ==(o) do return o isa JavaMethod and o.is_static == is_static and o.params == params
+	redef fun hash do return params.hash
 end
 
 # An attribute in a Java class

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -373,7 +373,7 @@ class JavaModel
 		object_type.identifier = ["java","lang","Object"]
 
 		# Fill POSet
-		for name, java_class in classes do
+		for name, java_class in all_classes do
 			# Skip anonymous classes
 			if java_class.class_type.is_anonymous then continue
 
@@ -387,7 +387,7 @@ class JavaModel
 			# Remove unavailable super classes
 			for super_type in super_classes.reverse_iterator do
 				# Is the super class available?
-				if not classes.keys.has(super_type.package_name) then super_classes.remove(super_type)
+				if not all_classes.keys.has(super_type.package_name) then super_classes.remove(super_type)
 			end
 
 			# If the is no explicit supers, add `java.lang.Object`
@@ -397,9 +397,9 @@ class JavaModel
 
 			for super_type in super_classes do
 				# Is the super class available?
-				if not classes.keys.has(super_type.package_name) then continue
+				if not all_classes.keys.has(super_type.package_name) then continue
 
-				var super_class = classes[super_type.package_name]
+				var super_class = all_classes[super_type.package_name]
 				class_hierarchy.add_edge(java_class, super_class)
 			end
 		end

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -287,6 +287,9 @@ class JavaModel
 		return classes
 	end
 
+	# Does this model have access to the `java.lang.Object`?
+	var knows_the_object_class: Bool = all_classes.keys.has("java.lang.Object") is lazy
+
 	# Add a class in `classes`
 	fun add_class(jclass: JavaClass)
 	do
@@ -390,8 +393,9 @@ class JavaModel
 				if not all_classes.keys.has(super_type.package_name) then super_classes.remove(super_type)
 			end
 
-			# If the is no explicit supers, add `java.lang.Object`
-			if super_classes.is_empty and java_class.class_type != object_type then
+			# If the is no explicit supers, add `java.lang.Object` (if it is known)
+			if super_classes.is_empty and java_class.class_type != object_type and
+			   knows_the_object_class then
 				super_classes.add object_type
 			end
 

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -15,12 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Contains the java and nit type representation used to convert java to nit code
-module model
+# Model of the parsed Java classes and their corresponding Nit types
+module model is serialize
 
 import more_collections
 import opts
 import poset
+import binary::serialization
 
 import jtype_converter
 
@@ -262,10 +263,10 @@ class JavaModel
 	end
 
 	# Unknown types, not already wrapped and not in this pass
-	var unknown_types = new HashMap[JavaType, NitType]
+	var unknown_types = new HashMap[JavaType, NitType] is noserialize
 
 	# Wrapped types, or classes analyzed in this pass
-	var known_types = new HashMap[JavaType, NitType]
+	var known_types = new HashMap[JavaType, NitType] is noserialize
 
 	# Get the `NitType` corresponding to the `JavaType`
 	#
@@ -331,7 +332,7 @@ class JavaModel
 	end
 
 	# Specialization hierarchy of `classes`
-	var class_hierarchy = new POSet[JavaClass]
+	var class_hierarchy = new POSet[JavaClass] is noserialize
 
 	# Fill `class_hierarchy`
 	fun build_class_hierarchy
@@ -528,7 +529,7 @@ redef class Sys
 	var opt_arrays = new OptionInt("Depth of the primitive array for each wrapped class (default: 1)", 1, "-a")
 end
 
-redef class Text
+redef abstract class Text
 	# Get a copy of `self` where the first letter is capitalized
 	fun simple_capitalized: String
 	do

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -177,6 +177,12 @@ class JavaClass
 	# Importations from this class
 	var imports = new HashSet[NitModule]
 
+	# Interfaces implemented by this class
+	var implements = new HashSet[JavaType]
+
+	# Super classes of this class
+	var extends = new HashSet[JavaType]
+
 	redef fun to_s do return class_type.to_s
 
 	# Resolve the types in `other` in the context of this class

--- a/lib/performance_analysis.nit
+++ b/lib/performance_analysis.nit
@@ -35,8 +35,8 @@
 # end
 #
 # assert sys.perfs["sleep 1ms"].count == 100
-# assert sys.perfs["sleep 1ms"].avg.is_approx(0.001, 0.0001)
-# assert sys.perfs["sleep 5ms"].avg.is_approx(0.005, 0.0005)
+# assert sys.perfs["sleep 1ms"].avg.is_approx(0.001, 0.001)
+# assert sys.perfs["sleep 5ms"].avg.is_approx(0.005, 0.005)
 # ~~~
 module performance_analysis
 


### PR DESCRIPTION
Continuing the work of #1578, #1589 and #1599, this PR adds the last big feature missing from jwrapper: duplicating the class hierarchy from Java to the generated wrapper classes. This allows user code to benefit from polymorphism when invoking Java methods wrappers.

This is done by collecting the implements and extends declaration from the javap output, rebuilding the class hierarchy and adding the super declarations needed to reproduce the hierarchy in Nit. To support a compatible hierarchy across modules, the model can now be serialized to a file and read by the following passes. Note that jwrapper wraps classes and interfaces in the same way so the implements and the extends hierarchy are merge into one on the Nit side.

What's to do next:
* Integrate generated modules in the `::java` and `::android` libraries!
* Add tools to extract concerns from a Jar archive to subdivide the wrappers in many modules. This could be done by targeting types, but more experimentation is needed.
* Clean up the duplicated features from the grep search and the serialized models. This is also an evolution as the grep features should be phased out in favor of a better `::java` lib and the serialized models.
* Automate declaring importations by using knowledge from the serialized models.
* Generate casts between the Java wrapper classes?
* Update the documentation with the latest changes.

What I'm probably not gonna do unless someone needs it:
* Full vararg types support, this would probably require using the JNI from C. In the time being, it can be done manually with a fixed number of parameters, as needed.