### PR TITLE
c_tool: reorder CC arguments since the semantic between gcc and clang differs

### DIFF
--- a/src/c_tools.nit
+++ b/src/c_tools.nit
@@ -148,7 +148,7 @@ class ExternCFile
 		if not pkgconfigs.is_empty then
 			pkg = "`pkg-config --cflags {pkgconfigs.join(" ")}`"
 		end
-		return "$(CC) $(CFLAGS) -Wno-unused-function -Wall {self.cflags} {pkg} -c -o {o} {ff}"
+		return "$(CC) $(CFLAGS) -Wall -Wno-unused-function {self.cflags} {pkg} -c -o {o} {ff}"
 	end
 
 	redef fun compiles_to_o_file do return true


### PR DESCRIPTION
Just a reordering to really silent the warning on osx