### PR TITLE
Markdown fix

### DIFF
--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -2102,6 +2102,7 @@ abstract class TokenLinkOrImage
 					if pos == -1 then return -1
 				end
 			end
+			if pos < start then return -1
 			if md[pos] != ')' then return -1
 		else if md[pos] == '[' then
 			pos += 1


### PR DESCRIPTION
Fix a small bug in Markdown, in some cases pos could be negative if `skip_spaces` at line 2093 returned -1