### PR TITLE
jenkins: name command test results with `cmd` instead of `run`

### DIFF
--- a/misc/jenkins/check_contrib.sh
+++ b/misc/jenkins/check_contrib.sh
@@ -25,11 +25,11 @@ for p in $projects; do
 	dir=`dirname "$p"`
 	name=`basename "$dir"`
 	echo "*** make $dir ***"
-	if misc/jenkins/unitrun.sh "run-$name-make" make -C "$dir"; then
+	if misc/jenkins/unitrun.sh "cmd-$name-make" make -C "$dir"; then
 		# Make OK, is there a `check` rule?
 		make -C "$dir" check -n 2>/dev/null || continue
 		echo "*** makecheck $dir ***"
-		if misc/jenkins/unitrun.sh "run-$name-makecheck" make -C "$dir" check; then
+		if misc/jenkins/unitrun.sh "cmd-$name-makecheck" make -C "$dir" check; then
 			:
 		else
 			failed="$failed $name-check"

--- a/misc/jenkins/nitester-wrapper.sh
+++ b/misc/jenkins/nitester-wrapper.sh
@@ -35,14 +35,14 @@ if ! git checkout $hash; then
 fi
 
 # Make basic bootstrap
-$tools_dir/unitrun.sh "run-make-csrc" make -C c_src
-$tools_dir/unitrun.sh "run-make-version" src/git-gen-version.sh
-$tools_dir/unitrun.sh "run-make-nitc_0" c_src/nitc -o bin/nitc_0 src/nitc.nit
-$tools_dir/unitrun.sh "run-make-nitc" bin/nitc_0 --dir bin/ src/nitc.nit
-$tools_dir/unitrun.sh "run-make-nit-and-nitvm" bin/nitc --dir bin/ src/nit.nit src/nitvm.nit
+$tools_dir/unitrun.sh "cmd-make-csrc" make -C c_src
+$tools_dir/unitrun.sh "cmd-make-version" src/git-gen-version.sh
+$tools_dir/unitrun.sh "cmd-make-nitc_0" c_src/nitc -o bin/nitc_0 src/nitc.nit
+$tools_dir/unitrun.sh "cmd-make-nitc" bin/nitc_0 --dir bin/ src/nitc.nit
+$tools_dir/unitrun.sh "cmd-make-nit-and-nitvm" bin/nitc --dir bin/ src/nit.nit src/nitvm.nit
 
 # Make nitester
-$tools_dir/unitrun.sh "run-make-nitester" make -C contrib/nitester/
+$tools_dir/unitrun.sh "cmd-make-nitester" make -C contrib/nitester/
 
 # Run tests
 cd tests


### PR DESCRIPTION
The infamous bug that caused some tests result to silently make Jenkins go mad is found.
The issue was to have a junit package named `run`; unfortunately, package names are used as is in URL by Jenkins and `run` in URL seems to have a special buggy behavior. Eg 

* http://gresil.org/jenkins/job/CI_github/lastCompletedBuild/testReport/run/foo
* http://gresil.org/jenkins/job/CI_github/lastCompletedBuild/testReport/notrun/foo

The solution is to name the pseudo-package `cmd` instead.