### PR TITLE
extends nitmd to handle manpages output format

### DIFF
--- a/lib/markdown/Makefile
+++ b/lib/markdown/Makefile
@@ -1,0 +1,6 @@
+NITC=../../bin/nitc
+
+all: nitmd
+
+nitmd: nitmd.nit
+	${NITC} $<

--- a/lib/markdown/decorators.nit
+++ b/lib/markdown/decorators.nit
@@ -70,7 +70,7 @@ class MdDecorator
 		in_orderedlist = true
 		current_li = 0
 		v.emit_in block
-		in_unorderedlist = false
+		in_orderedlist = false
 	end
 	private var in_orderedlist = false
 	private var current_li = 0

--- a/lib/markdown/man.nit
+++ b/lib/markdown/man.nit
@@ -1,0 +1,173 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple *groff* decorator restricted for manpages.
+module man
+
+import markdown
+
+# `Decorator` that outputs markdown.
+class ManDecorator
+	super Decorator
+
+	redef fun add_ruler(v, block) do v.add "***\n"
+
+	redef fun add_headline(v, block) do
+		var lvl = block.depth
+		if lvl == 1 then
+			v.add ".SH "
+		else if lvl == 2 then
+			v.add ".SS "
+		else if lvl >= 3 then
+			# We use dictionary (titled paragraph) to simulate a 3rd level (or more)
+			v.add ".TP\n"
+		end
+		v.emit_in block
+		v.addn
+	end
+
+	redef fun add_paragraph(v, block) do
+		if not in_unorderedlist and not in_orderedlist then
+			v.addn
+			v.emit_in block
+			v.addn
+		else
+			v.emit_in block
+		end
+	end
+
+	redef fun add_code(v, block) do
+		v.add ".RS\n.nf\n\\f[C]\n"
+		v.emit_in block
+		v.addn
+		v.add "\\f[]\n.fi\n.RE\n"
+	end
+
+	redef fun add_blockquote(v, block) do
+		v.add ".RS\n"
+		v.emit_in block
+		v.add ".RE\n"
+	end
+
+	redef fun add_unorderedlist(v, block) do
+		v.add ".RS\n"
+		in_unorderedlist = true
+		v.emit_in block
+		in_unorderedlist = false
+		v.add ".RE\n"
+	end
+	private var in_unorderedlist = false
+
+	redef fun add_orderedlist(v, block) do
+		v.add ".RS\n"
+		in_orderedlist = true
+		current_li = 0
+		v.emit_in block
+		in_orderedlist = false
+		v.add ".RE\n"
+	end
+	private var in_orderedlist = false
+	private var current_li = 0
+
+	redef fun add_listitem(v, block) do
+		if in_unorderedlist then
+			v.add ".IP \\[bu] 3\n"
+		else if in_orderedlist then
+			current_li += 1
+			v.add ".IP \"{current_li}.\" 3\n"
+		end
+		v.emit_in block
+		v.addn
+	end
+
+	redef fun add_em(v, text) do
+		v.add "\\f[I]"
+		v.add text
+		v.add "\\f[]"
+	end
+
+	redef fun add_strong(v, text) do
+		v.add "\\f[B]"
+		v.add text
+		v.add "\\f[]"
+	end
+
+	redef fun add_strike(v, text) do
+		v.add "[STRIKEOUT:"
+		v.add text
+		v.add "]"
+	end
+
+	redef fun add_image(v, link, name, comment) do
+		v.add name
+		v.add " ("
+		append_value(v, link)
+		if comment != null and not comment.is_empty then
+			v.add " "
+			append_value(v, comment)
+		end
+		v.add ")"
+	end
+
+	redef fun add_link(v, link, name, comment) do
+		v.add name
+		v.add " ("
+		append_value(v, link)
+		if comment != null and not comment.is_empty then
+			v.add " "
+			append_value(v, comment)
+		end
+		v.add ")"
+	end
+
+	redef fun add_abbr(v, name, comment) do
+		v.add "\">"
+		v.emit_text(name)
+		v.add " ("
+		append_value(v, comment)
+		v.add ")"
+	end
+
+	redef fun add_span_code(v, text, from, to) do
+		v.add "\\f[C]"
+		append_code(v, text, from, to)
+		v.add "\\f[]"
+	end
+
+	redef fun add_line_break(v) do
+		v.addn
+	end
+
+	redef fun append_value(v, text) do for c in text do escape_char(v, c)
+
+	redef fun add_char(v, c) do
+		# Escape - because manpages
+		if c == '-' then
+			v.addc '\\'
+		end
+		v.addc(c)
+	end
+
+	redef fun escape_char(v, c) do add_char(v, c)
+
+	redef fun append_code(v, buffer, from, to) do
+		for i in [from..to[ do
+			var c = buffer[i]
+			if c == '-' or c == ' ' then
+				v.addc '\\'
+			end
+			v.addc c
+		end
+	end
+end

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -646,6 +646,11 @@ interface Decorator
 	# Kind of emitter used for decoration.
 	type EMITTER: MarkdownEmitter
 
+	# Render a single plain char.
+	#
+	# Redefine this method to add special escaping for plain text.
+	fun add_char(v: EMITTER, c: Char) do v.addc c
+
 	# Render a ruler block.
 	fun add_ruler(v: EMITTER, block: BlockRuler) is abstract
 
@@ -1918,7 +1923,7 @@ abstract class Token
 	var char: Char
 
 	# Output that token using `MarkdownEmitter::decorator`.
-	fun emit(v: MarkdownEmitter) do v.addc char
+	fun emit(v: MarkdownEmitter) do v.decorator.add_char(v, char)
 end
 
 # A token without a specific meaning.

--- a/lib/markdown/nitmd.nit
+++ b/lib/markdown/nitmd.nit
@@ -16,12 +16,15 @@
 module nitmd
 
 import markdown
+import decorators
 
 import opts
 
 var options = new OptionContext
 var opt_help = new OptionBool("Show this help.", "-h", "-?", "--help")
 options.add_option(opt_help)
+var opt_to = new OptionString("Specify output format (html, md, man)", "-t", "--to")
+options.add_option(opt_to)
 
 options.parse(args)
 if options.rest.length != 1 then
@@ -41,4 +44,13 @@ var md = ifs.read_all
 ifs.close
 
 var processor = new MarkdownProcessor
+var to = opt_to.value
+if to == null or to == "html" then
+	# Noop
+else if to == "md" then
+	processor.emitter.decorator = new MdDecorator
+else
+	print "Unknown output format: {to}"
+	exit 1
+end
 print processor.process(md)

--- a/lib/markdown/nitmd.nit
+++ b/lib/markdown/nitmd.nit
@@ -17,6 +17,7 @@ module nitmd
 
 import markdown
 import decorators
+import man
 
 import opts
 
@@ -49,6 +50,8 @@ if to == null or to == "html" then
 	# Noop
 else if to == "md" then
 	processor.emitter.decorator = new MdDecorator
+else if to == "man" then
+	processor.emitter.decorator = new ManDecorator
 else
 	print "Unknown output format: {to}"
 	exit 1

--- a/lib/markdown/nitmd.nit
+++ b/lib/markdown/nitmd.nit
@@ -17,15 +17,23 @@ module nitmd
 
 import markdown
 
-if args.length != 1 then
-	print "usage: nitmd <file.md>"
-	exit 0
+import opts
+
+var options = new OptionContext
+var opt_help = new OptionBool("Show this help.", "-h", "-?", "--help")
+options.add_option(opt_help)
+
+options.parse(args)
+if options.rest.length != 1 then
+	print "usage: nitmd [-t format] <file.md>"
+	options.usage
+	exit 1
 end
 
-var file = args.first
+var file = options.rest.first
 if not file.file_exists then
 	print "'{file}' not found"
-	exit 0
+	exit 1
 end
 
 var ifs = new FileReader.open(file)

--- a/share/man/Makefile
+++ b/share/man/Makefile
@@ -15,11 +15,20 @@
 IN=$(wildcard nit*.md)
 OUT=$(patsubst %.md,man1/%.1,$(IN))
 
+MARKDOWN=../../lib/markdown
+NITMD=$(MARKDOWN)/nitmd
+
 all: $(OUT)
 
-man1/%.1: %.md
+
+man1/%.1: %.md $(NITMD)
 	mkdir -p man1
-	pandoc $< -t man -s -o $@
+	echo ".TH $* 1" > $@
+	$(NITMD) $< -t man >> $@
+
+
+$(NITMD):
+	$(MAKE) -C $(MARKDOWN)
 
 # Rule to produce mdwn files for ikiwiki that will be used at http://nitlanguage.org/tools/
 web:
@@ -27,7 +36,7 @@ web:
 	mkdir -p www
 	cp nit*.md www
 	rename '$$_ = "$${_}wn"' www/*.md
-	sed -i -e '1d;/SEE ALSO/,$$d' www/*.mdwn
+	sed -i -e '/SEE ALSO/,$$d' www/*.mdwn
 
 publish: web
 	rsync www/* asimov:wiki/nitlanguage/doc/tools/

--- a/share/man/nit.md
+++ b/share/man/nit.md
@@ -1,5 +1,3 @@
-% NIT(1)
-
 # NAME
 
 nit - interprets and debugs Nit programs.
@@ -55,60 +53,60 @@ Whatever follows it is used as arguments of the interpreted program.
 
 ## COMMAND
 
-`-e`
-:   Specifies the program from command-line.
+### `-e`
+Specifies the program from command-line.
 
-    The `-e` option runs a program written on the command line.
-    Like with ruby, perl, bash and other script language.
+The `-e` option runs a program written on the command line.
+Like with ruby, perl, bash and other script language.
 
-        $ nit -e 'print 5+5'
-        10
+    $ nit -e 'print 5+5'
+    10
 
-`-n`
-:   Repeatedly run the program for each line in file-name arguments.
+### `-n`
+Repeatedly run the program for each line in file-name arguments.
 
-    If no arguments are given, then `nit` iterates over the lines of the standard input (stdin).
+If no arguments are given, then `nit` iterates over the lines of the standard input (stdin).
 
-        $ echo "hello world" | nit -n -e 'print sys.line.capitalized'
-        Hello World
+    $ echo "hello world" | nit -n -e 'print sys.line.capitalized'
+    Hello World
 
-    If some arguments are given, then `nit` considers that each argument is a filepath then it iterates on their lines.
+If some arguments are given, then `nit` considers that each argument is a filepath then it iterates on their lines.
 
 ## INTERPRETATION OPTIONS
 
-`--discover-call-trace`
-:   Trace calls of the first invocation of methods.
+### `--discover-call-trace`
+Trace calls of the first invocation of methods.
 
-    Each time a method is invoked for the first time, its information is printed on the standard output for error (`stderr`).
+Each time a method is invoked for the first time, its information is printed on the standard output for error (`stderr`).
 
-    This option helps the user to have a simplified but humanly readable overview of the behavior of a particular program execution.
+This option helps the user to have a simplified but humanly readable overview of the behavior of a particular program execution.
 
 ## DEBUGGER OPTIONS
 
-`-d`
-:   Launches the target program with the debugger attached to it
+### `-d`
+Launches the target program with the debugger attached to it
 
-`-c`
-:   Launches the target program with the interpreter, such as when the program fails, the debugging prompt is summoned
+### `-c`
+Launches the target program with the interpreter, such as when the program fails, the debugging prompt is summoned
 
-`--socket`
-:   Launches the target program with raw output on the network via sockets
+### `--socket`
+Launches the target program with raw output on the network via sockets
 
-`--websocket`
-:   Launches the target program with output on the network via websockets
+### `--websocket`
+Launches the target program with output on the network via websockets
 
-`--port`
-:   Sets the debug port (Defaults to 22125) - Must be contained between 0 and 65535
+### `--port`
+Sets the debug port (Defaults to 22125) - Must be contained between 0 and 65535
 
 ## OTHER OPTIONS
 
-`--vm`
-:   Run the virtual machine instead of the naive interpreter (experimental)
+### `--vm`
+Run the virtual machine instead of the naive interpreter (experimental)
 
 The virtual machine is currently under heavy development and, unless you are developing the vm, there is no reason to use this option yet.
 
-`-o`
-:   Does nothing. Used for compatibility.
+### `-o`
+Does nothing. Used for compatibility.
 
 
 # DEBUGGER
@@ -139,58 +137,58 @@ If you want to trace the modifications or uses of a variable of your choice, the
 
 ## DEBUGGER COMMANDS
 
-`n`
-:   Proceeds to the next instruction (step-over)
+### `n`
+Proceeds to the next instruction (step-over)
 
-`s`
-:   Steps in an instruction
+### `s`
+Steps in an instruction
 
-`finish`
-:   Steps out of an instruction
+### `finish`
+Steps out of an instruction
 
-`c`
-:   Continues the execution until a breakpoint is encountered or until an error/end of program
+### `c`
+Continues the execution until a breakpoint is encountered or until an error/end of program
 
-`b/break line_number`
-:   Adds a breakpoint on line *line_number* for the current file
+### `b/break line_number`
+Adds a breakpoint on line *line_number* for the current file
 
-`b/break file line_number`
-:   Adds a breakpoint on line *line_number* for the file *file* (Don't forget to add the .nit extension to the command)
+### `b/break file line_number`
+Adds a breakpoint on line *line_number* for the file *file* (Don't forget to add the .nit extension to the command)
 
-`d/delete line_number`
-:   Removes a breakpoint on line *line_number* for the current file
+### `d/delete line_number`
+Removes a breakpoint on line *line_number* for the current file
 
-`d/delete file line_number`
-:   Removes a breakpoint on line *line_number* for the file *file*
+### `d/delete file line_number`
+Removes a breakpoint on line *line_number* for the file *file*
 
-`kill`
-:   Kills the current program (produces a stack trace)
+### `kill`
+Kills the current program (produces a stack trace)
 
-`variable = value`
-:   Sets the value of *variable* to *value* (Only supports primitive types for now : Bool, Char, Int, Float)
+### `variable = value`
+Sets the value of *variable* to *value* (Only supports primitive types for now : Bool, Char, Int, Float)
 
-`p/print variable_name`
-:   Prints the value of the variable *variable_name*
+### `p/print variable_name`
+Prints the value of the variable *variable_name*
 
-`p/print stack`
-:   Prints a stack trace starting with the current frame
+### `p/print stack`
+Prints a stack trace starting with the current frame
 
-`p/print variable_name[index]`
-:   Prints the value of the variable contained at the index *index* of variable *variable_name* (*variable_name* must be a subtype of SequenceRead)
+### `p/print variable_name[index]`
+Prints the value of the variable contained at the index *index* of variable *variable_name* (*variable_name* must be a subtype of SequenceRead)
 
-`p/print variable_name[index_from..index_to]`
-:   Prints the values of all the variables contained from index *index_from* up to *index_to* in the variable *variable_name*
+### `p/print variable_name[index_from..index_to]`
+Prints the values of all the variables contained from index *index_from* up to *index_to* in the variable *variable_name*
 
 All the print commands also work on any dimension SequenceRead collection.
 
-`variable_name as alias`
-:   Sets an alias *alias* for the variable *variable_name*
+### `variable_name as alias`
+Sets an alias *alias* for the variable *variable_name*
 
-`trace variable_name [break/print]`
-:   Traces the uses of the variable you chose to trace by printing the statement it appears in or by breaking on each use. (The [break/print] part is not mandatory, by default, the print option will be used)
+### `trace variable_name [break/print]`
+Traces the uses of the variable you chose to trace by printing the statement it appears in or by breaking on each use. (The [break/print] part is not mandatory, by default, the print option will be used)
 
-`untrace variable_name`
-:   Removes the trace on the variable you chose to trace earlier in the program
+### `untrace variable_name`
+Removes the trace on the variable you chose to trace earlier in the program
 
 
 # SEE ALSO

--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -1,5 +1,3 @@
-% NITC(1)
-
 # NAME
 
 nitc - compiles Nit programs.
@@ -46,214 +44,216 @@ See the documentation of these specific modules for details.
 
 ## MESSAGES
 
-`-W`, `--warn`
-:   Show additional warnings (advices).
+### `-W`, `--warn`
 
-    By default, only important warnings are displayed.
-    May be overridden by `-w`.
+Show additional warnings (advices).
 
-    Important warnings are displayed by default. A warning is considered important when:
+By default, only important warnings are displayed.
+May be overridden by `-w`.
 
-     * There is a simple correction.
-     * There is no reason to let the code this way.
-     * There is always a real issue (no false positive).
+Important warnings are displayed by default. A warning is considered important when:
 
-    Other warnings, called advices, are not displayed by default to avoid filling the terminal with
-    unwanted information.
-    A warning is considered an advice when:
+* There is a simple correction.
+* There is no reason to let the code this way.
+* There is always a real issue (no false positive).
 
-     * The correction could be complex. e.g. require a refactorisation or an API change.
-     * The correction cannot be done. e.g. Code that use a deprecated API for some compatibility reason.
-     * There is not a real issue (false positive). Note that this should be unlikely.
-     * Transitional: While a real important warning, it fires a lot in current code, so a transition is needed
-       in order to let people fix them before promoting the advice to an important warning.
+Other warnings, called advices, are not displayed by default to avoid filling the terminal with
+unwanted information.
+A warning is considered an advice when:
 
-`-w`, `--warning`
-:   Show/hide a specific warning.
+* The correction could be complex. e.g. require a refactorisation or an API change.
+* The correction cannot be done. e.g. Code that use a deprecated API for some compatibility reason.
+* There is not a real issue (false positive). Note that this should be unlikely.
+* Transitional: While a real important warning, it fires a lot in current code, so a transition is needed
+in order to let people fix them before promoting the advice to an important warning.
 
-    Each type of warning can be individually displayed or hidden.
-    The `-w` option takes the name of a warning (displayed at the end of the warning message, between parentheses) to activate it;
-    and "no-{name}" to disable it.
-    It has precedence over -q and -W.
-    Multiple `-w` can be given.
+### `-w`, `--warning`
 
-    To show only `missing-doc` warnings in standard"
+Show/hide a specific warning.
 
-        $ nitc -q -w missing-doc standard
+Each type of warning can be individually displayed or hidden.
+The `-w` option takes the name of a warning (displayed at the end of the warning message, between parentheses) to activate it;
+and "no-{name}" to disable it.
+It has precedence over -q and -W.
+Multiple `-w` can be given.
 
-    To show all warnings and advices, except `missing-doc`:
+To show only `missing-doc` warnings in standard"
 
-        $ nitc -W -w no-missing-doc standard
+    $ nitc -q -w missing-doc standard
 
-    To show important warnings except `useless-type-test`, but not advice except `missing-doc`:
+To show all warnings and advices, except `missing-doc`:
 
-        $ nitc -w missing-doc -w no-useless-type-test standard
+    $ nitc -W -w no-missing-doc standard
 
-`-q`, `--quiet`
-:   Do not show warnings.
-    May be overridden by `-w`
+To show important warnings except `useless-type-test`, but not advice except `missing-doc`:
 
-`--stop-on-first-error`
-:   Just display the first encountered error then stop.
+    $ nitc -w missing-doc -w no-useless-type-test standard
 
-    By default, nitc tries to detect and display more than one error before aborting the compilation.
+### `-q`, `--quiet`
+Do not show warnings.
+May be overridden by `-w`
 
-`--no-color`
-:   Do not use color to display errors and warnings.
+### `--stop-on-first-error`
+Just display the first encountered error then stop.
 
-    Also, do not echo the line.
-    This options is mainly used by scripts and tools that need parsable error messages.
+By default, nitc tries to detect and display more than one error before aborting the compilation.
 
-`-v`, `--verbose`
-:   Additional messages from the tool.
-    Multiple `-v` can be given to improve the verbosity.
+### `--no-color`
+Do not use color to display errors and warnings.
 
-    With one `-v`, there is constant number of lines.
-    With two `-v`, the number of lines is proportional to the number of modules.
-    With three `-v`, the number of lines is proportional to the number of definition of classes.
-    With four `-v`, the number of lines is proportional to the number of definition of properties.
+Also, do not echo the line.
+This options is mainly used by scripts and tools that need parsable error messages.
 
-`--log`
-:   Generate various log files.
+### `-v`, `--verbose`
+Additional messages from the tool.
+Multiple `-v` can be given to improve the verbosity.
 
-    The tool will generate some files in the logging directory (see `--log-dir`).
-    These files are intended to the advanced user and the developers of the tools.
+With one `-v`, there is constant number of lines.
+With two `-v`, the number of lines is proportional to the number of modules.
+With three `-v`, the number of lines is proportional to the number of definition of classes.
+With four `-v`, the number of lines is proportional to the number of definition of properties.
 
-`--log-dir`
-:   Directory where to generate log files.
+### `--log`
+Generate various log files.
 
-    By default the directory is called `logs` in the working directory.
+The tool will generate some files in the logging directory (see `--log-dir`).
+These files are intended to the advanced user and the developers of the tools.
+
+### `--log-dir`
+Directory where to generate log files.
+
+By default the directory is called `logs` in the working directory.
 
 
-`-h`, `-?`, `--help`
-:   Show Help (the list of options).
+### `-h`, `-?`, `--help`
+Show Help (the list of options).
 
-`--version`
-:   Show version and exit.
+### `--version`
+Show version and exit.
 
 
 ## PATHS
 
-`-I`, `--path`
-:   Add an additional include path.
+### `-I`, `--path`
+Add an additional include path.
 
-    This option is used to indicate an additional path of a directory containing Nit libraries.
+This option is used to indicate an additional path of a directory containing Nit libraries.
 
-    The path added with `-I` are searched before those added by the environment variable `NIT_PATH`.
+The path added with `-I` are searched before those added by the environment variable `NIT_PATH`.
 
-    May be used more than once.
+May be used more than once.
 
-`-o`, `--output`
-:   Output executable name.
+### `-o`, `--output`
+Output executable name.
 
-    Indicates the path and name of the produced executable.
+Indicates the path and name of the produced executable.
 
-    Note: it is better to use `--dir` if only the directory is important.
-    This way, the platform extension will be correctly set.
+Note: it is better to use `--dir` if only the directory is important.
+This way, the platform extension will be correctly set.
 
-    `-o` is not usable if multiple programs are compiled at once.
+### `-o` is not usable if multiple programs are compiled at once.
 
-`--dir`
-:   Output directory.
+### `--dir`
+Output directory.
 
-    Produce the executables in the given directory instead of the current directory.
+Produce the executables in the given directory instead of the current directory.
 
-`--nit-dir`
-:   Base directory of the Nit installation.
+### `--nit-dir`
+Base directory of the Nit installation.
 
-    Has precedence over the environment variable `NIT_DIR`.
+Has precedence over the environment variable `NIT_DIR`.
 
 ## COMPILATION
 
-`--compile-dir`
-:   Directory used to generate temporary files.
+### `--compile-dir`
+Directory used to generate temporary files.
 
-    By default, it is named `nit_compile` and created in the current directory and destroyed after the compilation.
+By default, it is named `nit_compile` and created in the current directory and destroyed after the compilation.
 
-    If the option `--compile_dir` or `--no-cc` is used, then the directory is not destroyed and let as is.
+If the option `--compile_dir` or `--no-cc` is used, then the directory is not destroyed and let as is.
 
-`--no-cc`
-:   Do not invoke the C compiler.
+### `--no-cc`
+Do not invoke the C compiler.
 
-    Files in the compilation directory are generated but the C compiler is not invoked.
+Files in the compilation directory are generated but the C compiler is not invoked.
 
-    This option is mainly used to produce C files distributable then compilable on system that do not have a Nit compiler (e.g. embedded system).
-    In this case, it is suggested to also use the options `--dir`, `--compile-dir` and `--semi-global`.
+This option is mainly used to produce C files distributable then compilable on system that do not have a Nit compiler (e.g. embedded system).
+In this case, it is suggested to also use the options `--dir`, `--compile-dir` and `--semi-global`.
 
-        $ nitc examples/hello_world.nit --no-cc --dir hello --compile-dir hello --semi-global
+    $ nitc examples/hello_world.nit --no-cc --dir hello --compile-dir hello --semi-global
 
-    Will produce a `hello` directory that contains the required C files to finish the compilation.
-    Only the C files required for the program are generated.
-    The final binary will be generated in the same directory.
+Will produce a `hello` directory that contains the required C files to finish the compilation.
+Only the C files required for the program are generated.
+The final binary will be generated in the same directory.
 
-    Note that, to be useful, the compilation directory is not destroyed when `--no-cc` is used.
+Note that, to be useful, the compilation directory is not destroyed when `--no-cc` is used.
 
-`-m`
-:   Additional module to mix-in.
+### `-m`
+Additional module to mix-in.
 
-    Additional modules are imported and refine the main module of the program.
-    This has basically the same effect than implementing a specific module that imports the main module of the program then each one of the mix-in modules.
-    May be used more than once.
+Additional modules are imported and refine the main module of the program.
+This has basically the same effect than implementing a specific module that imports the main module of the program then each one of the mix-in modules.
+May be used more than once.
 
-    This is option is used to weave additional behaviors to existing programs.
-    Modules designated to bring features to programs by refining basic or specialized services, without any intervention of the main program, are good candidates to be used with the `-m` option.
-    E.g. `hash_debug`.
+This is option is used to weave additional behaviors to existing programs.
+Modules designated to bring features to programs by refining basic or specialized services, without any intervention of the main program, are good candidates to be used with the `-m` option.
+E.g. `hash_debug`.
 
-    An other usage of the `-m` option is to compile program to a specific platform. E.g. `emscripten`  or `android`.
+An other usage of the `-m` option is to compile program to a specific platform. E.g. `emscripten`  or `android`.
 
-    A last usage is to develop programs as product lines with a main basic module (vanilla) and specific distinct features as flavor modules, then to combine them at compile-time.
+A last usage is to develop programs as product lines with a main basic module (vanilla) and specific distinct features as flavor modules, then to combine them at compile-time.
 
-        $ nitc prog_vanilla.nit -m feature_chocolate.nit -m feature_cherry.nit
+    $ nitc prog_vanilla.nit -m feature_chocolate.nit -m feature_cherry.nit
 
-`-D`, `--define`
-:   Define a specific property.
+### `-D`, `--define`
+Define a specific property.
 
-    The `-D` option allows to refine a top-level method at compile-time.
-    This has basically the same effect than implementing a specific module that imports the main module of the program and refines the designated methods.
+The `-D` option allows to refine a top-level method at compile-time.
+This has basically the same effect than implementing a specific module that imports the main module of the program and refines the designated methods.
 
-    The designated method must be top-level function with no parameters that returns a Bool, an Int or a String.
+The designated method must be top-level function with no parameters that returns a Bool, an Int or a String.
 
-    The argument of the `-D` option is "{name}={value}".
-    For Bool, the argument can also be just "{name}", in this case, the value is considered to be `true`.
+The argument of the `-D` option is "{name}={value}".
+For Bool, the argument can also be just "{name}", in this case, the value is considered to be `true`.
 
-        $ nitc foo.nit -D prefix=/opt/foo -D port=8080 -D with_ssl
+    $ nitc foo.nit -D prefix=/opt/foo -D port=8080 -D with_ssl
 
-`--release`
-:   Compile in release mode and finalize application.
+### `--release`
+Compile in release mode and finalize application.
 
-    Currently, this only affect the android platform.
+Currently, this only affect the android platform.
 
-`-g`, `--debug`
-:   Compile in debug mode.
+### `-g`, `--debug`
+Compile in debug mode.
 
-    Currently removes gcc optimizations.
-    Also preserves the source-files directory for C-debuggers.
+Currently removes gcc optimizations.
+Also preserves the source-files directory for C-debuggers.
 
-    For more debugging-related options, see also `--hardening` and `NIT_GC_OPTION`
+For more debugging-related options, see also `--hardening` and `NIT_GC_OPTION`
 
 ## COMPILATION MODES
 
-`nitc` includes distinct compilation modes.
+### `nitc` includes distinct compilation modes.
 
-`--separate`
-:   Use separate compilation (default mode).
+### `--separate`
+Use separate compilation (default mode).
 
-    In separate compilation, modules are compiled independently of their programs.
-    This makes the recompilation of programs faster since only the modified files need to be recompiled.
+In separate compilation, modules are compiled independently of their programs.
+This makes the recompilation of programs faster since only the modified files need to be recompiled.
 
-`--global`
-:   Use global compilation.
+### `--global`
+Use global compilation.
 
-    The produced executables may become huge and the compilation time is prohibitive.
-    But sometime, they are faster.
+The produced executables may become huge and the compilation time is prohibitive.
+But sometime, they are faster.
 
-    In practice, `--semi-global` produces nearly as fast but smaller executables.
+In practice, `--semi-global` produces nearly as fast but smaller executables.
 
-`--erasure`
-:   Erase generic types.
+### `--erasure`
+Erase generic types.
 
-    Like `--separate` but use an erasure dynamic typing policy for generics and virtual types.
-    Usually you do not need this, even if you understand the previous sentence.
+Like `--separate` but use an erasure dynamic typing policy for generics and virtual types.
+Usually you do not need this, even if you understand the previous sentence.
 
 
 ## SEMI-GLOBAL OPTIMIZATIONS
@@ -264,30 +264,30 @@ the independence on programs.
 Therefore, with these options, the produced executables may be faster and smaller but the recompilation time
 will increase.
 
-`--semi-global`
-:   Enable all semi-global optimizations.
+### `--semi-global`
+Enable all semi-global optimizations.
 
-`--rta`
-:   Activate RTA (Rapid Type Analysis).
+### `--rta`
+Activate RTA (Rapid Type Analysis).
 
-    This option only make sense in `--erasure` to enable some semi-global optimizations.
+This option only make sense in `--erasure` to enable some semi-global optimizations.
 
-    RTA is implicitly enabled in `--separate` and `--global`.
+RTA is implicitly enabled in `--separate` and `--global`.
 
-`--inline-coloring-numbers`
-:   Inline colors and ids (semi-global).
+### `--inline-coloring-numbers`
+Inline colors and ids (semi-global).
 
-`--inline-some-methods`
-:   Allow the separate compiler to inline some methods (semi-global).
-    Need `--rta`.
+### `--inline-some-methods`
+Allow the separate compiler to inline some methods (semi-global).
+Need `--rta`.
 
-`--direct-call-monomorph`
-:   Allow the separate compiler to direct call monomorphic sites (semi-global).
-    Need `--rta`.
+### `--direct-call-monomorph`
+Allow the separate compiler to direct call monomorphic sites (semi-global).
+Need `--rta`.
 
-`--skip-dead-methods`
-:   Do not compile dead methods (semi-global).
-    Need `--rta`.
+### `--skip-dead-methods`
+Do not compile dead methods (semi-global).
+Need `--rta`.
 
 ## LINK-BOOST OPTIMIZATIONS
 
@@ -296,29 +296,29 @@ In `--separate` and in `--erasure` modes, some optimization can be gained by hij
 Warning: these optimisations are not portable since they use extra features of the GNU linker `ld`.
 However, there is very few reasons to not use them if GNU `ld` is available.
 
-`--link-boost`
-:   Enable all link-boost optimizations.
+### `--link-boost`
+Enable all link-boost optimizations.
 
-`--colors-are-symbols`
-:   Store colors as symbols instead of static data.
+### `--colors-are-symbols`
+Store colors as symbols instead of static data.
 
-    By default, the various identifiers used to implement OO-mechanisms are stored as genuine constant static variables.
+By default, the various identifiers used to implement OO-mechanisms are stored as genuine constant static variables.
 
-    This option uses linker symbols to encode these identifiers.
-    This makes the compiled program faster since less indirections are required to get the values.
-    It also produces executables that are a little bit smaller since static memory does not have to store the colors.
+This option uses linker symbols to encode these identifiers.
+This makes the compiled program faster since less indirections are required to get the values.
+It also produces executables that are a little bit smaller since static memory does not have to store the colors.
 
-`--substitute-monomorph`
-:   Replace monomorphic trampolines with direct call.
+### `--substitute-monomorph`
+Replace monomorphic trampolines with direct call.
 
-    Late-binding is implemented with *trampolines*, that are small functions that just select and jump the to right implementations.
-    If, at link-time, is it known that the target will always by the same implementation then all calls to the trampoline are replaced by
-    direct calls to this single implementation.
+Late-binding is implemented with *trampolines*, that are small functions that just select and jump the to right implementations.
+If, at link-time, is it known that the target will always by the same implementation then all calls to the trampoline are replaced by
+direct calls to this single implementation.
 
-    Note that using trampolines as indirection slows down the executable.
-    However, it is expected that the gain of monomorphic direct-calls overcompensates the additional indirections in polymorphic trampoline-calls.
+Note that using trampolines as indirection slows down the executable.
+However, it is expected that the gain of monomorphic direct-calls overcompensates the additional indirections in polymorphic trampoline-calls.
 
-    Note: automatically enable option `--trampoline-call`.
+Note: automatically enable option `--trampoline-call`.
 
 ## DANGEROUS OPTIMIZATIONS
 
@@ -329,26 +329,26 @@ It also means that incorrect (buggy) programs may have unspecified behaviors
 
 In fact, these options are mainly used to bench the compilation results.
 
-`--no-check-all`
-:   Disable all tests (dangerous).
+### `--no-check-all`
+Disable all tests (dangerous).
 
-`--no-check-covariance`
-:   Disable type tests of covariant parameters (dangerous).
+### `--no-check-covariance`
+Disable type tests of covariant parameters (dangerous).
 
-`--no-check-attr-isset`
-:   Disable isset tests before each attribute access (dangerous).
+### `--no-check-attr-isset`
+Disable isset tests before each attribute access (dangerous).
 
-`--no-check-assert`
-:   Disable the evaluation of explicit `assert` and `as` (dangerous).
+### `--no-check-assert`
+Disable the evaluation of explicit `assert` and `as` (dangerous).
 
-`--no-check-autocast`
-:   Disable implicit casts on unsafe expression usage (dangerous).
+### `--no-check-autocast`
+Disable implicit casts on unsafe expression usage (dangerous).
 
-`--no-check-null`
-:   Disable tests of null receiver (dangerous).
+### `--no-check-null`
+Disable tests of null receiver (dangerous).
 
-`--no-check-erasure-cast`
-:   Disable implicit casts on unsafe return with erasure-typing policy (dangerous).
+### `--no-check-erasure-cast`
+Disable implicit casts on unsafe return with erasure-typing policy (dangerous).
 
 
 ## UNOPTIMIZATIONS
@@ -356,20 +356,20 @@ In fact, these options are mainly used to bench the compilation results.
 These options are used to debug or to bench the compilation results.
 Usually you do not need them since they make the generated code slower.
 
-`--hardening`
-:   Generate contracts in the C code against bugs in the compiler.
+### `--hardening`
+Generate contracts in the C code against bugs in the compiler.
 
-`--no-shortcut-range`
-:   Always instantiate a range and its iterator on 'for' loops.
+### `--no-shortcut-range`
+Always instantiate a range and its iterator on 'for' loops.
 
-`--no-union-attribute`
-:   Put primitive attributes in a box instead of an union.
+### `--no-union-attribute`
+Put primitive attributes in a box instead of an union.
 
-`--no-shortcut-equal`
-:   Always call == in a polymorphic way.
+### `--no-shortcut-equal`
+Always call == in a polymorphic way.
 
-`--no-tag-primitive`
-:   Use only boxes for primitive types.
+### `--no-tag-primitive`
+Use only boxes for primitive types.
 
 The separate compiler uses tagged values to encode common primitive types like Int, Bool and Char.
 This option disables tags and forces such primitive values to be boxed.
@@ -378,140 +378,140 @@ The drawback is that each boxing costs a memory allocation thus increases the am
 However, in some cases, it is possible that this option improves performance since the absence of tags simplify the implementation
 of OO mechanisms like method calls or equality tests.
 
-`--no-inline-intern`
-:   Do not inline call to intern methods.
+### `--no-inline-intern`
+Do not inline call to intern methods.
 
-`--colo-dead-methods`
-:   Force colorization of dead methods.
+### `--colo-dead-methods`
+Force colorization of dead methods.
 
-`--no-gcc-directive`
-:   Disable advanced gcc directives for optimization.
+### `--no-gcc-directive`
+Disable advanced gcc directives for optimization.
 
-`--trampoline-call`
-:   Use an indirection when calling.
+### `--trampoline-call`
+Use an indirection when calling.
 
-    Just add the trampolines of `--substitute-monomorph` without doing any aditionnal optimizations.
+Just add the trampolines of `--substitute-monomorph` without doing any aditionnal optimizations.
 
 ## INTERNAL OPTIONS
 
 These options can be used to control the fine behavior of the tool.
 They are useless for a normal user.
 
-`--disable-phase`
-:   Disable a specific phase; use `list` to get the list.
+### `--disable-phase`
+Disable a specific phase; use `list` to get the list.
 
-`--only-parse`
-:   Only proceed to parse files.
+### `--only-parse`
+Only proceed to parse files.
 
-`--only-metamodel`
-:   Stop after meta-model processing.
+### `--only-metamodel`
+Stop after meta-model processing.
 
-`--ignore-visibility`
-:   Do not check, and produce errors, on visibility issues.
+### `--ignore-visibility`
+Do not check, and produce errors, on visibility issues.
 
-`--no-main`
-:   Do not generate main entry point.
+### `--no-main`
+Do not generate main entry point.
 
-`--no-stacktrace`
-:   The compiled program will not display stack traces on runtime errors.
+### `--no-stacktrace`
+The compiled program will not display stack traces on runtime errors.
 
-    Because stack traces rely on libunwind, this option might be useful in order to generate more portable binaries
-    since libunwind might be non available on the runtime system (or available with an ABI incompatible version).
+Because stack traces rely on libunwind, this option might be useful in order to generate more portable binaries
+since libunwind might be non available on the runtime system (or available with an ABI incompatible version).
 
-    The generated C is API-portable and can be reused, distributed and compiled on any supported system.
-    If the option `--no-stacktrace` is not used but the development files of the library `libunwind` are not available, then a warning will be displayed
-    and stack trace will be disabled.
+The generated C is API-portable and can be reused, distributed and compiled on any supported system.
+If the option `--no-stacktrace` is not used but the development files of the library `libunwind` are not available, then a warning will be displayed
+and stack trace will be disabled.
 
-    Note that the `--no-stacktrace` option (or this absence) can be toggled manually in the generated Makefile (search `NO_STACKTRACE` in the Makefile).
-    Moreover, the environment variable `NIT_NO_STACK` (see bellow) can also be used at runtime to disable stack traces.
+Note that the `--no-stacktrace` option (or this absence) can be toggled manually in the generated Makefile (search `NO_STACKTRACE` in the Makefile).
+Moreover, the environment variable `NIT_NO_STACK` (see bellow) can also be used at runtime to disable stack traces.
 
-`--max-c-lines`
-:   Maximum number of lines in generated C files. Use 0 for unlimited.
+### `--max-c-lines`
+Maximum number of lines in generated C files. Use 0 for unlimited.
 
-`--group-c-files`
-:   Group all generated code in the same series of files.
+### `--group-c-files`
+Group all generated code in the same series of files.
 
-`--make-flags`
-:   Additional options to the `make` command.
+### `--make-flags`
+Additional options to the `make` command.
 
-          $ nitc foo.nit --make-flags 'CC=clang' --make-flags 'CFLAGS="-O0 -g"'
+      $ nitc foo.nit --make-flags 'CC=clang' --make-flags 'CFLAGS="-O0 -g"'
 
-`--typing-test-metrics`
-:   Enable static and dynamic count of all type tests.
+### `--typing-test-metrics`
+Enable static and dynamic count of all type tests.
 
-`--invocation-metrics`
-:   Enable static and dynamic count of all method invocations.
+### `--invocation-metrics`
+Enable static and dynamic count of all method invocations.
 
-`--isset-checks-metrics`
-:   Enable static and dynamic count of isset checks before attributes access.
+### `--isset-checks-metrics`
+Enable static and dynamic count of isset checks before attributes access.
 
-`--tables-metrics`
-:   Enable static size measuring of tables used for vft, typing and resolution.
+### `--tables-metrics`
+Enable static size measuring of tables used for vft, typing and resolution.
 
-`--set-dummy-tool`
-:   Set toolname and version to DUMMY. Useful for testing.
+### `--set-dummy-tool`
+Set toolname and version to DUMMY. Useful for testing.
 
-`--bash-completion`
-:   Generate bash_completion file for this program.
+### `--bash-completion`
+Generate bash_completion file for this program.
 
-`--stub-man`
-:   Generate a stub manpage in pandoc markdown format.
+### `--stub-man`
+Generate a stub manpage in pandoc markdown format.
 
-`--keep-going`
-:   Continue after errors, whatever the consequences.
+### `--keep-going`
+Continue after errors, whatever the consequences.
 
 The tool does not stop after some errors but continue until it produces incorrect result, crashes, erases the hard drive, or just continue forever in an infinite loop.
 This option is used to test the robustness of the tools by allowing phases to progress on incorrect data.
 
 # ENVIRONMENT VARIABLES
 
-`NIT_DIR`
-:   Base directory of the Nit installation.
+### `NIT_DIR`
+Base directory of the Nit installation.
 
-    When the `NIT_DIR` environment variable is set then it specifies the path of the Nit install directory.
+When the `NIT_DIR` environment variable is set then it specifies the path of the Nit install directory.
 
-    This directory is used to locate binaries, shared files and the common libraries.
+This directory is used to locate binaries, shared files and the common libraries.
 
-    When unset, the directory is guessed according to some heuristic.
+When unset, the directory is guessed according to some heuristic.
 
-    The `--nit-dir` option also set the base directory of the Nit installation but has precedence.
+The `--nit-dir` option also set the base directory of the Nit installation but has precedence.
 
-`NIT_PATH`
-:   Additional include paths.
+### `NIT_PATH`
+Additional include paths.
 
-    The `NIT_PATH` environment variable contains paths of directories containing Nit libraries.
-    Each path is separated with a column (`:`).
+The `NIT_PATH` environment variable contains paths of directories containing Nit libraries.
+Each path is separated with a column (`:`).
 
-    The `-I` option also add additional paths.
+The `-I` option also add additional paths.
 
-`NIT_GC_OPTION`
-:   Runtime control of the garbage collector.
+### `NIT_GC_OPTION`
+Runtime control of the garbage collector.
 
-    The behavior of the GC of the executables produced by nitc can be tuned with this environment variable.
+The behavior of the GC of the executables produced by nitc can be tuned with this environment variable.
 
-    The environment variable is used when programs are executed, not when they are compiled.
-    Thus, you do not need to recompile programs in order to tweak their GC options.
+The environment variable is used when programs are executed, not when they are compiled.
+Thus, you do not need to recompile programs in order to tweak their GC options.
 
-    Available values are:
+Available values are:
 
-    * boehm: use the Boehm-Demers-Weiser's conservative garbage collector (default).
-    * malloc: disable the GC and just use `malloc` without doing any `free`.
-    * large: disable the GC and just allocate a large memory area to use for all instantiation.
-    * help: show the list of available options.
+* boehm: use the Boehm-Demers-Weiser's conservative garbage collector (default).
+* malloc: disable the GC and just use `malloc` without doing any `free`.
+* large: disable the GC and just allocate a large memory area to use for all instantiation.
+* help: show the list of available options.
 
-`NIT_NO_STACK`
-:   Runtime control of stack traces.
+### `NIT_NO_STACK`
+Runtime control of stack traces.
 
-    By default, stack traces are printed when a runtime errors occurs during the execution of a compiled program.
-    When setting this environment variable to a non empty value, such stack traces are disabled.
+By default, stack traces are printed when a runtime errors occurs during the execution of a compiled program.
+When setting this environment variable to a non empty value, such stack traces are disabled.
 
-    The environment variable is used when programs are executed, not when they are compiled.
-    Thus, you do not need to recompile programs in order to disable generated stack traces.
+The environment variable is used when programs are executed, not when they are compiled.
+Thus, you do not need to recompile programs in order to disable generated stack traces.
 
-    Note that stack traces require that, during the compilation, development files of the library `libunwind` are available.
-    If they are not available, then programs are compiled without any stack trace support.
+Note that stack traces require that, during the compilation, development files of the library `libunwind` are available.
+If they are not available, then programs are compiled without any stack trace support.
 
-    To completely disable stack traces, see the option `--no-stacktrace`.
+To completely disable stack traces, see the option `--no-stacktrace`.
 
 # SEE ALSO
 

--- a/share/man/nitdbg_client.md
+++ b/share/man/nitdbg_client.md
@@ -1,5 +1,3 @@
-% NITDBG_CLIENT(1)
-
 # NAME
 
 nitdbg_client - network client for remote debugging.
@@ -16,13 +14,13 @@ See the interpreter command `nit(1)` for details about remote debugging.
 
 # OPTIONS
 
-`--host`
-:   Sets the host to debug from, use IPV4 only. (Defaults to 127.0.0.1).
+### `--host`
+Sets the host to debug from, use IPV4 only. (Defaults to 127.0.0.1).
 
-`--port`
-:   Sets the debug port (Defaults to 22125).
+### `--port`
+Sets the debug port (Defaults to 22125).
 
-    Must be contained between 0 and 65535
+Must be contained between 0 and 65535
 
 # SEE ALSO
 

--- a/share/man/nitdoc.md
+++ b/share/man/nitdoc.md
@@ -1,5 +1,3 @@
-% NITDOC(1)
-
 # NAME
 
 nitdoc - generates HTML pages of API documentation from Nit source files.
@@ -29,89 +27,89 @@ The format of the documentation is a dialect of [markdown] that allows GitHub fe
 
 Code blocks are interpreted as snippets of Nit programs and intended to be used as examples of code.
 When these code snippets are valid, executable and contain at least and `assert` clause, they could be automatically executed and verified.
-See niunit(1) for details.
+See `nitunit(1)` for details.
 
   [markdown]: http://daringfireball.net/projects/markdown
 
 # OPTIONS
 
-`-d`, `--dir`
-:   output directory.
+### `-d`, `--dir`
+output directory.
 
-    Where the HTML files are generated.
+Where the HTML files are generated.
 
-    By default, the directory is named `doc`.
+By default, the directory is named `doc`.
 
-`--source`
-:   Format to link source code.
+### `--source`
+Format to link source code.
 
-    The format string is used to generated links to some parts of the source-code.
-    Use `%f` for filename, `%l` for first line, and `%L` for last line.
+The format string is used to generated links to some parts of the source-code.
+Use `%f` for filename, `%l` for first line, and `%L` for last line.
 
-    For instance, the [standard library] use the following value to link to files in GitHub:
+For instance, the [standard library] use the following value to link to files in GitHub:
 
-        "https://github.com/privat/nit/blob/$(git rev-parse HEAD)/%f#L%l-%L"
+    "https://github.com/privat/nit/blob/$(git rev-parse HEAD)/%f#L%l-%L"
 
-    Here, the `git rev-parse HEAD` is used to link to the current snapshot revision of the file.
+Here, the `git rev-parse HEAD` is used to link to the current snapshot revision of the file.
 
-`--no-attribute`
-:   Ignore the attributes.
+### `--no-attribute`
+Ignore the attributes.
 
-    Note: In Nit, attributes are private. Therefore, this option is only useful
-    when combined with `--private`.
+Note: In Nit, attributes are private. Therefore, this option is only useful
+when combined with `--private`.
 
-`--no-dot`
-:   do not generate graphs with graphviz.
+### `--no-dot`
+do not generate graphs with graphviz.
 
-`--private`
-:   also generate private API.
+### `--private`
+also generate private API.
 
 ## CUSTOMIZATION
 
-`--sharedir`
-:   directory containing nitdoc assets.
+### `--sharedir`
+directory containing nitdoc assets.
 
-    By default `$NIT_DIR/share/nitdoc/` is used.
+By default `$NIT_DIR/share/nitdoc/` is used.
 
-`--shareurl`
-:   use shareurl instead of copy shared files.
+### `--shareurl`
+use shareurl instead of copy shared files.
 
-    By default, assets from the sharedir a copied into the output directory and refered with a relative path in the generated files.
-    Whith this option, the assets are not copied and the given URL of path is used in the generated files to locate assets.
+By default, assets from the sharedir a copied into the output directory and referred with a relative path in the generated files.
+With this option, the assets are not copied and the given URL of path is used in the generated files to locate assets.
 
-`--custom-title`
-:   custom title for homepage.
+### `--custom-title`
+custom title for homepage.
 
-`--custom-footer-text`
-:   custom footer text.
+### `--custom-footer-text`
+custom footer text.
 
-`--custom-overview-text`
-:   custom intro text for homepage
+### `--custom-overview-text`
+custom intro text for homepage
 
-`--custom-brand`
-:   custom link to external site
+### `--custom-brand`
+custom link to external site
 
 ## SERVICES
 
-`--github-upstream`
-:   Git branch where edited commits will be pulled into (ex: user:repo:branch)
+### `--github-upstream`
+Git branch where edited commits will be pulled into (ex: user:repo:branch)
 
-`--github-base-sha1`
-:   Git sha1 of base commit used to create pull request
+### `--github-base-sha1`
+Git sha1 of base commit used to create pull request
 
-`--github-gitdir`
-:   Git working directory used to resolve path name (ex: /home/me/myproject/)
+### `--github-gitdir`
+Git working directory used to resolve path name (ex: /home/me/myproject/)
 
-`--piwik-tracker`
-:   Piwik tracker URL (ex: `"nitlanguage.org/piwik/"`)
+### `--piwik-tracker`
+Piwik tracker URL (ex: `"nitlanguage.org/piwik/"`)
 
-`--piwik-site-id`
-:   Piwik site ID
+### `--piwik-site-id`
+Piwik site ID
 
 ## TESTING
 
-`--test`
-:   Only print the pages structure. Nothing is generated.
+### `--test`
+Only print the pages structure. Nothing is generated.
 
 # SEE ALSO
 

--- a/share/man/nitlight.md
+++ b/share/man/nitlight.md
@@ -1,5 +1,3 @@
-% NITLIGHT(1)
-
 # NAME
 
 nitlight - generates HTML of highlighted code from Nit source files.
@@ -17,49 +15,49 @@ Unlike generic lexical or syntactic highlighter, nitlight use semantic informati
 Common options of the Nit tools are understood.
 Here, only the specific one are indicated.
 
-`-f`, `--fragment`
-:   Omit document header and footer.
+### `-f`, `--fragment`
+Omit document header and footer.
 
-    By default, a complete autonomous HTML document is generated.
-    If `-f` is given, only the inside of the body part is generated such that it could be integrated
-    into a HTML document.
+By default, a complete autonomous HTML document is generated.
+If `-f` is given, only the inside of the body part is generated such that it could be integrated
+into a HTML document.
 
-`--line-id-prefix`
-:   Prefix of the id of each line `<span>` element.
+### `--line-id-prefix`
+Prefix of the id of each line `<span>` element.
 
-    By default, each line is enclosed in its own `<span>` element with an `id` attribute made of the line number prefixed by `L` (e.g. `L1` for the first line).
+By default, each line is enclosed in its own `<span>` element with an `id` attribute made of the line number prefixed by `L` (e.g. `L1` for the first line).
 
-    This option changes the prefix used.
-    If an empty string is used, then the `<span>` are generated without `id` attributes.
+This option changes the prefix used.
+If an empty string is used, then the `<span>` are generated without `id` attributes.
 
-    This option is especially usuful with `--fragment` when more than one highlighted code is
-    included in the same HTML document.
-    Each fragment can thus be generated with its own distinct prefix, or the id can be disabled alltogether.
+This option is especially useful with `--fragment` when more than one highlighted code is
+included in the same HTML document.
+Each fragment can thus be generated with its own distinct prefix, or the id can be disabled altogether.
 
-`--first-line`
-:   Start the source file at this line (default: 1).
+### `--first-line`
+Start the source file at this line (default: 1).
 
-    The generated HTML will only contains lines bellow the specified one.
+The generated HTML will only contains lines bellow the specified one.
 
-`--last-line`
-:   End the source file at this line (default: to the end)
+### `--last-line`
+End the source file at this line (default: to the end)
 
-    The generated HTML will only contains lines ebove the specified one.
+The generated HTML will only contains lines above the specified one.
 
-`-d`, `--dir`
-:   Output html files in a specific directory (required if more than one module).
+### `-d`, `--dir`
+Output html files in a specific directory (required if more than one module).
 
-    By default the generated HTML is outputted on the screen.
-    If this option is used, then HTML files are generated in the specified directory.
+By default the generated HTML is outputted on the screen.
+If this option is used, then HTML files are generated in the specified directory.
 
-    A basic `index.heml` and a `style.css` file are also generated in the directory.
+A basic `index.heml` and a `style.css` file are also generated in the directory.
 
-`--full`
-:   Process also imported modules.
+### `--full`
+Process also imported modules.
 
-    By default, only the modules indicated on the command line are highlighted.
+By default, only the modules indicated on the command line are highlighted.
 
-    With the `--full` option, all imported modules (even those in standard) are also precessed.
+With the `--full` option, all imported modules (even those in standard) are also precessed.
 
 # SEE ALSO
 

--- a/share/man/nitls.md
+++ b/share/man/nitls.md
@@ -1,5 +1,3 @@
-% NITLS(1)
-
 # NAME
 
 nitls - lists the projects, groups and paths of Nit sources files.
@@ -45,20 +43,20 @@ Each combination of option
 
 Three presentation modes are available.
 
-`-P`, `--project`
-:   List projects in a flat list (default).
+### `-P`, `--project`
+List projects in a flat list (default).
 
-    Only project are displayed (and not the individual files).
+Only project are displayed (and not the individual files).
 
-`-t`, `--tree`
-:   List source files in their groups and projects.
+### `-t`, `--tree`
+List source files in their groups and projects.
 
-    Each `.nit` file is presented in a tree of projects and groups.
+Each `.nit` file is presented in a tree of projects and groups.
 
-`-s`, `--source`
-:   List source files in a flat list.
+### `-s`, `--source`
+List source files in a flat list.
 
-    Each `.nit` file is presented indivitually.
+Each `.nit` file is presented indivitually.
 
 The three modes are exclusives.
 
@@ -66,37 +64,37 @@ The default mode is `--project` unless one on the argument is a group, then it i
 
 ## COLLECT
 
-`-r`, `--recursive`
-:   Process directories recursively.
+### `-r`, `--recursive`
+Process directories recursively.
 
-    All `.nit` files found in the specified directory and subdirectories are considered.
+All `.nit` files found in the specified directory and subdirectories are considered.
 
-`-d`, `--depends`
-:   List dependencies of given modules
+### `-d`, `--depends`
+List dependencies of given modules
 
-    All imported modules are also considered.
+All imported modules are also considered.
 
-    In --tree and --source modes, the modules direclty imported are also displayed.
+In --tree and --source modes, the modules direclty imported are also displayed.
 
-`-k`, `--keep`
-:   Ignore errors and files that are not a Nit source file.
+### `-k`, `--keep`
+Ignore errors and files that are not a Nit source file.
 
-    When a file that is not a valid Nit module is encoutered, it is ignored and the rest of the files are
-    processed.
+When a file that is not a valid Nit module is encoutered, it is ignored and the rest of the files are
+processed.
 
-    Without this option, an error message is displayed and nitls terminates on such a case.
+Without this option, an error message is displayed and nitls terminates on such a case.
 
 ## PRESENTATION OPTIONS
 
-`-p`, `--path`
-:   List only path (instead of name + path).
+### `-p`, `--path`
+List only path (instead of name + path).
 
-    Paths are displayed uncolored.
+Paths are displayed uncolored.
 
-`-M`
-:   List dependencies suitable for a rule in a Makefile.
+### `-M`
+List dependencies suitable for a rule in a Makefile.
 
-    Alias for `-d`, `-p` and `-s`.
+Alias for `-d`, `-p` and `-s`.
 
 # SEE ALSO
 

--- a/share/man/nitmetrics.md
+++ b/share/man/nitmetrics.md
@@ -1,5 +1,3 @@
-% NITMETRICS(1)
-
 # NAME
 
 nitmetrics -- computes various metrics on Nit programs.
@@ -12,63 +10,63 @@ nitmetrics [*options*]... FILE...
 
 ## METRICS
 
-`--all`
-:   Compute all metrics
+### `--all`
+Compute all metrics
 
-`--mmodules`
-:   Compute metrics about mmodules
+### `--mmodules`
+Compute metrics about mmodules
 
-`--mclasses`
-:   Compute metrics about mclasses
+### `--mclasses`
+Compute metrics about mclasses
 
-`--mendel`
-:   Compute mendel metrics
+### `--mendel`
+Compute mendel metrics
 
-`--inheritance`
-:   Compute metrics about inheritance usage
+### `--inheritance`
+Compute metrics about inheritance usage
 
-`--refinement`
-:   Compute metrics about refinement usage
+### `--refinement`
+Compute metrics about refinement usage
 
-`--self`
-:   Compute metrics about the usage of explicit and implicit self
+### `--self`
+Compute metrics about the usage of explicit and implicit self
 
-`--ast`
-:   Compute metrics about the usage of nodes and identifiers in the AST
+### `--ast`
+Compute metrics about the usage of nodes and identifiers in the AST
 
-`--nullables`
-:   Compute metrics on nullables send
+### `--nullables`
+Compute metrics on nullables send
 
-`--static-types`
-:   Compute explicit static types metrics
+### `--static-types`
+Compute explicit static types metrics
 
-`--tables`
-:   Compute tables metrics
+### `--tables`
+Compute tables metrics
 
-`--rta`
-:   Compute RTA metrics
+### `--rta`
+Compute RTA metrics
 
-`--generate_hyperdoc`
-:   Generate Hyperdoc
+### `--generate_hyperdoc`
+Generate Hyperdoc
 
-`--poset`
-:   Complete metrics on posets
+### `--poset`
+Complete metrics on posets
 
-`--detect-variance-constraints`
-:   Detects the definition-site variance constraints on formal parameters.
+### `--detect-variance-constraints`
+Detects the definition-site variance constraints on formal parameters.
 
-    Infers the possible variance annotations of formal types in Nit programs by identifying the existing constraints on the usage of those formal type.
+Infers the possible variance annotations of formal types in Nit programs by identifying the existing constraints on the usage of those formal type.
 
 ## OUTPUT
 
-`--csv`
-:   Also export metrics in CSV format.
+### `--csv`
+Also export metrics in CSV format.
 
-`-d`, `--dir`
-:   Directory where some statistics files are generated.
+### `-d`, `--dir`
+Directory where some statistics files are generated.
 
-`--no-colors`
-:   Disable colors in console outputs.
+### `--no-colors`
+Disable colors in console outputs.
 
 # SEE ALSO
 

--- a/share/man/nitpick.md
+++ b/share/man/nitpick.md
@@ -1,5 +1,3 @@
-% NITPICK(1)
-
 # NAME
 
 nitpick - collect potential style and code issues.

--- a/share/man/nitpretty.md
+++ b/share/man/nitpretty.md
@@ -1,5 +1,3 @@
-% NITPRETTY(1)
-
 # NAME
 
 nitpretty - pretty print Nit code from Nit source files.
@@ -10,36 +8,36 @@ nitpretty [*options*]... FILE
 
 # OPTIONS
 
-`--dir`
-:   Working directory (default is '.nitpretty')
+### `--dir`
+Working directory (default is '.nitpretty')
 
-`-o`, `--output`
-:   Output name (default is pretty.nit)
+### `-o`, `--output`
+Output name (default is pretty.nit)
 
-`--diff`
-:   Show diff between source and output
+### `--diff`
+Show diff between source and output
 
-`--meld`
-:   Show diff between source and output using meld
+### `--meld`
+Show diff between source and output using meld
 
-`--check`
-:   Check format of Nit source files
+### `--check`
+Check format of Nit source files
 
-    This option creates a temporary pretty printed file then checks if the output
-    of the diff command on the source file and the pretty printed one is empty.
+This option creates a temporary pretty printed file then checks if the output
+of the diff command on the source file and the pretty printed one is empty.
 
-`--break-strings`
-:   Break too long string literals
+### `--break-strings`
+Break too long string literals
 
-`--inline-do`
-:   Force do keyword on the same line as the method signature
+### `--inline-do`
+Force do keyword on the same line as the method signature
 
-`--skip-empty`
-:   Force formatting of empty lines
+### `--skip-empty`
+Force formatting of empty lines
 
-    By default empty lines are kept as they were typed in the file.
-    When enabling this option, `nitpretty` will decide where to break lines and
-    will put empty lines to separate properties and code blocks.
+By default empty lines are kept as they were typed in the file.
+When enabling this option, `nitpretty` will decide where to break lines and
+will put empty lines to separate properties and code blocks.
 
 # SPECIFICATION
 

--- a/share/man/nitserial.md
+++ b/share/man/nitserial.md
@@ -1,5 +1,3 @@
-% NITSERIAL(1)
-
 # NAME
 
 nitserial - generates a serialization support module
@@ -10,11 +8,11 @@ nitserial [*options*]... FILE
 
 # OPTIONS
 
-`-o`, `--output`
-:   Output file (can also be 'stdout')
+### `-o`, `--output`
+Output file (can also be 'stdout')
 
-`--dir`
-:   Output directory
+### `--dir`
+Output directory
 
 # SEE ALSO
 

--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -1,5 +1,3 @@
-% NITUNIT(1)
-
 # NAME
 
 nitunit - executes the unit tests from Nit source files.
@@ -32,24 +30,28 @@ The execution can be verified using `assert`.
 
 Example with a class:
 
-    module foo
-    #    var foo = new Foo
-    #    assert foo.bar == 10
-    class Foo
-        var bar = 10
-    end
+~~~
+module foo
+#    var foo = new Foo
+#    assert foo.bar == 10
+class Foo
+    var bar = 10
+end
+~~~
 
 Everything used in the test must be declared.
 To test a method you have to instantiate its class:
 
-    module foo
+~~~
+module foo
+#    var foo = new Foo
+#    assert foo.bar == 10
+class Foo
     #    var foo = new Foo
-    #    assert foo.bar == 10
-    class Foo
-        #    var foo = new Foo
-        #    assert foo.baz(1, 2) == 3
-        fun baz(a, b: Int) do return a + b
-    end
+    #    assert foo.baz(1, 2) == 3
+    fun baz(a, b: Int) do return a + b
+end
+~~~
 
 In a single piece of documentation, each docunit is considered a part of a single module, thus regrouped when
 tested.
@@ -125,16 +127,18 @@ So for the module `foo.nit` the test suite will be called `test_foo.nit`.
 
 The structure of a test suite is the following:
 
-    # test suite for module `foo`
-    module test_foo
-    import foo # can be intrude to test private things
-    class TestFoo
-        # test case for `foo::Foo::baz`
-        fun test_baz do
-            var subject = new Foo
-            assert subject.baz(1, 2) == 3
-        end
+~~~~
+# test suite for module `foo`
+module test_foo
+import foo # can be intrude to test private things
+class TestFoo
+    # test case for `foo::Foo::baz`
+    fun test_baz do
+        var subject = new Foo
+        assert subject.baz(1, 2) == 3
     end
+end
+~~~~
 
 Test suite can be executed using the same `nitunit` command:
 
@@ -143,112 +147,118 @@ Test suite can be executed using the same `nitunit` command:
 `nitunit` will execute a test for each method named `test_*` in a class named `Test*`
 so multiple tests can be executed for a single method:
 
-    class TestFoo
-        fun test_baz_1 do
-            var subject = new Foo
-            assert subject.baz(1, 2) == 3
-        end
-        fun test_baz_2 do
-            var subject = new Foo
-            assert subject.baz(1, -2) == -1
-        end
+~~~~
+class TestFoo
+    fun test_baz_1 do
+        var subject = new Foo
+        assert subject.baz(1, 2) == 3
     end
+    fun test_baz_2 do
+        var subject = new Foo
+        assert subject.baz(1, -2) == -1
+    end
+end
+~~~~
 
 `TestSuites` also provide methods to configure the test run:
 
 `before_test` and `after_test`: methods called before/after each test case.
 They can be used to factorize repetitive tasks:
 
-    class TestFoo
-        var subject: Foo
-        # Mandatory empty init
-        init do end
-        # Method executed before each test
-        fun before_test do
-            subject = new Foo
-        end
-        fun test_baz_1 do
-            assert subject.baz(1, 2) == 3
-        end
-        fun test_baz_2 do
-            assert subject.baz(1, -2) == -1
-        end
+~~~~
+class TestFoo
+    var subject: Foo
+    # Mandatory empty init
+    init do end
+    # Method executed before each test
+    fun before_test do
+        subject = new Foo
     end
+    fun test_baz_1 do
+        assert subject.baz(1, 2) == 3
+    end
+    fun test_baz_2 do
+        assert subject.baz(1, -2) == -1
+    end
+end
+~~~~
 
 When using custom test attributes, an empty `init` must be declared to allow automatic test running.
 
 `before_module` and `after_module`: methods called before/after each test suite.
 They have to be declared at top level:
 
-    module test_bdd_connector
-    import bdd_connector
-    # Testing the bdd_connector
-    class TestConnector
-        # test cases using a server
-    end
-    # Method executed before testing the module
-    fun before_module do
-        # start server before all test cases
-    end
-    # Method executed after testing the module
-    fun after_module do
-        # stop server after all test cases
-    end
+~~~~
+module test_bdd_connector
+import bdd_connector
+# Testing the bdd_connector
+class TestConnector
+    # test cases using a server
+end
+# Method executed before testing the module
+fun before_module do
+    # start server before all test cases
+end
+# Method executed after testing the module
+fun after_module do
+    # stop server after all test cases
+end
+~~~~
 
 ## Generating test suites
 
- Write test suites for big modules can be a repetitive and boring task...
- To make it easier, `nitunit` can generate test skeletons for Nit modules:
+Write test suites for big modules can be a repetitive and boring task...
+To make it easier, `nitunit` can generate test skeletons for Nit modules:
 
     $ nitunit --gen-suite foo.nit
 
- This will generate the test suite `test_foo` containing test case stubs for all public
- methods found in `foo.nit`.
+This will generate the test suite `test_foo` containing test case stubs for all public
+methods found in `foo.nit`.
 
 
 # OPTIONS
 
-`--full`
-:   Process also imported modules.
+### `--full`
+Process also imported modules.
 
-    By default, only the modules indicated on the command line are tested.
+By default, only the modules indicated on the command line are tested.
 
-    With the `--full` option, all imported modules (even those in standard) are also precessed.
+With the `--full` option, all imported modules (even those in standard) are also precessed.
 
-`-o`, `--output`
-:   Output name (default is 'nitunit.xml')
+### `-o`, `--output`
+Output name (default is 'nitunit.xml')
 
-    `nitunit` produces a XML file comatible with JUnit.
+### `nitunit` produces a XML file comatible with JUnit.
 
-`--dir`
-:   Working directory (default is '.nitunit')
+### `--dir`
+Working directory (default is '.nitunit')
 
-    In order to execute the tests, nit files are generated then compiled and executed in the giver working directory.
+In order to execute the tests, nit files are generated then compiled and executed in the giver working directory.
 
-`--no-act`
-:   Does not compile and run tests.
+### `--no-act`
+Does not compile and run tests.
 
-`-p`, `--pattern`
-:   Only run test case with name that match pattern. Examples: `TestFoo`, `TestFoo*`, `TestFoo::test_foo`, `TestFoo::test_foo*`, `test_foo`, `test_foo*`
+### `-p`, `--pattern`
+Only run test case with name that match pattern. Examples: `TestFoo`, `TestFoo*`, `TestFoo::test_foo`, `TestFoo::test_foo*`, `test_foo`, `test_foo*`
 
-`-t`, `--target-file`
-:   Specify test suite location.
+### `-t`, `--target-file`
+Specify test suite location.
 
 ## SUITE GENERATION
 
-`--gen-suite`
-:   Generate test suite skeleton for a module
+### `--gen-suite`
+Generate test suite skeleton for a module
 
-`-f`, `--force`
-:   Force test generation even if file exists.
+### `-f`, `--force`
+Force test generation even if file exists.
 
-    Any existing test suite will be overwritten.
+Any existing test suite will be overwritten.
 
-`--private`
-:   Also generate test case for private methods.
+### `--private`
+Also generate test case for private methods.
 
-`--only-show`
-:   Only display the skeleton, do not write any file.
+### `--only-show`
+Only display the skeleton, do not write any file.
 
 # SEE ALSO
 

--- a/share/man/nitx.md
+++ b/share/man/nitx.md
@@ -1,5 +1,3 @@
-% NITX(1)
-
 # NAME
 
 nitx - displays specific pieces of API information from Nit source files.
@@ -19,37 +17,37 @@ If no command are given, the program starts an interactive session where command
 
 # COMMANDS
 
-`name`
-:   lookup module, class and property with the corresponding 'name'.
+### `name`
+lookup module, class and property with the corresponding 'name'.
 
-`param: Type`
-:   lookup methods using the corresponding 'Type' as parameter.
+### `param: Type`
+lookup methods using the corresponding 'Type' as parameter.
 
-`return: Type`
-:   lookup methods returning the corresponding 'Type'.
+### `return: Type`
+lookup methods returning the corresponding 'Type'.
 
-`new: Type`
-:   lookup methods creating new instances of 'Type'.
+### `new: Type`
+lookup methods creating new instances of 'Type'.
 
-`call: Property`
-:   lookup calls to 'Property'.
+### `call: Property`
+lookup calls to 'Property'.
 
-`doc: name`
-:   lookup documentation pages about 'name'.
+### `doc: name`
+lookup documentation pages about 'name'.
 
-`code: name`
-:   lookup source code related to 'name'.
+### `code: name`
+lookup source code related to 'name'.
 
-`:h`
-:   display an help message about the commands.
+### `:h`
+display an help message about the commands.
 
-`:q`
-:   exit the tool.
+### `:q`
+exit the tool.
 
 # OPTIONS
 
-`-q`
-:	execute a query, display results in console then quit.
+### `-q`
+execute a query, display results in console then quit.
 
 # SEE ALSO
 


### PR DESCRIPTION
A lot of things are done here:

* extension of nitmd to handle more output formats
* new man decorator to transform markdown into basic groff suitable for manpages. Close #1506
* remove dubious usage of definition list in our markdown. Close #1594
* remove the use of pandoc and use nitmd to generate our manpages. Close #824