### PR TITLE
simplify glslangValidator test to support different versions of the tool

### DIFF
--- a/tests/sav/test_glsl_validation.res
+++ b/tests/sav/test_glsl_validation.res
@@ -1,6 +1,4 @@
 test_glsl_validation.nit:24,0: Shader error on 'binding' : not supported for this version or the enabled extensions 
 test_glsl_validation.nit:24,0: Shader error on 'binding' : requires uniform or buffer storage qualifier 
 test_glsl_validation.nit:24,0: Shader error on 'binding' : requires block, or sampler/image, or atomic-counter type 
-test_glsl_validation.nit:28,0: Shader error on 'gl_FragColor' : undeclared identifier 
-test_glsl_validation.nit:28,0: Shader error on 'assign' :  cannot convert from 'mediump 4-component vector of float' to 'float'
 test_glsl_validation.nit:29,0: Shader error on 'b' : undeclared identifier 

--- a/tests/test_glsl_validation.nit
+++ b/tests/test_glsl_validation.nit
@@ -25,7 +25,7 @@ layout(binding = 0) out vec4 outColor;
 
 void main()
 {
-	gl_FragColor = v_color * texture(vTex, v_texCoord);
+	outColor = v_color * texture(vTex, v_texCoord);
 	b;
 }
 """ @ glsl_fragment_shader


### PR DESCRIPTION
As reported in #1537, different versions of glslangValidator do not output the same error messages as they do not use the same default type for undeclared variables. This PR removes an error from the glsl code (or fix it if you prefer) so different versions of the tools have the same output. There are still many more errors to check that the integration of the tool within nitc works.

Fix #1537.