### PR TITLE
Friendly jenkins checks

### DIFF
--- a/misc/jenkins/checklicense.sh
+++ b/misc/jenkins/checklicense.sh
@@ -14,19 +14,33 @@
 # limitations under the License.
 
 # Check missing "This file is part of NIT…" comment in committed scripts.
+#
+# Usage: checklicense.sh from to
 
-if test "$#" -lt 2; then
-	echo "Usage: checklicense from to"
-	echo ""
-	exit
-fi
+set -e
 
-from=$1
-to=$2
+from=${1:-origin/master}
+to=${2:-HEAD}
 
 err=0
 
+cd `git rev-parse --show-toplevel`
+
+echo "checklicense $from (`git rev-parse "$from"`) .. $to (`git rev-parse "$to"`)"
 git diff --name-status $from..$to -- "*.nit" "*.sh" | sed -n 's/^A\s*//p' > checklicense_new_files.out
-test -s checklicense_new_files.out || exit 0
-grep -L '\(^\|\b\)# [Tt]his file is part of NIT ' `cat checklicense_new_files.out` 2>/dev/null | tee checklicense_missing.out
-test \! -s checklicense_missing.out
+if test \! -s checklicense_new_files.out; then
+	echo "No new files"
+	exit 0
+fi
+grep -L '\(^\|\b\)# [Tt]his file is part of NIT ' `cat checklicense_new_files.out` 2>/dev/null > checklicense_missing.out || true
+if test -s checklicense_missing.out; then
+	echo "These files are missing their licence:"
+	echo ""
+	cat checklicense_missing.out
+	echo ""
+	echo "Please double check that the licence text (i.e. \`This file is part of NIT...\`) is included at the begin of these files."
+	exit 1
+else
+	echo "All `cat checklicense_new_files.out | wc -l` checked new files have a correct license."
+	exit 0
+fi

--- a/misc/jenkins/checksignedoffby.sh
+++ b/misc/jenkins/checksignedoffby.sh
@@ -14,36 +14,47 @@
 # limitations under the License.
 
 # Check missing signed-off-by in commits
+# Usage: checksignedoffby from to
 
-if test "$#" -lt 2; then
-	echo "Usage: checksignedoffby from to"
-	echo ""
-	exit
-fi
+set -e
 
-from=$1
-to=$2
+from=${1:-origin/master}
+to=${2:-HEAD}
 
 err=0
 
+cd `git rev-parse --show-toplevel`
+
+echo "checksignedoffby $from (`git rev-parse "$from"`) .. $to (`git rev-parse "$to"`)"
 for ref in `git rev-list --no-merges "$from".."$to"`; do
 	# What is the expected?
 	sig=`git --no-pager show -s --format='Signed-off-by: %an <%ae>' $ref`
 	# Do we found some signed-off-by?
 	git --no-pager show -s --format="%b" $ref | grep "^Signed-off-by:" > check_signedoff_list.out || {
+		echo ""
+		echo "Missing $sig for commit"
 		git --no-pager show -s --oneline $ref
-		echo "Missing $sig"
 		err=1
 		continue
 	}
 	# Do we found the expected thing?
 	cat check_signedoff_list.out | grep -q "^$sig\$" && continue
+	echo ""
+	echo "Bad or missing Signed-off-by for commit"
 	git --no-pager show -s --oneline $ref
-	echo "Bad or missing $sig; got:"
+	echo "Expected (from local git config):"
+	echo "$sig"
+	echo "Got:"
 	cat check_signedoff_list.out
 	err=1
 done
 
 rm check_signedoff_list.out 2> /dev/null
+
+if test "$err" = 1; then
+	echo ""
+	echo "Please check that each commit contains a \`Signed-off-by:\` statement that matches the author's name and email."
+	echo "Note that existing commits should be amended; pushing new commit is not sufficient."
+fi
 
 exit $err

--- a/misc/jenkins/checkwhitespaces.sh
+++ b/misc/jenkins/checkwhitespaces.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check whitespace errors in commits
+# Usage: checkwhitespaces from to
+#
+# This script is in fact a more friendly version of `git log --check`
+
+set -e
+
+from=${1:-origin/master}
+to=${2:-HEAD}
+
+err=0
+
+cd `git rev-parse --show-toplevel`
+
+echo "checkwhitespaces $from (`git rev-parse "$from"`) .. $to (`git rev-parse "$to"`)"
+for ref in `git rev-list --no-merges "$from".."$to"`; do
+	# Show nothing if no error
+	if git --no-pager show --check --oneline $ref > /dev/null; then
+		continue
+	fi
+
+	# Run the command again to display things
+	echo ""
+	echo "Found whitespace errors in commit"
+	git --no-pager show --check --oneline $ref || true
+	err=1
+done
+
+if test "$err" = 1; then
+	echo ""
+	echo "Please check that each file in each commit does not contain whitespace errors."
+	echo "Note that existing commits should be amended; pushing new commit is not sufficient."
+	echo "Hint: use \"git log --check\" to see whitespace errors."
+fi
+
+exit $err

--- a/misc/jenkins/unitrun.sh
+++ b/misc/jenkins/unitrun.sh
@@ -63,13 +63,21 @@ if test "$res" != "0"; then
 echo >> "${name}.xml" "<error message='Command returned $res'/>"
 echo "+ Command returned $res" >&2
 fi
+if test -s "${name}.out"; then
 cat >> "${name}.xml"<<END
 <system-out><![CDATA[
 `cat -v ${name}.out`
 ]]></system-out>
+END
+fi
+if test -s "${name}.2.out"; then
+cat >> "${name}.xml"<<END
 <system-err><![CDATA[
 `cat -v ${name}.2.out`
 ]]></system-err>
+END
+fi
+cat >> "${name}.xml"<<END
 </testcase>
 </testsuite></testsuites>
 END


### PR DESCRIPTION
Improve scripts to make jenkins error friendlier about licenses, signed-off-bys and whitespaces.

Scripts now write sentences and add a final note in case of error to explain how to solve the issues.
Once #1639 is merged, the life of new contributors will never be that easy.

Examples of new messages:

* `./checklicense.sh v0.7 63e0f2c` gives:

~~~
checklicense v0.7 (68561eb8d91800ccb3fa289bff6721ddd11dbe25) .. 63e0f2c (63e0f2c7cd96f4c40366d92614785b1006e52367)
These files are missing their licence:

benchmarks/polygons/nit/bench_polygon.nit

Please double check that the licence text (i.e. `This file is part of NIT...`) is included at the begin of these files.
~~~

* `./checksignedoffby.sh origin/master 63e0f2c7cd96f4c40366d92614785b1006e52367` gives:

~~~
checksignedoffby origin/master (b144984d92908662f47a251f1cca1fd8e57b2594) .. 63e0f2c7cd96f4c40366d92614785b1006e52367 (63e0f2c7cd96f4c40366d92614785b1006e52367)

Bad or missing Signed-off-by for commit
63e0f2c lib/graphs: add module for directed graphs
Expected (from local git config):
Signed-off-by: Alexandre Blondin Massé <alexandre.blondin.masse@gmail.com>
Got:
Signed-off-by: Alexandre Blondin Massé <blondin_masse.alexandre@uqam.ca>

Please check that each commit contains a `Signed-off-by:` statement that matches the author's name and email.
Note that existing commits should be amended; pushing new commit is not sufficient.
~~~

* `./checkwhitespaces.sh origin/master e6cfa93` gives:

~~~
checkwhitespaces origin/master (b144984d92908662f47a251f1cca1fd8e57b2594) .. e6cfa93 (e6cfa93970687e33784c0251cf4da2f6e13d9f2c)

Found whitespace errors in commit
e6cfa93 Started documenting the digraph module.
lib/graphs/digraph.nit:5: trailing whitespace.
+# 
lib/graphs/digraph.nit:13: trailing whitespace.
+# 
lib/graphs/digraph.nit:18: trailing whitespace.
+# 
lib/graphs/digraph.nit:21: trailing whitespace.
+# 

Found whitespace errors in commit
e5c4311 Moved modules to lib/graphs.
lib/graphs/digraph.nit:313: trailing whitespace.
+		for 

Found whitespace errors in commit
5e7bf24 Started MatrixDigraph.
lib/digraph.nit:313: trailing whitespace.
+		for 

Found whitespace errors in commit
e6fd4d4 Basic methods for digraphs.
tests/test_graph.nit:34: new blank line at EOF.

Please check that each file in each commit does not contain whitespace errors.
Note that existing commits should be amended; pushing new commit is not sufficient.
Hint: use "git log --check" to see whitespace errors.
~~~