### PR TITLE
More abstract classes

### DIFF
--- a/lib/a_star.nit
+++ b/lib/a_star.nit
@@ -316,7 +316,7 @@ class AStarPath[N]
 end
 
 # Context related to an evocation of pathfinding
-class PathContext
+abstract class PathContext
 	serialize
 
 	# Type of the nodes in `graph`
@@ -400,7 +400,7 @@ class WeightedLink
 end
 
 # Advanced path conditions with customizable accept states
-class TargetCondition[N: Node]
+abstract class TargetCondition[N: Node]
 	serialize
 
 	# Should the pathfinding accept `node` as a goal?

--- a/lib/ai/backtrack.nit
+++ b/lib/ai/backtrack.nit
@@ -40,7 +40,7 @@ module backtrack
 # # Basic search
 #
 # The method `solve` returns a new solver for a backtrack search.
-class BacktrackProblem[S: Object,A]
+abstract class BacktrackProblem[S: Object,A]
 	# The starting state of the problem.
 	# It is this object that will be modified by `apply_action` and `backtrack`.
 	fun initial_state: S is abstract

--- a/lib/bucketed_game.nit
+++ b/lib/bucketed_game.nit
@@ -25,14 +25,14 @@ module bucketed_game is serialize
 import serialization
 
 # Something acting on the game
-class Turnable[G: Game]
+abstract class Turnable[G: Game]
 
 	# Execute `turn` for this instance.
 	fun do_turn(turn: GameTurn[G]) is abstract
 end
 
 # Something acting on the game from time to time
-class Bucketable[G: Game]
+abstract class Bucketable[G: Game]
 	super Turnable[G]
 
 	private var act_at: nullable Int = null

--- a/lib/github/hooks.nit
+++ b/lib/github/hooks.nit
@@ -51,7 +51,7 @@ import events
 import nitcorn
 
 # A nitcorn listener for Github hooks.
-class HookListener
+abstract class HookListener
 
 	# Api client used to perform Github API requests.
 	var api: GithubAPI

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -1838,7 +1838,7 @@ end
 
 # A markdown list line.
 # Mainly used to factorize code between ordered and unordered lists.
-class LineList
+abstract class LineList
 	super Line
 
 	redef fun process(v) do

--- a/lib/mnit/image_set.nit
+++ b/lib/mnit/image_set.nit
@@ -21,7 +21,7 @@ module image_set
 import assets
 
 # A set of images, look for sub-classes in projects using svg_to_png_and_nit
-class ImageSet
+abstract class ImageSet
 
 	# Load images to fill this image set
 	fun load_all(app: App) is abstract

--- a/lib/nitcc_runtime.nit
+++ b/lib/nitcc_runtime.nit
@@ -494,7 +494,7 @@ class Nodes[T: Node]
 end
 
 # A production with a specific, named and statically typed children
-class NProd
+abstract class NProd
 	super Node
 	redef var children: SequenceRead[nullable Node] = new NProdChildren(self)
 

--- a/src/parser/parser_nodes.nit
+++ b/src/parser/parser_nodes.nit
@@ -2189,7 +2189,7 @@ class AAmpExpr
 end
 
 # A unary operation on a method
-class AUnaryopExpr
+abstract class AUnaryopExpr
 	super ASendExpr
 
 	# The operator


### PR DESCRIPTION
The current leniency of abstract methods (see #808) make that a lot of concrete classes inherit abstract methods (I counted 5048 cases in the whole code base).
Some trivial cases are classes that just should be abstract.