### PR TITLE
Better module doc within Vim

### DIFF
--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -201,31 +201,7 @@ redef class MClassType
 		alpha_comparator.sort props
 		for prop in props do
 			if mclass.name == "Object" or prop.intro.mclassdef.mclass.name != "Object" then
-
-				if prop.visibility == public_visibility then
-					stream.write "+ "
-				else stream.write "~ " # protected_visibility
-
-				if prop isa MMethod then
-					if prop.is_new and prop.name != "new" then
-						stream.write "new "
-					else if prop.is_init and prop.name != "init" then
-						stream.write "init "
-					end
-				end
-
-				stream.write prop.name
-
-				if prop isa MMethod then
-					stream.write prop.intro.msignature.to_s
-				end
-
-				var mdoc = prop.intro.mdoc
-				if mdoc != null then
-					stream.write "  # "
-					stream.write mdoc.content.first
-				end
-				stream.write line_separator
+				prop.write_synopsis(mainmodule, stream)
 			end
 		end
 	end
@@ -308,5 +284,37 @@ private class AutocompletePhase
 				toolcontext.error(null, "Error: failed to write Vim autocomplete file: {error}.")
 			end
 		end
+	end
+end
+
+redef class MProperty
+	private fun write_synopsis(mainmodule: MModule, stream: Writer)
+	do
+		if visibility == public_visibility then
+			stream.write "+ "
+		else stream.write "~ " # protected_visibility
+
+		if self isa MMethod then
+			if is_new and name != "new" then
+				stream.write "new "
+			else if is_init and name != "init" then
+				stream.write "init "
+			end
+		end
+
+		stream.write name
+
+		if self isa MMethod then
+			var intro = intro
+			assert intro isa MMethodDef
+			stream.write intro.msignature.to_s
+		end
+
+		var mdoc = intro.mdoc
+		if mdoc != null then
+			stream.write "  # "
+			stream.write mdoc.content.first
+		end
+		stream.write line_separator
 	end
 end

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -287,6 +287,43 @@ private class AutocompletePhase
 	end
 end
 
+redef class MModule
+	redef fun write_extra_doc(mainmodule, stream)
+	do
+		# Introduced classes
+		var class_intros = collect_intro_mclasses(protected_visibility).to_a
+		if class_intros.not_empty then
+			alpha_comparator.sort class_intros
+			stream.write line_separator*2
+			stream.write "## Introduced classes"
+
+			for c in class_intros do
+				stream.write line_separator
+				stream.write "* {c.name}"
+				var doc = c.intro.mdoc
+				if doc != null then stream.write ": {doc.content.first}"
+			end
+		end
+
+		# Introduced properties
+		var prop_intros = new Array[MPropDef]
+		for c in mclassdefs do
+			prop_intros.add_all c.collect_intro_mpropdefs(protected_visibility)
+		end
+
+		if prop_intros.not_empty then
+			alpha_comparator.sort prop_intros
+			stream.write line_separator*2
+			stream.write "## Introduced properties"
+			stream.write line_separator
+
+			for p in prop_intros do
+				p.mproperty.write_synopsis(mainmodule, stream)
+			end
+		end
+	end
+end
+
 redef class MProperty
 	private fun write_synopsis(mainmodule: MModule, stream: Writer)
 	do

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -207,8 +207,11 @@ redef class MClassType
 				else stream.write "~ " # protected_visibility
 
 				if prop isa MMethod then
-					if prop.is_init and prop.name != "init" then stream.write "init "
-					if prop.is_new and prop.name != "new" then stream.write "new "
+					if prop.is_new and prop.name != "new" then
+						stream.write "new "
+					else if prop.is_init and prop.name != "init" then
+						stream.write "init "
+					end
 				end
 
 				stream.write prop.name


### PR DESCRIPTION
When searching for a module, generate list of introduced classes and properties to add to the user module documentation.

So from within vim, when entering `:Nit opts`, it shows:
~~~
# opts

Management of options on the command line

## Introduced classes
* Option: Super class of all option's class
* OptionArray: An option with an array as parameter
* OptionBool: A boolean option, `true` when present, `false` if not
* OptionContext: Context where the options process
* OptionCount: A count option. Count the number of time this option is present
* OptionEnum: An option to choose from an enumeration
* OptionFloat: An option with a Float as parameter
* OptionInt: An option with an Int as parameter
* OptionParameter: Option with one parameter (mandatory by default)
* OptionString: An option with a `String` as parameter
* OptionText: Not really an option. Just add a line of text when displaying the usage

## Introduced properties
+ VALUE  # Type of the value of the option
+ add_aliases(names: String...)  # Add new aliases for this option
+ default_value: VALUE  # Default value of this option
+ default_value=(default_value: VALUE)  # Default value of this option
+ errors: Array[String]  # Gathering errors during parsing
~ errors=(errors: Array[String])  # Gathering errors during parsing
+ helptext: String  # Human readable description of the option
~ helptext=(helptext: String)  # Human readable description of the option
+ hidden: Bool  # Is this option hidden from `usage`?
+ hidden=(hidden: Bool)  # Is this option hidden from `usage`?
+ init(help: String, default: VALUE, names: nullable Array[String])  # Create a new option
[...]
~~~

The list of properties can be long, but it is useful to search by keywords.

As usual, use `:pc` to **c**lose the **p**review window showing the doc.