### PR TITLE
Fix light FFI in interpreter on OS X

### DIFF
--- a/lib/md5.nit
+++ b/lib/md5.nit
@@ -492,23 +492,24 @@ in "C Header" `{
 redef class String
 	# returns the md5 digest of the receiver string
 	# algorithm implemented by L. Peter Deutsch <ghost@aladdin.com>
-	fun md5: String import String.to_cstring, NativeString.to_s `{
+	fun md5: String do return to_cstring.native_md5.to_s
+end
+
+redef class NativeString
+	private fun native_md5: NativeString `{
 		md5_state_t state;
 		md5_byte_t digest[16]; /* result */
 		char *hex_output = malloc(33*sizeof(char));
 		int di;
-		char *in_text;
-
-		in_text = String_to_cstring(self);
 
 		md5_init(&state);
-		md5_append(&state, (const md5_byte_t *)in_text, strlen(in_text));
+		md5_append(&state, (const md5_byte_t *)self, strlen(self));
 		md5_finish(&state, digest);
 
 		for (di = 0; di < 16; ++di)
 			sprintf(hex_output + di * 2, "%02x", digest[di]);
 		hex_output[32] = '\0';
 
-		return NativeString_to_s(hex_output);
+		return hex_output;
 	`}
 end

--- a/lib/md5.nit
+++ b/lib/md5.nit
@@ -490,8 +490,13 @@ in "C Header" `{
 `}
 
 redef class String
-	# returns the md5 digest of the receiver string
-	# algorithm implemented by L. Peter Deutsch <ghost@aladdin.com>
+	# MD5 digest of `self`
+	#
+	# ~~~
+	# assert "".md5 == "d41d8cd98f00b204e9800998ecf8427e"
+	# assert "a".md5 == "0cc175b9c0f1b6a831c399e269772661"
+	# assert "abc".md5 == "900150983cd24fb0d6963f7d28e17f72"
+	# ~~~
 	fun md5: String do return to_cstring.native_md5.to_s
 end
 

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -109,7 +109,7 @@ redef class AModule
 
 		# Link everything in a shared library
 		# TODO customize the compiler
-		var cmd = "{v.c_compiler} -Wall -shared -Wl,-soname,{mmodule.name}.so -g -o {foreign_code_lib_path} {object_files.join(" ")} {ldflags}"
+		var cmd = "{v.c_compiler} -Wall -shared -o {foreign_code_lib_path} {object_files.join(" ")} {ldflags}"
 		if sys.system(cmd) != 0 then
 			v.fatal "FFI Error: Failed to link native code using `{cmd}`"
 			return false

--- a/tests/sav/Darwin/todo
+++ b/tests/sav/Darwin/todo
@@ -2,4 +2,3 @@ fatal error: 'endian.h' file not found
 Error: package `glesv1_cm` unknown by `pkg-config`, make sure the development package is be installed
 Error: package `glesv2` unknown by `pkg-config`, make sure the development package is be installed
 fatal error: 'libintl.h' file not found
-ld: unknown option: -soname


### PR DESCRIPTION
Fix #1623 by removing the soname declaration (the soname was more of a placeholder at this time anyway). Also take this opportunity to remove the `-g` flag.

The fixes to the md5 modules update it to the latest style and use the nity/native pattern to avoid callbacks so it is light FFI compatible. This was used to test the interpreter on OS X.