### PR TITLE
Performance improvement in read_all_bytes

### DIFF
--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -156,7 +156,7 @@ class FileReader
 	init open(path: String)
 	do
 		self.path = path
-		prepare_buffer(10)
+		prepare_buffer(100)
 		_file = new NativeFile.io_open_read(path.to_cstring)
 		if _file.address_is_null then
 			last_error = new IOError("Cannot open `{path}`: {sys.errno.strerror}")

--- a/lib/standard/stream.nit
+++ b/lib/standard/stream.nit
@@ -518,14 +518,13 @@ abstract class BufferedReader
 	do
 		if last_error != null then return new Bytes.empty
 		var s = new Bytes.with_capacity(10)
+		var b = _buffer
 		while not eof do
 			var j = _buffer_pos
 			var k = _buffer_length
-			while j < k do
-				s.add(_buffer[j])
-				j += 1
-			end
-			_buffer_pos = j
+			var rd_sz = k - j
+			s.append_ns_from(b, rd_sz, j)
+			_buffer_pos = k
 			fill_buffer
 		end
 		return s


### PR DESCRIPTION
As @privat notified me of yesterday, a lot of time is wasted in read_all by boxing and unboxing bytes when doing the infamous `_buffer.add` operation in `read_all_bytes`.

This PR removes the boxing operations by bulk-writing a NativeString to a Bytes.
The buffer on files is also tenfold-bigger, which cuts I/O times while still retaining a reasonable size.

# Performances

On the Batmobile™

## Valgrind

Before:
standard___standard__BufferedReader___Reader__read_all_bytes: 90.816 MIr
After:
standard___standard__BufferedReader___Reader__read_all_bytes: 7.596 MIr

## ./ncall-best

Before
user	0m4.316s
After
user	0m4.182s

Close #1298